### PR TITLE
Configurable single panel expansion for accordions

### DIFF
--- a/elements/itemfilter/README.md
+++ b/elements/itemfilter/README.md
@@ -14,6 +14,12 @@ import "@eox/itemfilter"
 
 // TODO: add documentation
 
+## Attributes
+
+### `expandMultiple?: boolean = false`
+
+Allow opening multiple accordeons in parallel.
+
 ## Contribute
 
 ```

--- a/elements/itemfilter/README.md
+++ b/elements/itemfilter/README.md
@@ -16,11 +16,11 @@ import "@eox/itemfilter"
 
 ## Attributes
 
-### `expandMultipleFilters?: boolean = false`
+### `expandMultipleFilters?: boolean = true`
 
 Allow opening multiple filter accordeons in parallel.
 
-### `expandMultipleResults?: boolean = false`
+### `expandMultipleResults?: boolean = true`
 
 Allow opening multiple result accordeons in parallel.
 

--- a/elements/itemfilter/README.md
+++ b/elements/itemfilter/README.md
@@ -16,9 +16,13 @@ import "@eox/itemfilter"
 
 ## Attributes
 
-### `expandMultiple?: boolean = false`
+### `expandMultipleFilters?: boolean = false`
 
-Allow opening multiple accordeons in parallel.
+Allow opening multiple filter accordeons in parallel.
+
+### `expandMultipleResults?: boolean = false`
+
+Allow opening multiple result accordeons in parallel.
 
 ## Contribute
 

--- a/elements/itemfilter/index.html
+++ b/elements/itemfilter/index.html
@@ -70,6 +70,7 @@
         ],
         aggregateResults: "themes",
         enableSearch: true,
+        expandMultiple: false,
         // enableHighlighting: true,
         // showResults: false,
         onSelect: (item) => {

--- a/elements/itemfilter/index.html
+++ b/elements/itemfilter/index.html
@@ -70,7 +70,8 @@
         ],
         aggregateResults: "themes",
         enableSearch: true,
-        expandMultiple: false,
+        expandMultipleFilters: false,
+        expandMultipleResults: false,
         // enableHighlighting: true,
         // showResults: false,
         onSelect: (item) => {

--- a/elements/itemfilter/src/filters/_expandcontainer.ts
+++ b/elements/itemfilter/src/filters/_expandcontainer.ts
@@ -11,6 +11,14 @@ export class EOxItemFilterExpandContainer extends LitElement {
   @property()
   unstyled: boolean;
 
+  handleDetailsToggle(event: Event) {
+    this.dispatchEvent(new CustomEvent('details-toggled', {
+      detail: event,
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
   render() {
     return html`
       <style>
@@ -18,6 +26,7 @@ export class EOxItemFilterExpandContainer extends LitElement {
         ${!this.unstyled && styleEOX}
       </style>
       <details
+        @toggle="${this.handleDetailsToggle}"
         class="details-filter"
         part="details-filter"
         data-filter="${this.filterObject.key}"

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -79,6 +79,12 @@ export class ElementConfig {
    * The property of the result items used for display
    */
   public titleProperty = "title";
+
+  /**
+   * Allow opening multiple `details` accordeons in parallel
+   * @default false
+   */
+  public expandMultiple?: boolean = false;
 }
 
 @customElement("eox-itemfilter")
@@ -279,6 +285,23 @@ export class EOxItemFilter extends TemplateElement {
     this.search();
   }
 
+  toggleAccordion(event: Event) {
+    const detailsElement = event.target as HTMLDetailsElement;
+
+    // Return early if multiple expansions are allowed or if accordion is being closed.
+    if (!detailsElement.open || this.config.expandMultiple) return;
+
+    // If we reach this point, it means detailsElement is being opened. Grab all `details`
+    // elements and close all other than the current one.
+    this.shadowRoot!
+      .querySelectorAll('details')
+      .forEach(details => {
+          if (details !== detailsElement) {
+              details.removeAttribute('open');
+          }
+      });
+  }
+
   render() {
     return html`
       <style>
@@ -382,6 +405,7 @@ export class EOxItemFilter extends TemplateElement {
                         ),
                         (aggregationProperty) => html`<details
                           class="details-results"
+                          @toggle=${this.toggleAccordion}
                           open
                         >
                           <summary>

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -82,15 +82,15 @@ export class ElementConfig {
 
   /**
    * Allow opening multiple filter accordeons in parallel
-   * @default false
+   * @default true
    */
-  public expandMultipleFilters?: boolean = false;
+  public expandMultipleFilters?: boolean = true;
 
   /**
    * Allow opening multiple result accordeons in parallel
-   * @default false
+   * @default true
    */
-  public expandMultipleResults?: boolean = false;
+  public expandMultipleResults?: boolean = true;
 }
 
 @customElement("eox-itemfilter")

--- a/elements/itemfilter/test/general.cy.ts
+++ b/elements/itemfilter/test/general.cy.ts
@@ -24,6 +24,8 @@ describe("Item Filter Config", () => {
           ],
           aggregateResults: "themes",
           enableHighlighting: true,
+          expandMultipleFilters: false,
+          expandMultipleResults: false,
         };
         eoxItemFilter[0].apply(testItems);
       });
@@ -65,6 +67,37 @@ describe("Item Filter Config", () => {
         cy.get("[data-cy='search']").type("white");
         cy.get("mark.highlight").should("not.exist");
       });
