### PR TITLE
Parse layers from JSON

### DIFF
--- a/elements/map/examples/index.html
+++ b/elements/map/examples/index.html
@@ -16,6 +16,12 @@
     <eox-map></eox-map>
     <p>Basic map with defined zoom and center</p>
     <eox-map zoom="7" center="[1800000, 6150000]"></eox-map>
+    <p>Basic map with defined layers</p>
+    <eox-map layers="'[ { "type": "Vector", "background": "#1a2b39",
+    "myCustomProperty": "foo", "source": { "type": "Vector", "url":
+    "https://openlayers.org/data/vector/ecoregions.json", "format": "GeoJSON" },
+    "style": { "function": { "fill": { "type": "Fill", "color": "(feature) =>
+    feature.get('COLOR')" } } } } ]'"
     <script
       type="module"
       src="https://unpkg.com/@eox/map@latest/dist/eox-map.js"

--- a/elements/map/examples/index.html
+++ b/elements/map/examples/index.html
@@ -13,18 +13,19 @@
   </head>
   <body>
     <p>Basic map</p>
-    <eox-map></eox-map>
+    <eox-map layers='[{"type":"Tile","source":{"type":"OSM"}}]'></eox-map>
     <p>Basic map with defined zoom and center</p>
-    <eox-map zoom="7" center="[1800000, 6150000]"></eox-map>
-    <p>Basic map with defined layers</p>
-    <eox-map layers="'[ { "type": "Vector", "background": "#1a2b39",
-    "myCustomProperty": "foo", "source": { "type": "Vector", "url":
-    "https://openlayers.org/data/vector/ecoregions.json", "format": "GeoJSON" },
-    "style": { "function": { "fill": { "type": "Fill", "color": "(feature) =>
-    feature.get('COLOR')" } } } } ]'"
-    <script
-      type="module"
-      src="https://unpkg.com/@eox/map@latest/dist/eox-map.js"
-    ></script>
+    <eox-map
+      zoom="7"
+      center="[1800000, 6150000]"
+      layers='[{"type":"Tile","source":{"type":"OSM"}}]'
+    ></eox-map>
+    <p>Map with applied layers</p>
+    <eox-map id="applied"></eox-map>
+    <script type="module">
+      import "https://unpkg.com/@eox/map@latest/dist/eox-map.js"
+      import layers from "./layers.json" assert { type: "json" };
+      document.querySelector("eox-map#applied").setLayers(layers);
+    </script>
   </body>
 </html>

--- a/elements/map/examples/layers.json
+++ b/elements/map/examples/layers.json
@@ -1,0 +1,51 @@
+[
+  {
+    "type": "Tile",
+    "visible": false,
+    "source": {
+      "type": "TileWMS",
+      "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
+      "params": {
+        "LAYERS": "AWS_VIS_WIND_V_10M"
+      }
+    }
+  },
+  {
+    "type": "Tile",
+    "source": {
+      "type": "TileWMS",
+      "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
+      "params": {
+        "LAYERS": "AWS_NO2-VISUALISATION"
+      }
+    }
+  },
+  {
+    "type": "WebGLTile",
+    "style": {
+      "color": [
+        "array",
+        ["/", ["band", 4], 3000],
+        ["/", ["band", 1], 3000],
+        ["/", ["band", 2], 3000],
+        1
+      ],
+      "gamma": 1.1
+    },
+    "source": {
+      "type": "GeoTIFF",
+      "normalize": false,
+      "sources": [
+        {
+          "url": "https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif"
+        }
+      ]
+    }
+  },
+  {
+    "type": "Tile",
+    "source": {
+      "type": "OSM"
+    }
+  }
+]

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -1,12 +1,11 @@
 import Map from "ol/Map.js";
-import OSM from "ol/source/OSM.js";
-import TileLayer from "ol/layer/Tile.js";
 import View from "ol/View.js";
 import { Coordinate } from "ol/coordinate";
-import { apply } from "ol-mapbox-style";
+// import { apply } from "ol-mapbox-style";
 
 import olCss from "ol/ol.css";
 import { addDraw } from "./src/draw";
+import { generateLayers } from "./src/generate";
 import Interaction from "ol/interaction/Interaction";
 import { getLayerById } from "./src/layer";
 
@@ -67,11 +66,7 @@ export class EOxMap extends HTMLElement {
     this.map = new Map({
       controls: [],
       target: div,
-      layers: [
-        new TileLayer({
-          source: new OSM(),
-        }),
-      ],
+      layers: [],
       view: new View({
         center: this.hasAttribute("center")
           ? (JSON.parse(
@@ -87,7 +82,8 @@ export class EOxMap extends HTMLElement {
 
     this.setLayers = (json: JSON) => {
       // @ts-ignore
-      apply(this.map, json);
+      // apply(this.map, json);
+      this.map.setLayers(generateLayers(json));
     };
 
     this.addDraw = (layerId: string, options: Object) => {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -1,7 +1,6 @@
 import Map from "ol/Map.js";
 import View from "ol/View.js";
 import { Coordinate } from "ol/coordinate";
-// import { apply } from "ol-mapbox-style";
 
 import olCss from "ol/ol.css";
 import { addDraw } from "./src/draw";
@@ -66,7 +65,7 @@ export class EOxMap extends HTMLElement {
     this.map = new Map({
       controls: [],
       target: div,
-      layers: generateLayers(JSON.parse(this.getAttribute('layers'))),
+      layers: generateLayers(JSON.parse(this.getAttribute("layers"))),
       view: new View({
         center: this.hasAttribute("center")
           ? (JSON.parse(
@@ -81,8 +80,8 @@ export class EOxMap extends HTMLElement {
     this.interactions = {};
 
     this.setLayers = (json: JSON) => {
+      // TODO typing
       // @ts-ignore
-      // apply(this.map, json);
       this.map.setLayers(generateLayers(json));
     };
 

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -66,7 +66,7 @@ export class EOxMap extends HTMLElement {
     this.map = new Map({
       controls: [],
       target: div,
-      layers: [],
+      layers: generateLayers(JSON.parse(this.getAttribute('layers'))),
       view: new View({
         center: this.hasAttribute("center")
           ? (JSON.parse(

--- a/elements/map/package.json
+++ b/elements/map/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "dependencies": {
-    "ol": "7.3.0",
-    "ol-mapbox-style": "9.6.0"
+    "ol": "7.3.0"
   },
   "devDependencies": {
     "@eox/eslint-config": "^1.0.0",

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -1,0 +1,72 @@
+import * as olLayers from "ol/layer";
+import * as olSources from "ol/source";
+import * as olFormats from "ol/format";
+import * as olStyles from "ol/style";
+import { Feature } from "ol";
+
+export const generateLayers = (
+  layerArray: Array<{
+    type: olLayers.Layer;
+    source: { type: olSources.Source };
+  }>
+) => {
+  if (!layerArray) {
+    return [];
+  }
+
+  const layers: Array<olLayers.Layer> = [];
+
+  const parseStyle = (style: any) => {
+    if (!style.function) {
+      // normal style, doesn't need parsing
+      return style;
+    }
+    // trying to parse a style function in the format "(feature) => feature.get('COLOR')"
+    const parsedStyle = (feature: Feature) =>
+      Object.entries(style.function).reduce((acc, [property, options]) => {
+        const parsedOptions = {};
+        Object.entries(options).forEach(([key, value]) => {
+          if (value.startsWith("(feature")) {
+            var fn = eval(
+              `(function(feature) { return ${value.replace(
+                "(feature) => ",
+                ""
+              )} })`
+            );
+            // @ts-ignore
+            parsedOptions[key] = fn(feature);
+          } else {
+            // @ts-ignore
+            parsedOptions[key] = value;
+          }
+        });
+        // @ts-ignore
+        acc[property] = new olStyles[options.type]({
+          ...parsedOptions,
+        });
+        return acc;
+      }, {});
+    return (feature: Feature) => new olStyles.Style(parsedStyle(feature));
+  };
+
+  layerArray.reverse().forEach((layer) => {
+    layers.push(
+      // @ts-ignore
+      new olLayers[layer.type]({
+        ...layer,
+        // @ts-ignore
+        source: new olSources[layer.source.type]({
+          ...layer.source,
+          // @ts-ignore
+          ...(layer.source.format && {
+            // @ts-ignore
+            format: new olFormats[layer.source.format](),
+          }),
+        }),
+        // @ts-ignore
+        ...(layer.style && { style: parseStyle(layer.style) }),
+      })
+    );
+  });
+  return layers;
+};

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -1,12 +1,10 @@
 import * as olLayers from "ol/layer";
 import * as olSources from "ol/source";
-import * as olFormats from "ol/format";
-import * as olStyles from "ol/style";
-import { Feature } from "ol";
 
 export const generateLayers = (
   layerArray: Array<{
     type: olLayers.Layer;
+    properties?: Object;
     source: { type: olSources.Source };
   }>
 ) => {
@@ -16,55 +14,23 @@ export const generateLayers = (
 
   const layers: Array<olLayers.Layer> = [];
 
-  const parseStyle = (style: any) => {
-    if (!style.function) {
-      // normal style, doesn't need parsing
-      return style;
-    }
-    // trying to parse a style function in the format "(feature) => feature.get('COLOR')"
-    const parsedStyle = (feature: Feature) =>
-      Object.entries(style.function).reduce((acc, [property, options]) => {
-        const parsedOptions = {};
-        Object.entries(options).forEach(([key, value]) => {
-          if (value.startsWith("(feature")) {
-            var fn = eval(
-              `(function(feature) { return ${value.replace(
-                "(feature) => ",
-                ""
-              )} })`
-            );
-            // @ts-ignore
-            parsedOptions[key] = fn(feature);
-          } else {
-            // @ts-ignore
-            parsedOptions[key] = value;
-          }
-        });
-        // @ts-ignore
-        acc[property] = new olStyles[options.type]({
-          ...parsedOptions,
-        });
-        return acc;
-      }, {});
-    return (feature: Feature) => new olStyles.Style(parsedStyle(feature));
-  };
-
   layerArray.reverse().forEach((layer) => {
+    // @ts-ignore
+    const newLayer = olLayers[layer.type];
+    // @ts-ignore
+    const newSource = olSources[layer.source.type];
+    if (!newLayer) {
+      throw new Error(`Layer type ${layer.type} not supported!`);
+    }
+    if (!newSource) {
+      throw new Error(`Source type ${layer.source.type} not supported!`);
+    }
     layers.push(
-      // @ts-ignore
-      new olLayers[layer.type]({
+      new newLayer({
         ...layer,
-        // @ts-ignore
-        source: new olSources[layer.source.type]({
+        source: new newSource({
           ...layer.source,
-          // @ts-ignore
-          ...(layer.source.format && {
-            // @ts-ignore
-            format: new olFormats[layer.source.format](),
-          }),
         }),
-        // @ts-ignore
-        ...(layer.style && { style: parseStyle(layer.style) }),
       })
     );
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,8 +135,7 @@
       "name": "@eox/map",
       "version": "0.0.1",
       "dependencies": {
-        "ol": "7.3.0",
-        "ol-mapbox-style": "9.6.0"
+        "ol": "7.3.0"
       },
       "devDependencies": {
         "@eox/eslint-config": "^1.0.0",


### PR DESCRIPTION
This PR introduces parsing of a custom JSON format to generate layers. The basic structure of the layer JSON is:

```
[
  {
    "type": "<OL layer module type",
    [...additional layer parameters]
    "source": {
      "type": "<OL source module type",
      [...additional source parameters]
    } 
  }
]
```
Style functions need to be passed as an Object with the key `function`, and can have access to the Feature with the pattern `"(feature) => <your code here accessing feature>"`

Example of a successfully rendering layer array: 
```
[
  {
    "type": "Vector",
    "background": "#1a2b39",
    "myCustomProperty": "foo",
    "source": {
      "type": "Vector",
      "url": "https://openlayers.org/data/vector/ecoregions.json",
      "format": "GeoJSON"
    },
    "style": {
      "function": {
        "fill": {
          "type": "Fill",
          "color": "(feature) => feature.get('COLOR')"
        }
      }
    }
  },
  {
    "type": "WebGLTile",
    "visible": false,
    "style": {
      "color": [
        "array",
        ["/", ["band", 4], 3000],
        ["/", ["band", 1], 3000],
        ["/", ["band", 2], 3000],
        1
      ],
      "gamma": 1.1
    },
    "source": {
      "type": "GeoTIFF",
      "normalize": false,
      "sources": [
        {
          "url": "https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif"
        }
      ]
    }
  },
  {
    "type": "Tile",
    "visible": false,
    "source": {
      "type": "TileWMS",
      "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
      "params": {
        "LAYERS": "AWS_VIS_WIND_V_10M"
      }
    }
  },
  {
    "type": "Tile",
    "source": {
      "type": "TileWMS",
      "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
      "params": {
        "LAYERS": "AWS_NO2-VISUALISATION"
      }
    }
  },
  {
    "type": "Tile",
    "source": {
      "type": "OSM"
    }
  }
]
```