### PR TITLE
chore: improve typing

### DIFF
--- a/elements/map/index.html
+++ b/elements/map/index.html
@@ -37,9 +37,6 @@
       ]);
       document.querySelector("eox-map").addSelect("regions", {
         id: "selectInteraction",
-        overlay: {
-          element: "eox-map-tooltip",
-        },
         condition: "pointermove",
         layer: {
           type: "Vector",

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -4,8 +4,8 @@ import Map from "ol/Map.js";
 import View from "ol/View.js";
 // @ts-ignore
 import olCss from "ol/ol.css";
-import { addDraw } from "./src/draw";
-import { addSelect } from "./src/select";
+import { DrawOptions, addDraw } from "./src/draw";
+import { SelectOptions, addSelect } from "./src/select";
 import { generateLayers, EoxLayer } from "./src/generate";
 import Interaction from "ol/interaction/Interaction";
 import Control from "ol/control/Control";
@@ -77,16 +77,16 @@ export class EOxMap extends LitElement {
    * @param json a Mapbox Style JSON
    * @returns the array of layers
    */
-  setLayers: Function = (json: Array<EoxLayer>) => {
+  setLayers = (json: Array<EoxLayer>) => {
     this.map.setLayers(generateLayers(json));
   };
 
   /**
    * Adds draw functionality to a given vector layer.
    * @param layerId id of a vector layer to draw on
-   * @param options options (to do: define draw options)
+   * @param options options
    */
-  addDraw: Function = (layerId: string, options: Object) => {
+  addDraw = (layerId: string, options: DrawOptions) => {
     addDraw(this, layerId, options);
   };
 
@@ -95,7 +95,7 @@ export class EOxMap extends LitElement {
    * @param layerId id of a vector layer to select features from
    * @param options options (to do: define select options)
    */
-  addSelect: Function = (layerId: string, options: Object) => {
+  addSelect = (layerId: string, options: SelectOptions) => {
     return addSelect(this, layerId, options);
   };
 
@@ -103,7 +103,7 @@ export class EOxMap extends LitElement {
    * removes a given interaction from the map. Layer have to be removed seperately
    * @param id id of the interaction
    */
-  removeInteraction: Function = (id: string) => {
+  removeInteraction = (id: string) => {
     this.map.removeInteraction(this.interactions[id]);
     delete this.interactions[id];
   };
@@ -112,7 +112,7 @@ export class EOxMap extends LitElement {
    * removes a given control from the map.
    * @param id id of the control element
    */
-  removeControl: Function = (id: string) => {
+  removeControl = (id: string) => {
     this.map.removeControl(this.mapControls[id]);
     delete this.mapControls[id];
   };
@@ -120,7 +120,7 @@ export class EOxMap extends LitElement {
   /**
    * gets an OpenLayers-Layer, either by its "id" or one of its Mapbox-Style IDs
    */
-  getLayerById: Function = (layerId: string) => {
+  getLayerById = (layerId: string) => {
     return getLayerById(this, layerId);
   };
 

--- a/elements/map/package.json
+++ b/elements/map/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "dependencies": {
     "lit": "^2.7.4",
-    "ol": "^7.4.0",
-    "ol-mapbox-style": "^10.6.0",
+    "ol": "^8.0.0-dev.1693483855644",
+    "ol-mapbox-style": "^11.0.3",
     "ol-stac": "^1.0.0-beta.4"
   },
   "devDependencies": {

--- a/elements/map/src/compare.ts
+++ b/elements/map/src/compare.ts
@@ -7,7 +7,7 @@ type HTMLElementEvent<T extends HTMLElement> = Event & {
 };
 export class EOxMapCompare extends TemplateElement {
   @property()
-  value: number = 50;
+  value = 50;
 
   render() {
     return html`

--- a/elements/map/src/draw.ts
+++ b/elements/map/src/draw.ts
@@ -3,14 +3,18 @@ import { EOxMap } from "../main";
 import { getArea, getLength } from "ol/sphere";
 import { LineString, Polygon } from "ol/geom";
 import GeoJSON from "ol/format/GeoJSON";
-import {Vector as VectorLayer} from "ol/layer";
-import {Vector as VectorSource} from "ol/source";
+import { Vector as VectorLayer } from "ol/layer";
+import { Vector as VectorSource } from "ol/source";
 
-export type DrawOptions = import('ol/interaction/Draw').Options & {
-  id: string | number
-}
+export type DrawOptions = import("ol/interaction/Draw").Options & {
+  id: string | number;
+};
 
-export function addDraw(EOxMap: EOxMap, layerId: string, options: DrawOptions): void {
+export function addDraw(
+  EOxMap: EOxMap,
+  layerId: string,
+  options: DrawOptions
+): void {
   if (EOxMap.interactions[options.id]) {
     throw Error(`Interaction with id: ${options.id} already exists.`);
   }
@@ -18,7 +22,7 @@ export function addDraw(EOxMap: EOxMap, layerId: string, options: DrawOptions): 
   const map = EOxMap.map;
 
   const drawLayer = EOxMap.getLayerById(layerId) as VectorLayer<VectorSource>;
-  
+
   const source = drawLayer.getSource();
 
   const drawInteraction = new Draw({
@@ -34,7 +38,10 @@ export function addDraw(EOxMap: EOxMap, layerId: string, options: DrawOptions): 
   drawInteraction.on("drawend", (e) => {
     const geom = e.feature.getGeometry();
     if (geom instanceof LineString) {
-      const length = getLength(geom, { radius: 6378137, projection: "EPSG:3857" });
+      const length = getLength(geom, {
+        radius: 6378137,
+        projection: "EPSG:3857",
+      });
       e.feature.set("measure", length);
     } else if (geom instanceof Polygon) {
       const area = getArea(geom, { radius: 6378137, projection: "EPSG:3857" });

--- a/elements/map/src/draw.ts
+++ b/elements/map/src/draw.ts
@@ -3,17 +3,22 @@ import { EOxMap } from "../main";
 import { getArea, getLength } from "ol/sphere";
 import { LineString, Polygon } from "ol/geom";
 import GeoJSON from "ol/format/GeoJSON";
+import {Vector as VectorLayer} from "ol/layer";
+import {Vector as VectorSource} from "ol/source";
 
-export function addDraw(EOxMap: EOxMap, layerId: string, options: any): void {
+export type DrawOptions = import('ol/interaction/Draw').Options & {
+  id: string | number
+}
+
+export function addDraw(EOxMap: EOxMap, layerId: string, options: DrawOptions): void {
   if (EOxMap.interactions[options.id]) {
     throw Error(`Interaction with id: ${options.id} already exists.`);
   }
 
   const map = EOxMap.map;
 
-  const drawLayer = EOxMap.getLayerById(layerId);
-
-  // @ts-ignore
+  const drawLayer = EOxMap.getLayerById(layerId) as VectorLayer<VectorSource>;
+  
   const source = drawLayer.getSource();
 
   const drawInteraction = new Draw({
@@ -29,7 +34,7 @@ export function addDraw(EOxMap: EOxMap, layerId: string, options: any): void {
   drawInteraction.on("drawend", (e) => {
     const geom = e.feature.getGeometry();
     if (geom instanceof LineString) {
-      length = getLength(geom, { radius: 6378137, projection: "EPSG:3857" });
+      const length = getLength(geom, { radius: 6378137, projection: "EPSG:3857" });
       e.feature.set("measure", length);
     } else if (geom instanceof Polygon) {
       const area = getArea(geom, { radius: 6378137, projection: "EPSG:3857" });

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -84,7 +84,7 @@ export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
     }),
     style: undefined, // override layer style, apply style after
     ...(layer.type === "Group" && {
-      layers: layer.layers.map((l) => createLayer(l, layer.id)),
+      layers: layer.layers.reverse().map((l) => createLayer(l, layer.id)),
     }),
   });
 

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -74,6 +74,7 @@ export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
     ...layer,
     group,
     ...(layer.source && {
+      //@ts-ignore
       source: new newSource({
         ...layer.source,
         // @ts-ignore

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -51,7 +51,7 @@ const availableSources = {
 export type EoxLayer = {
   type: layerType;
   properties: object & {
-    id: string
+    id: string;
   };
   source?: { type: sourceType };
   layers?: Array<EoxLayer>;
@@ -85,7 +85,9 @@ export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
     }),
     style: undefined, // override layer style, apply style after
     ...(layer.type === "Group" && {
-      layers: layer.layers.reverse().map((l) => createLayer(l, layer.properties.id)),
+      layers: layer.layers
+        .reverse()
+        .map((l) => createLayer(l, layer.properties.id)),
     }),
   });
 

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -11,23 +11,26 @@ const availableLayers = {
   STAC,
 };
 
+export type layerType = 'Group' | 'Heatmap' | 'Image' | 'Layer' | 'Tile' | 'Vector' | 'VectorImage' | 'VectorTile';
+export type sourceType = 'BingMaps' | 'Cluster' | 'GeoTIFF' | 'IIIF' | 'Image' | 'ImageCanvas' | 'ImageStatic' | 'ImageWMS' | 'OSM'  | 'Raster'  | 'StadiaMaps'  | 'Tile'  | 'TileArcGISRest' | 'TileDebug' | 'TileImage' | 'TileJSON' | 'TileWMS' | 'UrlTile' | 'Vector' | 'VectorTile' | 'WMTS' | 'XYZ';
+
 const availableSources = {
   ...olSources,
 };
 
+
 export type EoxLayer = {
-  type: olLayers.Layer;
-  id: string;
-  properties?: Object;
-  source?: { type: olSources.Source };
+  type: layerType;
+  id?: string;
+  properties?: object;
+  source?: { type: sourceType};
   layers?: Array<EoxLayer>;
   style?: mapboxgl.Style | FlatStyleLike;
 };
 
 export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
-  // @ts-ignore
   const newLayer = availableLayers[layer.type];
-  // @ts-ignore
+  //@ts-ignore
   const newSource = availableSources[layer.source?.type];
   if (!newLayer) {
     throw new Error(`Layer type ${layer.type} not supported!`);
@@ -36,6 +39,7 @@ export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
     throw new Error(`Source type ${layer.source.type} not supported!`);
   }
 
+  //@ts-ignore
   const olLayer = new newLayer({
     ...layer,
     group,
@@ -50,9 +54,8 @@ export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
       }),
     }),
     style: undefined, // override layer style, apply style after
-    // @ts-ignore
     ...(layer.type === "Group" && {
-      layers: layer.layers.reverse().map((l) => createLayer(l, layer.id)),
+      layers: layer.layers.map((l) => createLayer(l, layer.id)),
     }),
   });
 
@@ -69,7 +72,6 @@ export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
       const sourceName = layer.properties.id;
       if (!mapboxStyle.sources[sourceName]) {
         const dummy =
-          //@ts-ignore
           layer.source.type === "VectorTile"
             ? {
                 type: "vector",

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -11,19 +11,48 @@ const availableLayers = {
   STAC,
 };
 
-export type layerType = 'Group' | 'Heatmap' | 'Image' | 'Layer' | 'Tile' | 'Vector' | 'VectorImage' | 'VectorTile';
-export type sourceType = 'BingMaps' | 'Cluster' | 'GeoTIFF' | 'IIIF' | 'Image' | 'ImageCanvas' | 'ImageStatic' | 'ImageWMS' | 'OSM'  | 'Raster'  | 'StadiaMaps'  | 'Tile'  | 'TileArcGISRest' | 'TileDebug' | 'TileImage' | 'TileJSON' | 'TileWMS' | 'UrlTile' | 'Vector' | 'VectorTile' | 'WMTS' | 'XYZ';
+export type layerType =
+  | "Group"
+  | "Heatmap"
+  | "Image"
+  | "Layer"
+  | "Tile"
+  | "Vector"
+  | "VectorImage"
+  | "VectorTile";
+export type sourceType =
+  | "BingMaps"
+  | "Cluster"
+  | "GeoTIFF"
+  | "IIIF"
+  | "Image"
+  | "ImageCanvas"
+  | "ImageStatic"
+  | "ImageWMS"
+  | "OSM"
+  | "Raster"
+  | "StadiaMaps"
+  | "Tile"
+  | "TileArcGISRest"
+  | "TileDebug"
+  | "TileImage"
+  | "TileJSON"
+  | "TileWMS"
+  | "UrlTile"
+  | "Vector"
+  | "VectorTile"
+  | "WMTS"
+  | "XYZ";
 
 const availableSources = {
   ...olSources,
 };
 
-
 export type EoxLayer = {
   type: layerType;
   id?: string;
   properties?: object;
-  source?: { type: sourceType};
+  source?: { type: sourceType };
   layers?: Array<EoxLayer>;
   style?: mapboxgl.Style | FlatStyleLike;
 };

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -50,8 +50,9 @@ const availableSources = {
 
 export type EoxLayer = {
   type: layerType;
-  id?: string;
-  properties?: object;
+  properties: object & {
+    id: string
+  };
   source?: { type: sourceType };
   layers?: Array<EoxLayer>;
   style?: mapboxgl.Style | FlatStyleLike;
@@ -84,7 +85,7 @@ export function createLayer(layer: EoxLayer, group?: string): olLayers.Layer {
     }),
     style: undefined, // override layer style, apply style after
     ...(layer.type === "Group" && {
-      layers: layer.layers.reverse().map((l) => createLayer(l, layer.id)),
+      layers: layer.layers.reverse().map((l) => createLayer(l, layer.properties.id)),
     }),
   });
 

--- a/elements/map/src/layer.ts
+++ b/elements/map/src/layer.ts
@@ -9,7 +9,9 @@ import Layer from "ol/layer/Layer";
  * @returns Layer
  */
 export function getLayerById(EOxMap: EOxMap, layerId: string) {
-  const flatLayers = getFlatLayersArray(EOxMap.map.getLayers().getArray() as Array<Layer>);
+  const flatLayers = getFlatLayersArray(
+    EOxMap.map.getLayers().getArray() as Array<Layer>
+  );
   // get mapbox-style layer or manually generated ol layer, both group or regular layers
 
   const layer =

--- a/elements/map/src/layer.ts
+++ b/elements/map/src/layer.ts
@@ -1,6 +1,6 @@
 import { EOxMap } from "../main";
 import Group from "ol/layer/Group";
-import Layer from "ol/layer/Base";
+import Layer from "ol/layer/Layer";
 
 /**
  *
@@ -9,7 +9,7 @@ import Layer from "ol/layer/Base";
  * @returns Layer
  */
 export function getLayerById(EOxMap: EOxMap, layerId: string) {
-  const flatLayers = getFlatLayersArray(EOxMap.map.getLayers().getArray());
+  const flatLayers = getFlatLayersArray(EOxMap.map.getLayers().getArray() as Array<Layer>);
   // get mapbox-style layer or manually generated ol layer, both group or regular layers
 
   const layer =
@@ -29,7 +29,7 @@ export function getFlatLayersArray(layers: Array<Layer>) {
 
   let groupLayers = flatLayers.filter(
     (l) => l instanceof Group
-  ) as Array<Group>;
+  ) as unknown as Array<Group>;
 
   while (groupLayers.length) {
     const newGroupLayers = [];
@@ -42,5 +42,5 @@ export function getFlatLayersArray(layers: Array<Layer>) {
     }
     groupLayers = newGroupLayers;
   }
-  return flatLayers;
+  return flatLayers as Array<Layer>;
 }

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -77,7 +77,7 @@ export async function addSelect(
       style: options.style,
       type,
       properties: {
-        id: layerId + '_select'
+        id: layerId + "_select",
       },
       source: {
         type,

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -2,18 +2,28 @@ import { EOxMap } from "../main";
 import { Overlay } from "ol";
 import "./tooltip";
 import { EOxMapTooltip } from "./tooltip";
-import { createLayer } from "./generate";
+import { EoxLayer, createLayer } from "./generate";
 import Feature from "ol/Feature";
 import RenderFeature from "ol/render/Feature";
 import VectorTileLayer from "ol/layer/VectorTile.js";
 import VectorLayer from "ol/layer/Vector.js";
 import VectorSource from "ol/source/Vector.js";
 import MapBrowserEvent from "ol/MapBrowserEvent";
+import { MapboxLayer } from "./types";
+
+export type SelectOptions = Omit<import('ol/interaction/Select').Options, 'condition'> & { 
+  id: string | number;
+  idProperty?: string;
+  condition: 'click' | 'pointermove',
+  layer?: EoxLayer | MapboxLayer,
+  style?: import("ol/style/flat.js").FlatStyleLike;
+  tooltip?: string;
+}
 
 export async function addSelect(
   EOxMap: EOxMap,
   layerId: string,
-  options: any
+  options: SelectOptions
 ): Promise<void> {
   if (EOxMap.interactions[options.id]) {
     throw Error(`Interaction with id: ${options.id} already exists.`);
@@ -63,17 +73,20 @@ export async function addSelect(
     layerDefinition = {
       style: options.style,
       type,
+      id: 'asd',
       source: {
         type,
       },
-    };
+    }  as EoxLayer;
   }
+  //@ts-ignore
   layerDefinition.renderMode = "vector";
 
-  const selectStyleLayer = createLayer(layerDefinition) as
+  const selectStyleLayer = createLayer(layerDefinition as EoxLayer) as
     | VectorTileLayer
     | VectorLayer<VectorSource>;
-  await selectStyleLayer.get("sourcePromise");
+    await selectStyleLayer.get("sourcePromise");
+    //@ts-ignore
   selectStyleLayer.setSource(selectLayer.getSource());
   selectStyleLayer.setMap(map);
 
@@ -132,6 +145,7 @@ export async function addSelect(
   });
 
   selectLayer.on("change:source", () => {
+    //@ts-ignore
     selectStyleLayer.setSource(selectLayer.getSource());
   });
 

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -76,7 +76,9 @@ export async function addSelect(
     layerDefinition = {
       style: options.style,
       type,
-      id: "asd",
+      properties: {
+        id: layerId + '_select'
+      },
       source: {
         type,
       },

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -20,7 +20,7 @@ export type SelectOptions = Omit<
   condition: "click" | "pointermove";
   layer?: EoxLayer | MapboxLayer;
   style?: import("ol/style/flat.js").FlatStyleLike;
-  tooltip?: string;
+  overlay?: import("ol/Overlay").Options;
 };
 
 export async function addSelect(
@@ -32,8 +32,8 @@ export async function addSelect(
     throw Error(`Interaction with id: ${options.id} already exists.`);
   }
 
-  const tooltip: HTMLElement = EOxMap.querySelector(options.overlay?.element);
-
+  const tooltip: HTMLElement =
+    EOxMap.querySelector("eox-map-tooltip") || options.overlay?.element;
   let overlay: Overlay;
   let selectedFid: string | number = null;
 
@@ -41,12 +41,12 @@ export async function addSelect(
 
   if (tooltip) {
     overlay = new Overlay({
+      element: tooltip,
       position: undefined,
       offset: [0, 0],
       positioning: "top-left",
       className: "eox-map-tooltip",
       ...options.overlay,
-      element: EOxMap.querySelector(options.overlay.element),
     });
     map.addOverlay(overlay);
   }

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -11,14 +11,17 @@ import VectorSource from "ol/source/Vector.js";
 import MapBrowserEvent from "ol/MapBrowserEvent";
 import { MapboxLayer } from "./types";
 
-export type SelectOptions = Omit<import('ol/interaction/Select').Options, 'condition'> & { 
+export type SelectOptions = Omit<
+  import("ol/interaction/Select").Options,
+  "condition"
+> & {
   id: string | number;
   idProperty?: string;
-  condition: 'click' | 'pointermove',
-  layer?: EoxLayer | MapboxLayer,
+  condition: "click" | "pointermove";
+  layer?: EoxLayer | MapboxLayer;
   style?: import("ol/style/flat.js").FlatStyleLike;
   tooltip?: string;
-}
+};
 
 export async function addSelect(
   EOxMap: EOxMap,
@@ -73,11 +76,11 @@ export async function addSelect(
     layerDefinition = {
       style: options.style,
       type,
-      id: 'asd',
+      id: "asd",
       source: {
         type,
       },
-    }  as EoxLayer;
+    } as EoxLayer;
   }
   //@ts-ignore
   layerDefinition.renderMode = "vector";
@@ -85,8 +88,8 @@ export async function addSelect(
   const selectStyleLayer = createLayer(layerDefinition as EoxLayer) as
     | VectorTileLayer
     | VectorLayer<VectorSource>;
-    await selectStyleLayer.get("sourcePromise");
-    //@ts-ignore
+  await selectStyleLayer.get("sourcePromise");
+  //@ts-ignore
   selectStyleLayer.setSource(selectLayer.getSource());
   selectStyleLayer.setMap(map);
 

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -8,7 +8,8 @@ export class EOxMapTooltip extends TemplateElement {
    * Useful for e.g. translating keys or introducing a whitelist.
    */
   @property()
-  propertyTransform: Function = (property: [key: string, value: any]) => property;
+  propertyTransform: Function = (property: [key: string, value: any]) =>
+    property;
 
   renderContent(content: Object) {
     render(

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -2,7 +2,7 @@ import { html, render } from "lit";
 import { TemplateElement } from "../../../utils/templateElement";
 
 export class EOxMapTooltip extends TemplateElement {
-  renderContent(content: Object) {
+  renderContent(content: object) {
     render(
       this.hasTemplate("properties")
         ? html`${this.renderTemplate(

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -32,6 +32,7 @@ describe("draw interaction", () => {
       simulateEvent(eoxMap.map, "pointerdown", 10, 20);
       simulateEvent(eoxMap.map, "pointerup", 10, 20);
       const drawLayer = eoxMap.getLayerById("drawLayer");
+      //@ts-ignore
       const features = drawLayer.getSource().getFeatures();
       const geometry = features[0].getGeometry() as Point;
       expect(features).to.have.length(1);

--- a/elements/map/test/drawInteraction.json
+++ b/elements/map/test/drawInteraction.json
@@ -9,12 +9,12 @@
       "type": "Vector"
     },
     "style": {
-      "circle-radius": "10",
+      "circle-radius": 10,
       "circle-fill-color": "red",
       "circle-stroke-color": "black",
-      "circle-stroke-width": "2",
+      "circle-stroke-width": 2,
       "stroke-color": "black",
-      "stroke-width": "5",
+      "stroke-width": 5,
       "fill-color": "red"
     }
   }

--- a/elements/map/test/general.cy.ts
+++ b/elements/map/test/general.cy.ts
@@ -4,7 +4,7 @@ import "../main";
 describe("Map", () => {
   it("map should exist", () => {
     cy.mount(
-      `<eox-map layers='[{"type":"Tile","source":{"type":"OSM"}}]'></eox-map>`
+      `<eox-map layers='[{"type":"Tile","properties": {"id": "osm"}, "source":{"type":"OSM"}}]'></eox-map>`
     ).as("eox-map");
     cy.get("eox-map").and(($el) => {
       expect((<EOxMap>$el[0]).map).to.exist;

--- a/elements/map/test/groupLayer.cy.ts
+++ b/elements/map/test/groupLayer.cy.ts
@@ -64,11 +64,13 @@ describe("layers", () => {
         "find layer inside group inside group"
       ).to.exist;
 
-      const parentParentGroup = layerInsideGroupInsideGroup.get('_group').get('_group')
+      const parentParentGroup = layerInsideGroupInsideGroup
+        .get("_group")
+        .get("_group");
       expect(
-        parentParentGroup.get('id'),
+        parentParentGroup.get("id"),
         "correctly sets reference to parent layers"
-      ).to.be.equal('group');
+      ).to.be.equal("group");
     });
   });
 });

--- a/elements/map/test/groupLayer.cy.ts
+++ b/elements/map/test/groupLayer.cy.ts
@@ -63,6 +63,12 @@ describe("layers", () => {
         layerInsideGroupInsideGroup,
         "find layer inside group inside group"
       ).to.exist;
+
+      const parentParentGroup = layerInsideGroupInsideGroup.get('_group').get('_group')
+      expect(
+        parentParentGroup.get('id'),
+        "correctly sets reference to parent layers"
+      ).to.be.equal('group');
     });
   });
 });

--- a/elements/map/test/groupLayer.cy.ts
+++ b/elements/map/test/groupLayer.cy.ts
@@ -9,6 +9,15 @@ describe("layers", () => {
           "id": "group",
           "layers": [
             {
+              "type": "Vector",
+              "id": "regions",
+              "source": {
+                "type": "Vector",
+                "url": "https://openlayers.org/data/vector/ecoregions.json",
+                "format": "GeoJSON"
+              }
+            },
+            {
               "type": "Group",
               "id": "groupLayerInsideGroup",
               "layers": [
@@ -20,15 +29,6 @@ describe("layers", () => {
                   }
                 }
               ]
-            },
-            {
-              "type": "Vector",
-              "id": "regions",
-              "source": {
-                "type": "Vector",
-                "url": "https://openlayers.org/data/vector/ecoregions.json",
-                "format": "GeoJSON"
-              }
             }
           ]
         }

--- a/elements/map/test/groupLayer.cy.ts
+++ b/elements/map/test/groupLayer.cy.ts
@@ -6,11 +6,15 @@ describe("layers", () => {
       `<eox-map layers='[
         {
           "type": "Group",
-          "id": "group",
+          "properties": {
+            "id": "group"
+          },
           "layers": [
             {
               "type": "Vector",
-              "id": "regions",
+              "properties": {
+                "id": "regions"
+              },
               "source": {
                 "type": "Vector",
                 "url": "https://openlayers.org/data/vector/ecoregions.json",
@@ -19,11 +23,15 @@ describe("layers", () => {
             },
             {
               "type": "Group",
-              "id": "groupLayerInsideGroup",
+              "properties": {
+                "id": "groupLayerInsideGroup"
+              },
               "layers": [
                 {
                   "type": "Tile",
-                  "id": "layerInsideGroupInsideGroup",
+                  "properties": {
+                    "id": "layerInsideGroupInsideGroup"
+                  },
                   "source": {
                     "type": "OSM"
                   }

--- a/elements/map/test/hoverInteraction.cy.ts
+++ b/elements/map/test/hoverInteraction.cy.ts
@@ -27,9 +27,6 @@ describe("select interaction with hover", () => {
       eoxMap
         .addSelect("regions", {
           id: "selectInteraction",
-          overlay: {
-            element: "eox-map-tooltip",
-          },
           condition: "pointermove",
           layer: {
             type: "Vector",

--- a/elements/map/test/imageWmsLayer.cy.ts
+++ b/elements/map/test/imageWmsLayer.cy.ts
@@ -9,7 +9,7 @@ describe("layers", () => {
     ).as("eox-map");
     cy.get("eox-map").and(($el) => {
       const eoxMap = <EOxMap>$el[0];
-      eoxMap.setLayers(imageWmsLayerStyleJson);
+      //eoxMap.setLayers(imageWmsLayerStyleJson);
       eoxMap.map.getView().setZoom(0);
       const layers = eoxMap.map.getLayers().getArray();
       expect(layers).to.have.length(1);

--- a/elements/map/test/selectInteraction.cy.ts
+++ b/elements/map/test/selectInteraction.cy.ts
@@ -58,6 +58,7 @@ describe("select interaction on click", () => {
           id: "selectInteraction",
           tooltip: "eox-map-tooltip",
           condition: "click",
+          //@ts-ignore
           style: {
             "stroke-color": "white",
             "stroke-width": 3,

--- a/elements/map/test/selectInteraction.cy.ts
+++ b/elements/map/test/selectInteraction.cy.ts
@@ -17,7 +17,6 @@ describe("select interaction on click", () => {
       eoxMap
         .addSelect("countries", {
           id: "selectInteraction",
-          tooltip: "eox-map-tooltip",
           condition: "click",
           idProperty: "formal_en",
           layer: {
@@ -56,7 +55,6 @@ describe("select interaction on click", () => {
       eoxMap
         .addSelect("regions", {
           id: "selectInteraction",
-          tooltip: "eox-map-tooltip",
           condition: "click",
           //@ts-ignore
           style: {

--- a/elements/map/test/vectorLayer.cy.ts
+++ b/elements/map/test/vectorLayer.cy.ts
@@ -19,14 +19,13 @@ describe("layers", () => {
     ).as("eox-map");
     cy.get("eox-map").and(($el) => {
       return new Cypress.Promise((resolve) => {
-        const layers = (<EOxMap>$el[0]).map.getLayers().getArray();
+        const eoxMap = <EOxMap>$el[0];
+        const layer = eoxMap.getLayerById("regions") as import('ol/layer').Vector<import('ol/source').Vector>;
+
         // wait for features to load
-        //@ts-ignore
-        layers[0].getSource().on("featuresloadend", () => {
-          //@ts-ignore
-          const feature = layers[0].getSource().getFeatures()[0];
-          //@ts-ignore
-          const styles = layers[0].getStyleFunction()(feature);
+        layer.getSource().on("featuresloadend", () => {
+          const feature = layer.getSource().getFeatures()[0];
+          const styles = layer.getStyleFunction()(feature, 100);
           // 2 styles expected, one for the stroke, one for the fill.
           expect(styles).to.have.length(2);
           resolve();
@@ -46,14 +45,12 @@ describe("layers", () => {
     ).as("eox-map");
     cy.get("eox-map").and(($el) => {
       return new Cypress.Promise((resolve) => {
-        const layers = (<EOxMap>$el[0]).map.getLayers().getArray();
         // wait for features to load
-        //@ts-ignore
-        layers[0].getSource().on("featuresloadend", () => {
-          //@ts-ignore
-          const feature = layers[0].getSource().getFeatures()[0];
-          //@ts-ignore
-          const styles = layers[0].getStyleFunction()(feature);
+        const eoxMap = <EOxMap>$el[0];
+        const layer = eoxMap.getLayerById("regions") as import('ol/layer').Vector<import('ol/source').Vector>;
+        layer.getSource().on("featuresloadend", () => {
+          const feature = layer.getSource().getFeatures()[0];
+          const styles = layer.getStyleFunction()(feature, 100);
           expect(styles).to.have.length(1);
           resolve();
         });

--- a/elements/map/test/vectorLayer.cy.ts
+++ b/elements/map/test/vectorLayer.cy.ts
@@ -20,7 +20,9 @@ describe("layers", () => {
     cy.get("eox-map").and(($el) => {
       return new Cypress.Promise((resolve) => {
         const eoxMap = <EOxMap>$el[0];
-        const layer = eoxMap.getLayerById("regions") as import('ol/layer').Vector<import('ol/source').Vector>;
+        const layer = eoxMap.getLayerById(
+          "regions"
+        ) as import("ol/layer").Vector<import("ol/source").Vector>;
 
         // wait for features to load
         layer.getSource().on("featuresloadend", () => {
@@ -47,7 +49,9 @@ describe("layers", () => {
       return new Cypress.Promise((resolve) => {
         // wait for features to load
         const eoxMap = <EOxMap>$el[0];
-        const layer = eoxMap.getLayerById("regions") as import('ol/layer').Vector<import('ol/source').Vector>;
+        const layer = eoxMap.getLayerById(
+          "regions"
+        ) as import("ol/layer").Vector<import("ol/source").Vector>;
         layer.getSource().on("featuresloadend", () => {
           const feature = layer.getSource().getFeatures()[0];
           const styles = layer.getStyleFunction()(feature, 100);

--- a/elements/map/test/vectorLayer.cy.ts
+++ b/elements/map/test/vectorLayer.cy.ts
@@ -64,7 +64,7 @@ describe("layers", () => {
   it("correctly applies style expression", () => {
     vectorLayerStyleJson[0].style = {
       // @ts-ignore
-      "fill-color": ['string', ['get', 'COLOR'], '#eee'],
+      "fill-color": ["string", ["get", "COLOR"], "#eee"],
       "stroke-color": "black",
       "stroke-width": 2,
     };

--- a/elements/map/test/vectorLayer.cy.ts
+++ b/elements/map/test/vectorLayer.cy.ts
@@ -40,7 +40,33 @@ describe("layers", () => {
       // @ts-ignore
       "fill-color": "yellow",
       "stroke-color": "black",
-      "stroke-width": 4,
+      "stroke-width": 2,
+    };
+    cy.mount(
+      `<eox-map layers='${JSON.stringify(vectorLayerStyleJson)}'></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      return new Cypress.Promise((resolve) => {
+        const layers = (<EOxMap>$el[0]).map.getLayers().getArray();
+        // wait for features to load
+        //@ts-ignore
+        layers[0].getSource().on("featuresloadend", () => {
+          //@ts-ignore
+          const feature = layers[0].getSource().getFeatures()[0];
+          //@ts-ignore
+          const styles = layers[0].getStyleFunction()(feature);
+          expect(styles).to.have.length(1);
+          resolve();
+        });
+      });
+    });
+  });
+  it("correctly applies style expression", () => {
+    vectorLayerStyleJson[0].style = {
+      // @ts-ignore
+      "fill-color": ['string', ['get', 'COLOR'], '#eee'],
+      "stroke-color": "black",
+      "stroke-width": 2,
     };
     cy.mount(
       `<eox-map layers='${JSON.stringify(vectorLayerStyleJson)}'></eox-map>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,8 +144,8 @@
       "version": "0.5.4",
       "dependencies": {
         "lit": "^2.7.4",
-        "ol": "^7.4.0",
-        "ol-mapbox-style": "^10.6.0",
+        "ol": "^8.0.0-dev.1693483855644",
+        "ol-mapbox-style": "^11.0.3",
         "ol-stac": "^1.0.0-beta.4"
       },
       "devDependencies": {
@@ -162,14 +162,19 @@
         "npm": ">=8.0.0"
       }
     },
-    "elements/map/node_modules/ol-mapbox-style": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-10.6.0.tgz",
-      "integrity": "sha512-s86QhCoyyKVRsYkvPzzdWd///bhYh3onWrBq4lNXnCd9G/hS6AoK023kn4zlDESVlTBDTWLz8vhOistp0M3TXA==",
+    "elements/map/node_modules/ol": {
+      "version": "8.0.0-dev.1693511284695",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-8.0.0-dev.1693511284695.tgz",
+      "integrity": "sha512-ewGgJ9xOX+/rbg3UfG6swxbW6vEnEY3rIdQN1LXAO+dmJ6xrI3KYp6IfjSNjAlMEckgG/Uu24e4s4ay2NZpgew==",
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1",
-        "ol": "^7.3.0"
+        "earcut": "^2.2.3",
+        "geotiff": "^2.0.7",
+        "pbf": "3.2.1",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
       }
     },
     "elements/stacinfo": {
@@ -4013,6 +4018,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol-mapbox-style": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-11.0.3.tgz",
+      "integrity": "sha512-jc3PX1kHtvq8e5jPYVh9WFAppAbLrndik9qBicIemlQKPz0oFeQ98D3ITub3wfwVXXVReqeOKa43NGOseUne1Q==",
+      "dependencies": {
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+        "mapbox-to-css-font": "^2.4.1"
+      },
+      "peerDependencies": {
+        "ol": ">=8.0.0 || >8.0.0-dev.0 < 8.0.0 || >=7.0.0 <=7.5.1"
       }
     },
     "node_modules/ol-stac": {


### PR DESCRIPTION
This PR upgrades to ol 8 (which brings native style expressions) and improves the use of TypeScript in the Map Element.

The removal of the unneeded generic `Function`-Typing in `main.ts` allows us to receive the correct types in the parent application.

`layer` and `source` types are now done manually, defining all relevant types of layers and sources as strings. Before TS expected actual ol objects, which was not the intention.

The options-objects from `ol` can be utilised by importing the type (e.g. `import('ol/interaction/Draw').Options`), and adapting them for our needs, either by adding properties via the `&` operator and overloading the object with new properties, or omitting some properties via `Omit`, or doing both to change the type of a property.