+  });
+
+  it('should allow only one accordion of each type to be open at a time if configured', () => {
+    const checkExclusiveOpen = (selector: string, isSubcomponent = false) => {
+      cy.get("eox-itemfilter").shadow().within(() => {
+        cy.get(selector).then(accordions => {
+          for (let i = 0; i < accordions.length; i++) {
+            const accordionToClick = isSubcomponent
+              ? cy.get(selector).eq(i).find('eox-itemfilter-expandcontainer').shadow().find('details')
+              : cy.get(selector).eq(i).find('details');
+
+            accordionToClick.click({ multiple: true, force: true });
+            accordionToClick.should('have.attr', 'open');
+
+            // Check that all other accordions are closed
+            for (let j = 0; j < accordions.length; j++) {
+              if (i !== j) {
+                const accordionToCheck = isSubcomponent
+                  ? cy.get(selector).eq(j).find('eox-itemfilter-expandcontainer').shadow().find('details')
+                  : cy.get(selector).eq(j).find('details');
+
+                accordionToCheck.should('not.have.attr', 'open');
+              }
+            }
+          }
+        });
+      });
+    }
+
+    checkExclusiveOpen('ul#filters', true);
+    checkExclusiveOpen('ul#results');
   });
 
   // it("should not have a search bar", () => {

--- a/elements/itemfilter/test/general.cy.ts
+++ b/elements/itemfilter/test/general.cy.ts
@@ -140,8 +140,8 @@ describe("Item Filter Config", () => {
 
   it('should allow only one accordion of each type to be open at a time if configured', () => {
     cy.get("eox-itemfilter").then(($el) => {
-      $el[0].config.expandMultipleFilters = false;
-      $el[0].config.expandMultipleResults = false;
+      (<EOxItemFilter>$el[0]).config.expandMultipleFilters = false;
+      (<EOxItemFilter>$el[0]).config.expandMultipleResults = false;
     });
 
     const checkExclusiveOpen = (selector: string, isSubcomponent = false) => {

--- a/elements/itemfilter/test/general.cy.ts
+++ b/elements/itemfilter/test/general.cy.ts
@@ -24,8 +24,6 @@ describe("Item Filter Config", () => {
           ],
           aggregateResults: "themes",
           enableHighlighting: true,
-          expandMultipleFilters: false,
-          expandMultipleResults: false,
         };
         eoxItemFilter[0].apply(testItems);
       });
@@ -67,37 +65,6 @@ describe("Item Filter Config", () => {
         cy.get("[data-cy='search']").type("white");
         cy.get("mark.highlight").should("not.exist");
       });
-  });
-
-  it('should allow only one accordion of each type to be open at a time if configured', () => {
-    const checkExclusiveOpen = (selector: string, isSubcomponent = false) => {
-      cy.get("eox-itemfilter").shadow().within(() => {
-        cy.get(selector).then(accordions => {
-          for (let i = 0; i < accordions.length; i++) {
-            const accordionToClick = isSubcomponent
-              ? cy.get(selector).eq(i).find('eox-itemfilter-expandcontainer').shadow().find('details')
-              : cy.get(selector).eq(i).find('details');
-
-            accordionToClick.click({ multiple: true, force: true });
-            accordionToClick.should('have.attr', 'open');
-
-            // Check that all other accordions are closed
-            for (let j = 0; j < accordions.length; j++) {
-              if (i !== j) {
-                const accordionToCheck = isSubcomponent
-                  ? cy.get(selector).eq(j).find('eox-itemfilter-expandcontainer').shadow().find('details')
-                  : cy.get(selector).eq(j).find('details');
-
-                accordionToCheck.should('not.have.attr', 'open');
-              }
-            }
-          }
-        });
-      });
-    }
-
-    checkExclusiveOpen('ul#filters', true);
-    checkExclusiveOpen('ul#results');
   });
 
   // it("should not have a search bar", () => {
@@ -170,4 +137,40 @@ describe("Item Filter Config", () => {
   //         });
   //     });
   // });
+
+  it('should allow only one accordion of each type to be open at a time if configured', () => {
+    cy.get("eox-itemfilter").then(($el) => {
+      $el[0].config.expandMultipleFilters = false;
+      $el[0].config.expandMultipleResults = false;
+    });
+
+    const checkExclusiveOpen = (selector: string, isSubcomponent = false) => {
+      cy.get("eox-itemfilter").shadow().within(() => {
+        cy.get(selector).then(accordions => {
+          for (let i = 0; i < accordions.length; i++) {
+            const accordionToClick = isSubcomponent
+              ? cy.get(selector).eq(i).find('eox-itemfilter-expandcontainer').shadow().find('details')
+              : cy.get(selector).eq(i).find('details');
+
+            accordionToClick.click({ multiple: true, force: true });
+            accordionToClick.should('have.attr', 'open');
+
+            // Check that all other accordions are closed
+            for (let j = 0; j < accordions.length; j++) {
+              if (i !== j) {
+                const accordionToCheck = isSubcomponent
+                  ? cy.get(selector).eq(j).find('eox-itemfilter-expandcontainer').shadow().find('details')
+                  : cy.get(selector).eq(j).find('details');
+
+                accordionToCheck.should('not.have.attr', 'open');
+              }
+            }
+          }
+        });
+      });
+    }
+
+    checkExclusiveOpen('ul#filters', true);
+    checkExclusiveOpen('ul#results');
+  });
 });


### PR DESCRIPTION
This PR implements two new Boolean config options for the item filter called `expandMultipleFilters` and `expandMultipleResults` which allow having multiple accordeons expanded at the same time if set. If unset, each opening of a new accordeon will close all other ones. This happens independently for each of the accordeon sets.

Closes #174 

https://github.com/EOX-A/EOxElements/assets/94269527/95723ecc-1172-4a16-a9f0-2fe9aabe5c07



