### PR TITLE
Controls as JSON

### DIFF
--- a/elements/map/src/controls.ts
+++ b/elements/map/src/controls.ts
@@ -1,5 +1,6 @@
 import { EOxMap } from "../main";
 import * as olControls from "ol/control";
+import { generateLayers } from "./generate";
 
 type controlType =
   | "Attribution"
@@ -12,17 +13,28 @@ type controlType =
   | "ZoomToExtent"
   | "Zoom";
 
+type controlDictionary = {
+  [key in controlType]?: Object;
+};
+
 /**
  * adds initial controls from webcomponent attributes, if any are given.
  */
 export function addInitialControls(EOxMap: EOxMap) {
   const controls = JSON.parse(
     EOxMap.getAttribute("controls")
-  ) as Array<controlType>;
-  if (controls && controls.length) {
-    for (let i = 0, ii = controls.length; i < ii; i++) {
-      const controlName = controls[i];
-      const control = new olControls[controlName]();
+  ) as controlDictionary;
+  if (controls) {
+    const keys = Object.keys(controls);
+    for (let i = 0, ii = keys.length; i < ii; i++) {
+      const controlName = keys[i] as controlType;
+      const controlOptions = controls[controlName];
+      // @ts-ignore
+      if (controlOptions && controlOptions.layers) {
+        // @ts-ignore
+        controlOptions.layers = generateLayers(controlOptions.layers); // parse layers (OverviewMap)
+      }
+      const control = new olControls[controlName](controlOptions);
       EOxMap.map.addControl(control);
       EOxMap.controls[controlName] = control;
     }

--- a/elements/map/test/controls.cy.ts
+++ b/elements/map/test/controls.cy.ts
@@ -12,7 +12,24 @@ describe("webcomponent attribute parsing", () => {
       const controlsMapElement = document.createElement("eox-map") as EOxMap;
       controlsMapElement.setAttribute(
         "controls",
-        '["Zoom", "Attribution", "FullScreen"]'
+        `{
+          "Zoom": {},
+          "Attribution": {},
+          "FullScreen": {},
+          "OverviewMap": {
+            "layers":   [
+              {
+                "type": "Tile",
+                "properties": {
+                  "id": "customId"
+                },
+                "source": {
+                  "type": "OSM"
+                }
+              }
+            ]
+          }
+        }`
       );
       controlsMapElement.classList.add("map");
       controlsMapElement.style.position = "absolute";
@@ -22,12 +39,12 @@ describe("webcomponent attribute parsing", () => {
       expect(
         controlsMapElement.map.getControls().getLength(),
         "set controls via webcomponent attributes"
-      ).to.be.equal(3);
+      ).to.be.equal(4);
       controlsMapElement.removeControl("FullScreen");
       expect(
         controlsMapElement.map.getControls().getLength(),
         "can remove control by name"
-      ).to.be.equal(2);
+      ).to.be.equal(3);
     });
   });
 });


### PR DESCRIPTION
This PR implements the controls as JSON. The Key of each property is the name of the control, the property itself represents the `options` of the ol-control.

If the control has a `layers`-Option (e.G. the `OverviewMap`), a JSON is expected, in the same way as when defining layers. Those layers will get parsed and will be added to the control only. The test is updated to display an `OverviewMap`-Control with OSM Tiles, which are not represented in the main map.