### PR TITLE
get layer inside group

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -9,7 +9,7 @@ import { addSelect } from "./src/select";
 import { generateLayers, EoxLayer } from "./src/generate";
 import Interaction from "ol/interaction/Interaction";
 import Control from "ol/control/Control";
-import { getLayerById } from "./src/layer";
+import { getLayerById, getFlatLayersArray } from "./src/layer";
 import { getCenterFromAttribute } from "./src/center";
 import { addInitialControls } from "./src/controls";
 import "./src/compare";
@@ -123,6 +123,8 @@ export class EOxMap extends LitElement {
   getLayerById: Function = (layerId: string) => {
     return getLayerById(this, layerId);
   };
+
+  getFlatLayersArray = getFlatLayersArray;
 
   render() {
     const shadowStyleFix = `

--- a/elements/map/src/layer.ts
+++ b/elements/map/src/layer.ts
@@ -1,4 +1,6 @@
 import { EOxMap } from "../main";
+import Group from "ol/layer/Group";
+import Layer from "ol/layer/Base";
 
 /**
  *
@@ -7,16 +9,38 @@ import { EOxMap } from "../main";
  * @returns Layer
  */
 export function getLayerById(EOxMap: EOxMap, layerId: string) {
-  // get mapbox-style layer or manually generated ol layer
-  const layers = EOxMap.map.getLayers().getArray();
+  const flatLayers = getFlatLayersArray(EOxMap.map.getLayers().getArray());
+  // get mapbox-style layer or manually generated ol layer, both group or regular layers
+
   const layer =
-    layers.find((l) => l.get("id") === layerId) ||
-    layers
+    flatLayers.find((l) => l.get("id") === layerId) ||
+    flatLayers
       .filter((l) => l.get("mapbox-layers"))
       .find((l) => l.get("mapbox-layers").includes(layerId));
-
   if (!layer) {
     throw Error(`Layer with id: ${layerId} does not exist.`);
   }
   return layer;
+}
+
+export function getFlatLayersArray(layers: Array<Layer>) {
+  const flatLayers = [];
+  flatLayers.push(...layers);
+
+  let groupLayers = flatLayers.filter(
+    (l) => l instanceof Group
+  ) as Array<Group>;
+
+  while (groupLayers.length) {
+    const newGroupLayers = [];
+    for (let i = 0, ii = groupLayers.length; i < ii; i++) {
+      const layersInsideGroup = groupLayers[i].getLayers().getArray();
+      flatLayers.push(...layersInsideGroup);
+      newGroupLayers.push(
+        ...(layersInsideGroup.filter((l) => l instanceof Group) as Array<Group>)
+      );
+    }
+    groupLayers = newGroupLayers;
+  }
+  return flatLayers;
 }

--- a/elements/map/test/groupLayer.cy.ts
+++ b/elements/map/test/groupLayer.cy.ts
@@ -1,0 +1,60 @@
+import "../main";
+
+describe("layers", () => {
+  it("loads a Vector Layer", () => {
+    cy.mount(
+      `<eox-map layers='[
+        {
+          "type": "Group",
+          "id": "group",
+          "layers": [
+            {
+              "type": "Group",
+              "id": "groupLayerInsideGroup",
+              "layers": [
+                {
+                  "type": "Tile",
+                  "id": "layerInsideGroupInsideGroup",
+                  "source": {
+                    "type": "OSM"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "Vector",
+              "id": "regions",
+              "source": {
+                "type": "Vector",
+                "url": "https://openlayers.org/data/vector/ecoregions.json",
+                "format": "GeoJSON"
+              }
+            }
+          ]
+        }
+      ]'></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      const groupLayer = eoxMap.getLayerById("group");
+      expect(groupLayer, "find group layer").to.exist;
+
+      const layerInsideGroup = eoxMap.getLayerById("regions");
+      expect(layerInsideGroup, "find layer inside group").to.exist;
+
+      const groupLayerInsideGroup = eoxMap.getLayerById(
+        "groupLayerInsideGroup"
+      );
+      expect(groupLayerInsideGroup, "find group layer inside group").to.exist;
+
+      const layerInsideGroupInsideGroup = eoxMap.getLayerById(
+        "layerInsideGroupInsideGroup"
+      );
+      expect(
+        layerInsideGroupInsideGroup,
+        "find layer inside group inside group"
+      ).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
This PR is based in the ideas listed in #151. In order to get all the layers inside groups, but also the group layers itself, a function `getFlatLayersArray` was created. Maybe we want to expose this helper function, as filtering for attributes, but also non-property-based attributes (like `visible` to get all visible layers) would be 1-liners in the parent application?

The `getLayerById` function remained mostly unchanged, as it contains some special logic for mapbox-layers, which may or may not be used in the future. It currently also throws an error, which was useful when testing, but maybe it should just return `undefined` instead?

@silvester-pari currently the `generate`- function does a `Array.reverse` on the layers array, is there a certain reason for that? the added test does not show the vector layer, although it should be showing considering the layer order.