### PR TITLE
Make menu subentries scrollable if they cross a length threshold

### DIFF
--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -171,7 +171,6 @@ export class EOxLayerControl extends LitElement {
       for (let entry of entries) {
         if (entry.target === this) { // Ensure we're observing the correct element
           this.containerHeight = entry.contentRect.height;
-          console.log(this.containerHeight);
         }
       }
     });

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -69,6 +69,12 @@ export class EOxLayerControl extends LitElement {
   @property({ type: Boolean })
   unstyled: boolean;
 
+  @property({ type: ResizeObserver })
+  resizeObserver: ResizeObserver;
+
+  @property({ type: Number })
+  containerHeight: number;
+
   private _updateControl(layerCollection: Collection<BaseLayer>) {
     // initially check if all layers have an id and title,
     // fill in some backup in case they haven't
@@ -157,6 +163,28 @@ export class EOxLayerControl extends LitElement {
       });
     }
     this.requestUpdate();
+  }
+
+  // Set up Resize Observer
+  firstUpdated() {
+    this.resizeObserver = new ResizeObserver(entries => {
+      for (let entry of entries) {
+        if (entry.target === this) { // Ensure we're observing the correct element
+          this.containerHeight = entry.contentRect.height;
+          console.log(this.containerHeight);
+        }
+      }
+    });
+    this.resizeObserver.observe(this);
+  }
+
+  // Deinitialize Resize Observer
+  disconnectedCallback() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+    super.disconnectedCallback();
   }
 
   render() {
@@ -252,7 +280,10 @@ export class EOxLayerControl extends LitElement {
       layers: Array<BaseLayer>,
       group?: string
     ): TemplateResult => html`
-      <ul data-group="${group ?? nothing}" style="max-height: ${(document.querySelector('eox-layercontrol') as HTMLElement).offsetHeight * 0.3}">
+      <ul
+        data-group="${group ?? nothing}"
+        style="${group == 'group2' ? `max-height: ${this.containerHeight * 0.3}px` : '' }"
+      >
         ${repeat(
           layers,
           (layer) => layer.get(this.layerIdentifier),

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -45,6 +45,12 @@ export class EOxLayerControl extends LitElement {
   @state()
   optionalLayerArray: Array<BaseLayer>;
 
+  @state()
+  resizeObserver: ResizeObserver;
+
+  @state()
+  containerHeight: number;
+
   /**
    * The query selector for the map
    */
@@ -68,12 +74,6 @@ export class EOxLayerControl extends LitElement {
 
   @property({ type: Boolean })
   unstyled: boolean;
-
-  @property({ type: ResizeObserver })
-  resizeObserver: ResizeObserver;
-
-  @property({ type: Number })
-  containerHeight: number;
 
   private _updateControl(layerCollection: Collection<BaseLayer>) {
     // initially check if all layers have an id and title,

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -281,7 +281,7 @@ export class EOxLayerControl extends LitElement {
     ): TemplateResult => html`
       <ul
         data-group="${group ?? nothing}"
-        style="${group == 'group2' && !this.unstyled
+        style="${!!group && !this.unstyled
           ? `max-height: ${this.containerHeight * 0.3}px`
           : ''
         }"

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -282,7 +282,10 @@ export class EOxLayerControl extends LitElement {
     ): TemplateResult => html`
       <ul
         data-group="${group ?? nothing}"
-        style="${group == 'group2' ? `max-height: ${this.containerHeight * 0.3}px` : '' }"
+        style="${group == 'group2' && !this.unstyled
+          ? `max-height: ${this.containerHeight * 0.3}px`
+          : ''
+        }"
       >
         ${repeat(
           layers,

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -48,9 +48,6 @@ export class EOxLayerControl extends LitElement {
   @state()
   resizeObserver: ResizeObserver;
 
-  @state()
-  containerHeight: number;
-
   /**
    * The query selector for the map
    */
@@ -167,10 +164,15 @@ export class EOxLayerControl extends LitElement {
 
   // Set up Resize Observer
   firstUpdated() {
-    this.resizeObserver = new ResizeObserver(entries => {
+    this.resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
-        if (entry.target === this) { // Ensure we're observing the correct element
-          this.containerHeight = entry.contentRect.height;
+        // Ensure we're observing the correct element
+        if (entry.target === this) {
+          this.style.setProperty(
+            "--container-height",
+            `${entry.contentRect.height}px`
+          );
+          this.requestUpdate();
         }
       }
     });
@@ -279,13 +281,7 @@ export class EOxLayerControl extends LitElement {
       layers: Array<BaseLayer>,
       group?: string
     ): TemplateResult => html`
-      <ul
-        data-group="${group ?? nothing}"
-        style="${!!group && !this.unstyled
-          ? `max-height: ${this.containerHeight * 0.3}px`
-          : ''
-        }"
-      >
+      <ul data-group="${group ?? nothing}">
         ${repeat(
           layers,
           (layer) => layer.get(this.layerIdentifier),

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -252,7 +252,7 @@ export class EOxLayerControl extends LitElement {
       layers: Array<BaseLayer>,
       group?: string
     ): TemplateResult => html`
-      <ul data-group="${group ?? nothing}">
+      <ul data-group="${group ?? nothing}" style="max-height: ${(document.querySelector('eox-layercontrol') as HTMLElement).offsetHeight * 0.3}">
         ${repeat(
           layers,
           (layer) => layer.get(this.layerIdentifier),

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -22,7 +22,7 @@ summary > .layer {
 }
 
 ul[data-group] {
-  max-height: 220px;
+  max-height: 30vh;
   overflow-y: scroll;
 }
 

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -22,8 +22,7 @@ summary > .layer {
 }
 
 ul[data-group] {
-  max-height: 30%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 [data-type=group] .title {

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -23,6 +23,7 @@ summary > .layer {
 
 ul[data-group] {
   overflow-y: auto;
+  max-height: calc(var(--container-height) * 0.3);
 }
 
 [data-type=group] .title {

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -22,7 +22,7 @@ summary > .layer {
 }
 
 ul[data-group] {
-  max-height: 30vh;
+  max-height: 30%;
   overflow-y: scroll;
 }
 

--- a/elements/layercontrol/src/style.eox.ts
+++ b/elements/layercontrol/src/style.eox.ts
@@ -21,6 +21,11 @@ summary > .layer {
   padding-top: 0px;
 }
 
+ul[data-group] {
+  max-height: 220px;
+  overflow-y: scroll;
+}
+
 [data-type=group] .title {
   display: flex;
   align-items: flex-start;

--- a/elements/layercontrol/src/style.ts
+++ b/elements/layercontrol/src/style.ts
@@ -1,6 +1,8 @@
 export const style = `
 :host {
   display: block;
+  overflow-y: auto;
+  height: 100%;
 }
 .layer {
   display: inline-flex;


### PR DESCRIPTION
To help contain the children of menu entries, especially those with many sub-items coming from, for example, a STAC catalogue, this style PR limits the height of sublists and makes sure they are appropriately sized for different viewport sizes.

https://github.com/EOX-A/EOxElements/assets/94269527/e6ecfbcb-fd86-4b79-b1fa-278a911628b1

Closes #218 