### PR TITLE
Pre-expanded subsections using new `layerControlExpanded` layer attribute

### DIFF
--- a/elements/layercontrol/README.md
+++ b/elements/layercontrol/README.md
@@ -79,6 +79,10 @@ Initially hide a layer from the layer control, but make it available as an optio
 
 Make layers mutually exclusive. If two or more layers (on the same level, i.e. at root or inside a layer group) have this property, then only one of them can be visualized at a time.
 
+### `layerControlExpanded?: Boolean`
+
+Pre-expand a layer dropdown so that it is always open when the component initializes.
+
 ## Contribute
 
 ### Setup

--- a/elements/layercontrol/index.html
+++ b/elements/layercontrol/index.html
@@ -95,6 +95,7 @@
               "type": "WebGLTile",
               "id": "s2",
               "layerControlExclusive": true,
+              "layerControlExpanded": true,
               "title": "s2",
               "style": {
                 "variables": {

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -172,7 +172,7 @@ export class EOxLayerControl extends LitElement {
     });
 
     const singleLayer = (layer: Layer, groupId: string) => html`
-      <details>
+      <details open="${layer.get("layerControlExpanded") ? true : nothing}">
         <summary>
           <div class="layer">
             <div class="left">

--- a/elements/layercontrol/test/_mockMap.ts
+++ b/elements/layercontrol/test/_mockMap.ts
@@ -13,6 +13,7 @@ const mockLayer = (layerId: number) =>
     id: layerId,
     layerControlDisable: undefined,
     layerControlExclusive: undefined,
+    layerControlExpanded: undefined,
     layerControlHide: undefined,
     layerControlOptional: undefined,
     opacity: 1,

--- a/elements/layercontrol/test/general.cy.ts
+++ b/elements/layercontrol/test/general.cy.ts
@@ -84,4 +84,18 @@ describe("LayerControl", () => {
         cy.get(".layer").find(".title").contains("bar");
       });
   });
+
+  it("pre-opens a section if layerControlExpanded is present", () => {
+    cy.get("mock-map").and(($el) => {
+      (<MockMap>$el[0]).setLayers([
+        { visible: true },
+        { layerControlExpanded: true },
+      ]);
+    });
+    cy.get("eox-layercontrol")
+      .shadow()
+      .within(() => {
+        cy.get("details[open]").should("exist");
+      });
+  });
 });


### PR DESCRIPTION
This PR implements a simple change to enable the subsections in the layer control to pre-expand if a flag is present in the layer config, as described in #184

<img width="643" alt="Screenshot 2023-08-21 at 14 23 12" src="https://github.com/EOX-A/EOxElements/assets/94269527/2b3a173d-1478-4339-8959-11b734a59d32">
