### PR TITLE
Proposal: deprecate attachTo method

### DIFF
--- a/elements/layercontrol/README.md
+++ b/elements/layercontrol/README.md
@@ -55,12 +55,6 @@ The layer title property of the layers. "title" by default, fallback is set auto
 
 Display the unstyled version of the layer control.
 
-## Methods
-
-### `attachTo(mapObject: Map)`
-
-Attach the layer control to an OpenLayer map instance. Alternative to the (preferred) [`for` attribute](#for-string--eox-map).
-
 ## Layer properties
 
 In order to be displayed correctly, the OpenLayers map layers need some custom properties (using e.g. `layer.set(property, value)`).

--- a/elements/layercontrol/README.md
+++ b/elements/layercontrol/README.md
@@ -32,7 +32,7 @@ const olMap = new Map({
 })
 document.querySelector("map-div").map = olMap
 
-<eox-layercontrol for="map-div"></eox-layercontrol>
+<eox-layercontrol for="#map-div"></eox-layercontrol>
 ```
 
 ### `layerIdentifier: string = "id"`

--- a/elements/layercontrol/README.md
+++ b/elements/layercontrol/README.md
@@ -14,9 +14,26 @@ import "@eox/layercontrol"
 
 ## Attributes
 
-### `for: string = "eox-map"` (when used with `eox-map`)
+### `for: string = "eox-map"`
 
-The query selector of the `eox-map` you wish to attch the layer control to. When used with a vanilla OpenLayer map, see the [`attachTo` method](#attachtomapobject-map-when-used-with-a-vanilla-openlayer-map) instead.
+The query selector of the `eox-map` you wish to attach the layer control to.
+
+```
+<eox-map layers="[...]"></eox-map>
+<eox-layercontrol for="eox-map"></eox-layercontrol>
+```
+
+When used with a vanilla OpenLayer map, you need to reference the JS map object in the DOM, such as:
+
+```
+const olMap = new Map({
+    ...
+    target: "map-div"
+})
+document.querySelector("map-div").map = olMap
+
+<eox-layercontrol for="map-div"></eox-layercontrol>
+```
 
 ### `layerIdentifier: string = "id"`
 
@@ -40,9 +57,9 @@ Display the unstyled version of the layer control.
 
 ## Methods
 
-### `attachTo(mapObject: Map)` (when used with a vanilla OpenLayer map)
+### `attachTo(mapObject: Map)`
 
-Attach the layer control to an OpenLayer map instance. When used with an `eox-map`, see the [`for` attribute](#for-when-used-with-eox-map) instead.
+Attach the layer control to an OpenLayer map instance. Alternative to the (preferred) [`for` attribute](#for-string--eox-map).
 
 ## Layer properties
 

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -54,16 +54,6 @@ export class EOxLayerControl extends LitElement {
   @property({ type: Boolean })
   unstyled: Boolean;
 
-  /**
-   * Alternative way to attach a map isntance. Preferred way is the "for" attribute
-   * @param mapObject OpenLayers map instance
-   * @deprecated
-   */
-  public attachTo(mapObject: Map) {
-    this.olMap = mapObject;
-    this.requestUpdate();
-  }
-
   private _updateControl(layerCollection: Collection<any>) {
     // initially check if all layers have an id and title,
     // fill in some backup in case they haven't

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -54,6 +54,11 @@ export class EOxLayerControl extends LitElement {
   @property({ type: Boolean })
   unstyled: Boolean;
 
+  /**
+   * Alternative way to attach a map isntance. Preferred way is the "for" attribute
+   * @param mapObject OpenLayers map instance
+   * @deprecated
+   */
   public attachTo(mapObject: Map) {
     this.olMap = mapObject;
     this.requestUpdate();


### PR DESCRIPTION
This PR deprecates the attachTo method and prefers the "for" attribute. Question is if we still want to have the attachTo method in the readme.
This would require the apps using vanilla OL to add the map instance to the DOM object.