### PR TITLE
Map Selection

### DIFF
--- a/elements/map/index.html
+++ b/elements/map/index.html
@@ -31,6 +31,19 @@
         id: "selectInteraction",
         tooltip: "eox-map-tooltip",
         condition: "pointermove",
+        layer: {
+          type: "Vector",
+          properties: {
+            id: "selectLayer",
+          },
+          source: {
+            type: "Vector",
+          },
+          style: {
+            "stroke-color": "red",
+            "stroke-width": 3,
+          },
+        },
       });
     </script>
   </body>

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -141,7 +141,7 @@ export class EOxMap extends LitElement {
     };
 
     this.addSelect = (layerId: string, options: Object) => {
-      addSelect(this, layerId, options);
+      return addSelect(this, layerId, options);
     };
 
     this.removeInteraction = (id: string) => {

--- a/elements/map/src/controls.ts
+++ b/elements/map/src/controls.ts
@@ -37,7 +37,7 @@ export function addInitialControls(EOxMap: EOxMap) {
         // @ts-ignore
         if (controlOptions && controlOptions.layers) {
           // @ts-ignore
-          controlOptions.layers = await generateLayers(controlOptions.layers); // parse layers (OverviewMap)
+          controlOptions.layers = generateLayers(controlOptions.layers); // parse layers (OverviewMap)
         }
         const control = new olControls[controlName](controlOptions);
         EOxMap.map.addControl(control);

--- a/elements/map/src/controls.ts
+++ b/elements/map/src/controls.ts
@@ -37,7 +37,7 @@ export function addInitialControls(EOxMap: EOxMap) {
         // @ts-ignore
         if (controlOptions && controlOptions.layers) {
           // @ts-ignore
-          controlOptions.layers = generateLayers(controlOptions.layers); // parse layers (OverviewMap)
+          controlOptions.layers = await generateLayers(controlOptions.layers); // parse layers (OverviewMap)
         }
         const control = new olControls[controlName](controlOptions);
         EOxMap.map.addControl(control);

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -14,79 +14,83 @@ export type EoxLayer = {
   style?: mapboxgl.Style | FlatStyleLike;
 };
 
+export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
+  // @ts-ignore
+  const newLayer = olLayers[layer.type];
+  // @ts-ignore
+  const newSource = olSources[layer.source?.type];
+  if (!newLayer) {
+    throw new Error(`Layer type ${layer.type} not supported!`);
+  }
+  if (layer.source && !newSource) {
+    throw new Error(`Source type ${layer.source.type} not supported!`);
+  }
+
+  const olLayer = new newLayer({
+    ...layer,
+    group,
+    ...(layer.source && {
+      source: new newSource({
+        ...layer.source,
+        // @ts-ignore
+        ...(layer.source.format && {
+          // @ts-ignore
+          format: new olFormats[layer.source.format](),
+        }),
+      }),
+    }),
+    style: undefined, // override layer style, apply style after
+    // @ts-ignore
+    ...(layer.type === "Group" && {
+      layers: layer.layers.reverse().map((l) => createLayer(l, layer.id)),
+    }),
+  });
+
+  if (layer.style) {
+    if ("version" in layer.style) {
+      const mapboxStyle: mapboxgl.Style = layer.style;
+      // existing layer source will not get overridden by "style" property
+      // to allow vector layers without defined sources, create a dummy-geojson-source
+      // if source does exist
+      if (!mapboxStyle.sources) {
+        mapboxStyle.sources = {};
+      }
+      // @ts-ignore
+      const sourceName = layer.properties.id;
+      if (!mapboxStyle.sources[sourceName]) {
+        const dummy =
+          //@ts-ignore
+          layer.source.type === "VectorTile"
+            ? {
+                type: "vector",
+              }
+            : {
+                type: "geojson",
+                data: {
+                  type: "FeatureCollection",
+                  //@ts-ignore
+                  features: [],
+                },
+              };
+        mapboxStyle.sources[sourceName] = dummy as AnySourceData;
+      }
+      olLayer.set(
+        "sourcePromise",
+        applyStyle(olLayer, mapboxStyle, sourceName, {
+          updateSource: false,
+        })
+      );
+    } else {
+      olLayer.setStyle(layer.style);
+      olLayer.set("sourcePromise", Promise.resolve());
+    }
+  }
+  return olLayer;
+}
+
 export const generateLayers = (layerArray: Array<EoxLayer>) => {
   if (!layerArray) {
     return [];
-  }
-
-  function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
-    // @ts-ignore
-    const newLayer = olLayers[layer.type];
-    // @ts-ignore
-    const newSource = olSources[layer.source?.type];
-    if (!newLayer) {
-      throw new Error(`Layer type ${layer.type} not supported!`);
-    }
-    if (layer.source && !newSource) {
-      throw new Error(`Source type ${layer.source.type} not supported!`);
-    }
-
-    const olLayer = new newLayer({
-      ...layer,
-      group,
-      ...(layer.source && {
-        source: new newSource({
-          ...layer.source,
-          // @ts-ignore
-          ...(layer.source.format && {
-            // @ts-ignore
-            format: new olFormats[layer.source.format](),
-          }),
-        }),
-      }),
-      style: undefined, // override layer style, apply style after
-      // @ts-ignore
-      ...(layer.type === "Group" && {
-        layers: layer.layers.reverse().map((l) => createLayer(l, layer.id)),
-      }),
-    });
-
-    if (layer.style) {
-      if ("version" in layer.style) {
-        const mapboxStyle: mapboxgl.Style = layer.style;
-        // existing layer source will not get overridden by "style" property
-        // to allow vector layers without defined sources, create a dummy-geojson-source
-        // if source does exist
-        if (!mapboxStyle.sources) {
-          mapboxStyle.sources = {};
-        }
-        // @ts-ignore
-        const sourceName = layer.properties.id;
-        if (!mapboxStyle.sources[sourceName]) {
-          const dummy =
-            //@ts-ignore
-            layer.source.type === "VectorTile"
-              ? {
-                  type: "vector",
-                }
-              : {
-                  type: "geojson",
-                  data: {
-                    type: "FeatureCollection",
-                    //@ts-ignore
-                    features: [],
-                  },
-                };
-          mapboxStyle.sources[sourceName] = dummy as AnySourceData;
-        }
-        applyStyle(olLayer, mapboxStyle, sourceName, {
-          updateSource: false,
-        });
-      } else {
-        olLayer.setStyle(layer.style);
-      }
-    }
-    return olLayer;
   }
 
   return layerArray.reverse().map((l) => createLayer(l));

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -1,80 +1,122 @@
-import Select from "ol/interaction/Select";
 import { EOxMap } from "../main";
-import { pointerMove } from "ol/events/condition";
-import { MapBrowserEvent, Overlay } from "ol";
+import { Overlay } from "ol";
 import "./tooltip";
 import { EOxMapTooltip } from "./tooltip";
+import { createLayer } from "./generate";
+import Feature from "ol/Feature";
+import RenderFeature from "ol/render/Feature";
+import VectorTileLayer from "ol/layer/VectorTile.js";
+import VectorLayer from "ol/layer/Vector.js";
+import VectorTileSource from "ol/source/VectorTile.js";
+import VectorSource from "ol/source/Vector.js";
+import MapBrowserEvent from "ol/MapBrowserEvent";
 
-export function addSelect(EOxMap: EOxMap, layerId: string, options: any): void {
+export async function addSelect(
+  EOxMap: EOxMap,
+  layerId: string,
+  options: any
+): Promise<void> {
   if (EOxMap.interactions[options.id]) {
     throw Error(`Interaction with id: ${options.id} already exists.`);
   }
 
+  const tooltip: EOxMapTooltip = EOxMap.querySelector(options.tooltip);
+
+  let overlay: Overlay;
+  let selectedFid: string | number = null;
+
   const map = EOxMap.map;
 
-  const selectLayer = EOxMap.getLayerById(layerId);
-
-  const selectInteraction = new Select({
-    condition: pointerMove,
-    style: null,
-    layers: [selectLayer],
-  });
-
-  // identifier to retrieve the interaction
-  map.addInteraction(selectInteraction);
-  const tooltip: EOxMapTooltip = EOxMap.querySelector(options.tooltip);
   if (tooltip) {
-    const overlay = new Overlay({
+    overlay = new Overlay({
       element: tooltip,
       position: undefined,
       offset: [0, -30],
       positioning: "top-center",
       className: "eox-map-tooltip",
     });
-
-    // if pointermove condition, update the position of the tooltip on pointermove
-    // instead of only when selection changes
-    if (options.condition === "pointermove") {
-      const pointermoveListener = (e: MapBrowserEvent<any>) => {
-        if (e.dragging) {
-          return;
-        }
-        if (selectInteraction.getFeatures().getLength()) {
-          overlay.setPosition(e.coordinate);
-          tooltip.renderContent(
-            e.target.getFeaturesAtPixel(e.pixel)[0].getProperties()
-          );
-        }
-      };
-      map.on("pointermove", pointermoveListener);
-
-      map.getInteractions().on("remove", (e) => {
-        if (e.element === selectInteraction) {
-          // remove the pointermove-listener when select-interaction is removed
-          map.un("pointermove", pointermoveListener);
-        }
-      });
-    }
-
-    selectInteraction.on("select", (e) => {
-      map.addOverlay(overlay);
-      if (e.selected.length) {
-        tooltip.innerHTML = JSON.stringify(e.selected[0].get("name"));
-        overlay.setPosition(
-          EOxMap.map.getEventCoordinate(e.mapBrowserEvent.originalEvent)
-        );
-      } else {
-        overlay.setPosition(null);
-      }
-    });
-
-    map.getInteractions().on("remove", (e) => {
-      if (e.element === selectInteraction) {
-        // remove the pointermove-listener when select-interaction is removed
-        map.removeOverlay(overlay);
-      }
-    });
+    map.addOverlay(overlay);
   }
 
-  EOxMap.interactions[options.id] = selectInteraction;
+  /**
+   * returns the ID of a feature.
+   * @param feature
+   * @returns {number | string} ID value of feature
+   */
+  function getId(feature: Feature | RenderFeature) {
+    if (options.idProperty) {
+      return feature.get(options.idProperty);
+    }
+    return feature.getId();
+  }
+
+  const selectLayer = EOxMap.getLayerById(layerId);
+  await selectLayer.get("sourcePromise");
+
+  options.layer.renderMode = "vector";
+
+  // a layer that only contains the selected features, for displaying purposes only
+  // unmanaged by the map
+  const selectStyleLayer = createLayer(options.layer) as
+    | VectorTileLayer
+    | VectorLayer<VectorSource>;
+  await selectStyleLayer.get("sourcePromise");
+  selectStyleLayer.setSource(selectLayer.getSource());
+  selectStyleLayer.setMap(map);
+
+  const initialStyle = selectStyleLayer.getStyleFunction();
+
+  selectStyleLayer.setStyle((feature: Feature, resolution: number) => {
+    if (selectedFid && getId(feature) === selectedFid) {
+      return initialStyle(feature, resolution);
+    }
+    return null;
+  });
+
+  const listener = (event: MapBrowserEvent<any>) => {
+    if (event.dragging) {
+      return;
+    }
+    selectLayer
+      .getFeatures(event.pixel)
+      .then(function (features: Array<Feature | RenderFeature>) {
+        const feature = features.length ? features[0] : null;
+        selectedFid = feature ? getId(feature) : null;
+        selectStyleLayer.changed();
+
+        if (overlay) {
+          overlay.setPosition(feature ? event.coordinate : null);
+          tooltip.renderContent(feature.getProperties());
+        }
+
+        const selectdEvt = new CustomEvent("select", {
+          detail: {
+            originalEvent: event,
+            feature: feature,
+          },
+        });
+        EOxMap.dispatchEvent(selectdEvt);
+      });
+  };
+  map.on(options.condition || "click", listener);
+
+  // if the parent layer changes, also change the selection layer.
+  selectLayer.on("change:opacity", (value: number) => {
+    selectStyleLayer.setOpacity(value);
+  });
+  selectLayer.on("change:visible", (visible: boolean) => {
+    selectStyleLayer.setVisible(visible);
+  });
+  selectLayer.on("change:source", (value: VectorSource | VectorTileSource) => {
+    //@ts-ignore
+    selectStyleLayer.setSource(value);
+  });
+  map.getLayers().on("remove", () => {
+    if (!EOxMap.getLayerById(layerId)) {
+      selectStyleLayer.setMap(null);
+      if (overlay) {
+        map.removeOverlay(overlay);
+      }
+    }
+  });
 }

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -7,7 +7,6 @@ import Feature from "ol/Feature";
 import RenderFeature from "ol/render/Feature";
 import VectorTileLayer from "ol/layer/VectorTile.js";
 import VectorLayer from "ol/layer/Vector.js";
-import VectorTileSource from "ol/source/VectorTile.js";
 import VectorSource from "ol/source/Vector.js";
 import MapBrowserEvent from "ol/MapBrowserEvent";
 

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -52,11 +52,25 @@ export async function addSelect(
   const selectLayer = EOxMap.getLayerById(layerId);
   await selectLayer.get("sourcePromise");
 
-  options.layer.renderMode = "vector";
-
   // a layer that only contains the selected features, for displaying purposes only
   // unmanaged by the map
-  const selectStyleLayer = createLayer(options.layer) as
+  let layerDefinition;
+  if (options.layer.style) {
+    layerDefinition = options.layer;
+  } else {
+    const type = selectLayer instanceof VectorLayer ? "Vector" : "VectorTile";
+    // a layer can be defined by only its style property as a shorthand.
+    layerDefinition = {
+      style: options.layer,
+      type,
+      source: {
+        type,
+      },
+    };
+  }
+  layerDefinition.renderMode = "vector";
+
+  const selectStyleLayer = createLayer(layerDefinition) as
     | VectorTileLayer
     | VectorLayer<VectorSource>;
   await selectStyleLayer.get("sourcePromise");

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -100,16 +100,27 @@ export async function addSelect(
   map.on(options.condition || "click", listener);
 
   // if the parent layer changes, also change the selection layer.
-  selectLayer.on("change:opacity", (value: number) => {
-    selectStyleLayer.setOpacity(value);
+
+  selectLayer.on("change:opacity", () => {
+    selectStyleLayer.setOpacity(selectLayer.getOpacity());
   });
-  selectLayer.on("change:visible", (visible: boolean) => {
+
+  selectLayer.on("change:visible", () => {
+    const visible = selectLayer.getVisible();
     selectStyleLayer.setVisible(visible);
+    if (overlay) {
+      if (visible) {
+        map.addOverlay(overlay);
+      } else {
+        map.removeOverlay(overlay);
+      }
+    }
   });
-  //@ts-ignore
-  selectLayer.on("change:source", (value) => {
-    selectStyleLayer.setSource(value);
+
+  selectLayer.on("change:source", () => {
+    selectStyleLayer.setSource(selectLayer.getSource());
   });
+
   map.getLayers().on("remove", () => {
     if (!EOxMap.getLayerById(layerId)) {
       selectStyleLayer.setMap(null);

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -66,7 +66,7 @@ export async function addSelect(
 
   const initialStyle = selectStyleLayer.getStyleFunction();
 
-  selectStyleLayer.setStyle((feature: Feature, resolution: number) => {
+  selectStyleLayer.setStyle((feature, resolution) => {
     if (selectedFid && getId(feature) === selectedFid) {
       return initialStyle(feature, resolution);
     }
@@ -107,8 +107,8 @@ export async function addSelect(
   selectLayer.on("change:visible", (visible: boolean) => {
     selectStyleLayer.setVisible(visible);
   });
-  selectLayer.on("change:source", (value: VectorSource | VectorTileSource) => {
-    //@ts-ignore
+  //@ts-ignore
+  selectLayer.on("change:source", (value) => {
     selectStyleLayer.setSource(value);
   });
   map.getLayers().on("remove", () => {

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -55,13 +55,13 @@ export async function addSelect(
   // a layer that only contains the selected features, for displaying purposes only
   // unmanaged by the map
   let layerDefinition;
-  if (options.layer.style) {
+  if (options.layer) {
     layerDefinition = options.layer;
   } else {
     const type = selectLayer instanceof VectorLayer ? "Vector" : "VectorTile";
     // a layer can be defined by only its style property as a shorthand.
     layerDefinition = {
-      style: options.layer,
+      style: options.style,
       type,
       source: {
         type,

--- a/elements/map/test/hoverInteraction.cy.ts
+++ b/elements/map/test/hoverInteraction.cy.ts
@@ -13,10 +13,10 @@ describe("select interaction with hover", () => {
       let selectCounter = 0;
       let featureSelectCounter = 0;
       eoxMap.addEventListener("select", (evt) => {
-        selectCounter++
+        selectCounter++;
         //@ts-ignore
         if (evt.detail.feature) {
-          featureSelectCounter++
+          featureSelectCounter++;
         }
         if (selectCounter === 3) {
           // moving the cursor to a feature, moving it off the feature, and onto the feature again
@@ -24,31 +24,32 @@ describe("select interaction with hover", () => {
         }
       });
 
-      eoxMap.addSelect("regions", {
-        id: "selectInteraction",
-        tooltip: "eox-map-tooltip",
-        condition: "pointermove",
-        layer: {
-          type: "Vector",
-          properties: {
-            id: "selectLayer",
-          },
-          source: {
+      eoxMap
+        .addSelect("regions", {
+          id: "selectInteraction",
+          tooltip: "eox-map-tooltip",
+          condition: "pointermove",
+          layer: {
             type: "Vector",
+            properties: {
+              id: "selectLayer",
+            },
+            source: {
+              type: "Vector",
+            },
+            style: {
+              "stroke-color": "red",
+              "stroke-width": 3,
+            },
           },
-          style: {
-            "stroke-color": "red",
-            "stroke-width": 3,
-          },
-        },
-      })
-      .then(() => {
-        setTimeout(() => {
-          simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
-          simulateEvent(eoxMap.map, "pointermove", 0, -140);   // no feature here
-          simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
-        }, 1000);
-      });
+        })
+        .then(() => {
+          setTimeout(() => {
+            simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
+            simulateEvent(eoxMap.map, "pointermove", 0, -140); // no feature here
+            simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
+          }, 1000);
+        });
     });
   });
 

--- a/elements/map/test/hoverInteraction.cy.ts
+++ b/elements/map/test/hoverInteraction.cy.ts
@@ -52,22 +52,4 @@ describe("select interaction with hover", () => {
         });
     });
   });
-
-  /*it("fires a select event", () => {
-    cy.get("eox-map").should(($el) => {
-      const eoxMap = <EOxMap>$el[0];
-      // get the interaction via the source key
-      const drawInteraction = eoxMap.interactions["drawInteraction"];
-      expect(drawInteraction).to.exist;
-      expect(drawInteraction.getActive()).to.equal(true);
-    });
-  });
-
-
-  it("remove interaction", () => {
-    cy.get("eox-map").should(($el) => {
-      const eoxMap = <EOxMap>$el[0];
-      eoxMap.removeInteraction("drawInteraction");
-    });
-  });*/
 });

--- a/elements/map/test/hoverInteraction.cy.ts
+++ b/elements/map/test/hoverInteraction.cy.ts
@@ -1,6 +1,6 @@
-import { Select } from "ol/interaction";
 import "../main";
 import vectorLayerStyleJson from "./hoverInteraction.json";
+import { simulateEvent } from "./utils/events";
 
 describe("select interaction with hover", () => {
   it("adds a select interaction", () => {
@@ -9,18 +9,46 @@ describe("select interaction with hover", () => {
     ).as("eox-map");
     cy.get("eox-map").and(($el) => {
       const eoxMap = <EOxMap>$el[0];
+
+      let selectCounter = 0;
+      let featureSelectCounter = 0;
+      eoxMap.addEventListener("select", (evt) => {
+        selectCounter++
+        //@ts-ignore
+        if (evt.detail.feature) {
+          featureSelectCounter++
+        }
+        if (selectCounter === 3) {
+          // moving the cursor to a feature, moving it off the feature, and onto the feature again
+          expect(featureSelectCounter).to.be.equal(2);
+        }
+      });
+
       eoxMap.addSelect("regions", {
         id: "selectInteraction",
         tooltip: "eox-map-tooltip",
         condition: "pointermove",
+        layer: {
+          type: "Vector",
+          properties: {
+            id: "selectLayer",
+          },
+          source: {
+            type: "Vector",
+          },
+          style: {
+            "stroke-color": "red",
+            "stroke-width": 3,
+          },
+        },
+      })
+      .then(() => {
+        setTimeout(() => {
+          simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
+          simulateEvent(eoxMap.map, "pointermove", 0, -140);   // no feature here
+          simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
+        }, 1000);
       });
-
-      // get the interaction via the source key
-      const selectInteraction = eoxMap.interactions[
-        "selectInteraction"
-      ] as Select;
-      expect(selectInteraction).to.exist;
-      expect(selectInteraction.getActive()).to.equal(true);
     });
   });
 

--- a/elements/map/test/selectInteraction.cy.ts
+++ b/elements/map/test/selectInteraction.cy.ts
@@ -59,17 +59,8 @@ describe("select interaction on click", () => {
           tooltip: "eox-map-tooltip",
           condition: "click",
           layer: {
-            type: "Vector",
-            properties: {
-              id: "selectLayer",
-            },
-            source: {
-              type: "Vector",
-            },
-            style: {
-              "stroke-color": "white",
-              "stroke-width": 3,
-            },
+            "stroke-color": "white",
+            "stroke-width": 3,
           },
         })
         .then(() => {

--- a/elements/map/test/selectInteraction.cy.ts
+++ b/elements/map/test/selectInteraction.cy.ts
@@ -1,0 +1,82 @@
+import "../main";
+import vectorTileLayerStyleJson from "./vectorTilesLayer.json";
+import vectorLayerJson from "./vectorLayer.json";
+import { simulateEvent } from "./utils/events";
+
+describe("select interaction on click", () => {
+  it("adds a select interaction to VectorTile layer", () => {
+    cy.mount(
+      `<eox-map layers='${JSON.stringify(vectorTileLayerStyleJson)}'></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.addEventListener("select", (evt) => {
+        //@ts-ignore
+        expect(evt.detail.feature).to.exist;
+      });
+      eoxMap
+        .addSelect("countries", {
+          id: "selectInteraction",
+          tooltip: "eox-map-tooltip",
+          condition: "click",
+          idProperty: "formal_en",
+          layer: {
+            type: "VectorTile",
+            properties: {
+              id: "selectLayer",
+            },
+            source: {
+              type: "VectorTile",
+            },
+            style: {
+              "stroke-color": "white",
+              "stroke-width": 3,
+            },
+          },
+        })
+        .then(() => {
+          setTimeout(() => {
+            simulateEvent(eoxMap.map, "click", 120, -140);
+          }, 1000);
+        });
+    });
+  });
+  it("adds a select interaction to Vector layer", () => {
+    cy.mount(
+      `<eox-map layers='${JSON.stringify(vectorLayerJson)}'></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      eoxMap.addEventListener("select", (evt) => {
+        //@ts-ignore
+        expect(evt.detail.feature).to.exist;
+      });
+
+      eoxMap
+        .addSelect("regions", {
+          id: "selectInteraction",
+          tooltip: "eox-map-tooltip",
+          condition: "click",
+          layer: {
+            type: "Vector",
+            properties: {
+              id: "selectLayer",
+            },
+            source: {
+              type: "Vector",
+            },
+            style: {
+              "stroke-color": "white",
+              "stroke-width": 3,
+            },
+          },
+        })
+        .then(() => {
+          setTimeout(() => {
+            simulateEvent(eoxMap.map, "click", 120, -140);
+          }, 1000);
+        });
+    });
+  });
+});

--- a/elements/map/test/selectInteraction.cy.ts
+++ b/elements/map/test/selectInteraction.cy.ts
@@ -58,7 +58,7 @@ describe("select interaction on click", () => {
           id: "selectInteraction",
           tooltip: "eox-map-tooltip",
           condition: "click",
-          layer: {
+          style: {
             "stroke-color": "white",
             "stroke-width": 3,
           },

--- a/elements/map/test/utils/events.ts
+++ b/elements/map/test/utils/events.ts
@@ -7,7 +7,7 @@ const height = 400;
  */
 export function simulateEvent(
   map: Map,
-  type: "pointermove" | "pointerup" | "pointerdown",
+  type: "pointermove" | "pointerup" | "pointerdown" | "click",
   x: number,
   y: number
 ) {
@@ -19,6 +19,7 @@ export function simulateEvent(
   event.target = viewport.firstChild;
   event.clientX = position.left + x + width / 2;
   event.clientY = position.top + y + height / 2;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   event.preventDefault = function () {};
   event.pointerType = "mouse";
   const simulatedEvent = new MapBrowserEvent(type, map, event);


### PR DESCRIPTION
This PR introduces updates to the "Selection"-functionality (#194) and some refactoring of the map-element.

Selecting a feature does not work with the normal "Select"-Interaction. The `addSelect`-method of the map-element now creates a listener for the given event type (`click` or `pointermove`, defaulting to `click`) and creates an unmanaged layer to display the selected feature. That has the same source as the original layer, much like the `select`-interaction does internally, but can be styled freely, e.g. via flat styles. This also removes the hassle of working with `setFeatureState` (#193).

Additionally to the tooltip and the condition, an optional `idPoperty` can be defined (see the VectorTile-Test of `selectInteraction.cy.ts`), in case the native ID of the features are not stable across tile borders or the features have no native ID at all.

The layer for the selected feature follows events of the original selection layer. When the original layer is removed, so is the selection layer as well as the event listener. Similar measures are taken when changing opacity, visibility or the source.