### PR TITLE
Default tooltip pointer events to none

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -75,6 +75,9 @@ export class EOxMap extends HTMLElement {
     :host {
       display: block;
     }
+    .eox-map-tooltip {
+      pointer-events: none !important;
+    }
   `;
     style.innerHTML = shadowStyleFix + olCss;
     this.shadow.appendChild(style);

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -29,6 +29,7 @@ export function addSelect(EOxMap: EOxMap, layerId: string, options: any): void {
       position: undefined,
       offset: [0, -30],
       positioning: "top-center",
+      className: "eox-map-tooltip",
     });
 
     // if pointermove condition, update the position of the tooltip on pointermove


### PR DESCRIPTION
This PR sets the pointer-events for the map tooltip container to `none`. This can be still overridden if need be by explicitly setting a div inside the tooltip template to e.g. `pointer-events: all`.