### PR TITLE
Tooltip enhancements

### DIFF
--- a/elements/map/index.html
+++ b/elements/map/index.html
@@ -16,6 +16,14 @@
     </eox-map>
     <script type="module">
       import "./main.ts";
+      document.querySelector("eox-map-tooltip").renderProperty = ([
+        key,
+        value,
+      ]) => {
+        return key === "geometry"
+          ? [`${key} extent`, value.getExtent()]
+          : [key, value];
+      };
       document.querySelector("eox-map").setLayers([
         {
           type: "Vector",

--- a/elements/map/index.html
+++ b/elements/map/index.html
@@ -31,7 +31,6 @@
         id: "selectInteraction",
         overlay: {
           element: "eox-map-tooltip",
-          offset: [0, 30],
         },
         condition: "pointermove",
         layer: {

--- a/elements/map/index.html
+++ b/elements/map/index.html
@@ -29,7 +29,10 @@
       ]);
       document.querySelector("eox-map").addSelect("regions", {
         id: "selectInteraction",
-        tooltip: "eox-map-tooltip",
+        overlay: {
+          element: "eox-map-tooltip",
+          offset: [0, 30],
+        },
         condition: "pointermove",
         layer: {
           type: "Vector",

--- a/elements/map/index.html
+++ b/elements/map/index.html
@@ -16,7 +16,7 @@
     </eox-map>
     <script type="module">
       import "./main.ts";
-      document.querySelector("eox-map-tooltip").renderProperty = ([
+      document.querySelector("eox-map-tooltip").propertyTransform = ([
         key,
         value,
       ]) => {

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -29,8 +29,8 @@ export async function addSelect(
   if (tooltip) {
     overlay = new Overlay({
       position: undefined,
-      offset: [0, -30],
-      positioning: "top-center",
+      offset: [0, 0],
+      positioning: "top-left",
       className: "eox-map-tooltip",
       ...options.overlay,
       element: EOxMap.querySelector(options.overlay.element),

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -19,7 +19,7 @@ export async function addSelect(
     throw Error(`Interaction with id: ${options.id} already exists.`);
   }
 
-  const tooltip: EOxMapTooltip = EOxMap.querySelector(options.tooltip);
+  const tooltip: HTMLElement = EOxMap.querySelector(options.overlay?.element);
 
   let overlay: Overlay;
   let selectedFid: string | number = null;
@@ -28,11 +28,12 @@ export async function addSelect(
 
   if (tooltip) {
     overlay = new Overlay({
-      element: tooltip,
       position: undefined,
       offset: [0, -30],
       positioning: "top-center",
       className: "eox-map-tooltip",
+      ...options.overlay,
+      element: EOxMap.querySelector(options.overlay.element),
     });
     map.addOverlay(overlay);
   }
@@ -105,8 +106,8 @@ export async function addSelect(
 
         if (overlay) {
           overlay.setPosition(feature ? event.coordinate : null);
-          if (feature) {
-            tooltip.renderContent(feature.getProperties());
+          if (feature && (<EOxMapTooltip>tooltip).renderContent) {
+            (<EOxMapTooltip>tooltip).renderContent(feature.getProperties());
           }
         }
 

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -105,6 +105,11 @@ export async function addSelect(
         selectStyleLayer.changed();
 
         if (overlay) {
+          const xPosition =
+            event.pixel[0] > EOxMap.offsetWidth / 2 ? "right" : "left";
+          const yPosition =
+            event.pixel[1] > EOxMap.offsetHeight / 2 ? "bottom" : "top";
+          overlay.setPositioning(`${yPosition}-${xPosition}`);
           overlay.setPosition(feature ? event.coordinate : null);
           if (feature && (<EOxMapTooltip>tooltip).renderContent) {
             (<EOxMapTooltip>tooltip).renderContent(feature.getProperties());

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -4,10 +4,11 @@ import { TemplateElement } from "../../../utils/templateElement";
 
 export class EOxMapTooltip extends TemplateElement {
   /**
-   * Override the default rendering of feature property key/value
+   * Transform the default rendering of each feature property key/value.
+   * Useful for e.g. translating keys or introducing a whitelist.
    */
   @property()
-  renderProperty: Function = (property: [key: string, value: any]) => property;
+  propertyTransform: Function = (property: [key: string, value: any]) => property;
 
   renderContent(content: Object) {
     render(
@@ -34,7 +35,7 @@ export class EOxMapTooltip extends TemplateElement {
             </style>
             <ul>
               ${Object.entries(content)
-                .map(([key, value]) => this.renderProperty([key, value]))
+                .map(([key, value]) => this.propertyTransform([key, value]))
                 .filter((v) => v)
                 .map(
                   ([key, value]) => html`<li><span>${key}</span>: ${value}</li>`

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -11,11 +11,25 @@ export class EOxMapTooltip extends TemplateElement {
             // `tooltip-${this.content.id}`
             "tooltip-1"
           )}`
-        : html`<ul>
-            ${Object.entries(content).map(
-              ([key, value]) => html`<li>${key}: ${value}</li>`
-            )}
-          </ul>`,
+        : html` <style>
+              ul {
+                margin: 0;
+                padding: 15px 5px 15px 30px;
+                background: #0008;
+                border-radius: 15px;
+                color: white;
+                max-width: 50%;
+                font-size: small;
+              }
+              span {
+                font-weight: bold;
+              }
+            </style>
+            <ul>
+              ${Object.entries(content).map(
+                ([key, value]) => html`<li><span>${key}</span>: ${value}</li>`
+              )}
+            </ul>`,
       this.shadowRoot
     );
   }

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -1,7 +1,14 @@
 import { html, render } from "lit";
+import { property } from "lit/decorators.js";
 import { TemplateElement } from "../../../utils/templateElement";
 
 export class EOxMapTooltip extends TemplateElement {
+  /**
+   * Override the default rendering of feature property key/value
+   */
+  @property()
+  renderProperty: Function = (property: [key: string, value: any]) => property;
+
   renderContent(content: Object) {
     render(
       this.hasTemplate("properties")
@@ -26,9 +33,12 @@ export class EOxMapTooltip extends TemplateElement {
               }
             </style>
             <ul>
-              ${Object.entries(content).map(
-                ([key, value]) => html`<li><span>${key}</span>: ${value}</li>`
-              )}
+              ${Object.entries(content)
+                .map(([key, value]) => this.renderProperty([key, value]))
+                .filter((v) => v)
+                .map(
+                  ([key, value]) => html`<li><span>${key}</span>: ${value}</li>`
+                )}
             </ul>`,
       this.shadowRoot
     );

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -14,11 +14,11 @@ export class EOxMapTooltip extends TemplateElement {
         : html` <style>
               ul {
                 margin: 0;
-                padding: 15px 5px 15px 30px;
+                padding: 15px 15px 15px 30px;
                 background: #0008;
                 border-radius: 15px;
                 color: white;
-                max-width: 50%;
+                max-width: 250px;
                 font-size: small;
               }
               span {

--- a/elements/map/test/hoverInteraction.cy.ts
+++ b/elements/map/test/hoverInteraction.cy.ts
@@ -27,7 +27,9 @@ describe("select interaction with hover", () => {
       eoxMap
         .addSelect("regions", {
           id: "selectInteraction",
-          tooltip: "eox-map-tooltip",
+          overlay: {
+            element: "eox-map-tooltip",
+          },
           condition: "pointermove",
           layer: {
             type: "Vector",


### PR DESCRIPTION
This PR introduces some enhancements for the eox-map-tooltip:
- it allows passing native OL parameters to the Overlay
- it adds some default styling of the tooltip component
- it adds positioning of the tooltip (top-left/right, bottom-left/right) depending on the mouse position within the map
- it adds the functionality to override the rendering of the feature properties.