### PR TITLE
Make long layer names render nicely in LayerControl

### DIFF
--- a/elements/layercontrol/index.html
+++ b/elements/layercontrol/index.html
@@ -61,7 +61,7 @@
             {
               "type": "Tile",
               "id": "NO2",
-              "title": "NO2",
+              "title": "Super Duper Uber Long Title for Nitrous Dioxide",
               "source": {
                 "type": "TileWMS",
                 "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -186,8 +186,8 @@ export class EOxLayerControl extends LitElement {
                 }}
               />
               <span class="title"
-                >${layer.get(this.layerTitle) ||
-                `${layer.get(this.layerIdentifier)}`}
+                ><span>${layer.get(this.layerTitle) ||
+                `${layer.get(this.layerIdentifier)}`}</span>
               </span>
             </div>
             <div class="right">

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -14,16 +14,22 @@ ${radio}
 ${checkbox}
 
 summary > .layer {
-  height: 36px;
-  border-bottom: 1px solid #00417000;
+  min-height: 36px;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   padding-right: 12px;
+  padding-top: 0px;
 }
 
 [data-type=group] .title {
+  display: flex;
+  align-items: flex-start;
   font-style: italic;
-  line-height: 1rem;
+  line-height: 1.3rem;
+}
+
+[data-type] .title span {
+  margin-bottom: 8px;
 }
 
 
@@ -33,6 +39,7 @@ summary > .layer {
   height: 24px;
   margin-right: 6px;
   margin-left: -1px;
+  transform: translateY(-2px);
 }
 
 [data-layerconfig] button {
@@ -204,12 +211,18 @@ li .layer {
 li .layer .left,
 li .layer .right {
   display: flex;
+  align-items: flex-start;
 }
-li .layer .left span {
+li .layer .left .title {
   cursor: pointer;
   display: flex;
-  align-items: center;
   margin-left: 6px;
+}
+li .layer .left {
+  margin-top: 7px;
+}
+li .layer .right {
+  margin-top: 5px;
 }
 .drag-handle span {
   display: none;

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -23,6 +23,7 @@ summary > .layer {
 
 [data-type=group] .title {
   font-style: italic;
+  line-height: 1rem;
 }
 
 

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -28,6 +28,7 @@ summary > .layer {
 
 [data-type] .title::before {
   width: 24px;
+  min-width: 24px;
   height: 24px;
   margin-right: 6px;
   margin-left: -1px;


### PR DESCRIPTION
This PR contains changes which ensure that long names render nicely and don't affect the surroundings.

<img width="533" alt="Screenshot 2023-08-22 at 14 33 13" src="https://github.com/EOX-A/EOxElements/assets/94269527/bd36298f-3985-4f3d-bc98-596b9a023410">



 