### PR TITLE
Map/feature/draw box

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -12,7 +12,7 @@ import Control from "ol/control/Control";
 import { getLayerById, getFlatLayersArray } from "./src/layer";
 import { getCenterFromAttribute } from "./src/center";
 import { addInitialControls } from "./src/controls";
-import {buffer} from 'ol/extent';
+import { buffer } from "ol/extent";
 import "./src/compare";
 
 @customElement("eox-map")
@@ -150,11 +150,11 @@ export class EOxMap extends LitElement {
   /**
    * Return extent increased by the provided value.
    * @param {import("ol/extent").Extent} extent
-   * @param {number} value 
+   * @param {number} value
    * @returns {import("ol/extent").Extent}
    */
   buffer(extent: import("ol/extent").Extent, value: number) {
-    return buffer(extent, value)
+    return buffer(extent, value);
   }
 
   firstUpdated() {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -12,6 +12,7 @@ import Control from "ol/control/Control";
 import { getLayerById, getFlatLayersArray } from "./src/layer";
 import { getCenterFromAttribute } from "./src/center";
 import { addInitialControls } from "./src/controls";
+import {buffer} from 'ol/extent';
 import "./src/compare";
 
 @customElement("eox-map")
@@ -144,6 +145,16 @@ export class EOxMap extends LitElement {
       <div style="width: 100%; height: 100%"></div>
       <slot></slot>
     `;
+  }
+
+  /**
+   * Return extent increased by the provided value.
+   * @param {import("ol/extent").Extent} extent
+   * @param {number} value 
+   * @returns {import("ol/extent").Extent}
+   */
+  buffer(extent: import("ol/extent").Extent, value: number) {
+    return buffer(extent, value)
   }
 
   firstUpdated() {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -7,7 +7,7 @@ import olCss from "ol/ol.css";
 import { DrawOptions, addDraw } from "./src/draw";
 import { SelectOptions, addSelect } from "./src/select";
 import { generateLayers, EoxLayer } from "./src/generate";
-import Interaction from "ol/interaction/Interaction";
+import { Draw, Modify } from "ol/interaction";
 import Control from "ol/control/Control";
 import { getLayerById, getFlatLayersArray } from "./src/layer";
 import { getCenterFromAttribute } from "./src/center";
@@ -64,7 +64,7 @@ export class EOxMap extends LitElement {
    * dictionary of ol interactions associated with the map.
    */
   @state()
-  interactions: { [index: string]: Interaction } = {};
+  interactions: { [index: string]: Draw | Modify } = {};
 
   /**
    * dictionary of ol controls associated with the map.

--- a/elements/map/src/draw.ts
+++ b/elements/map/src/draw.ts
@@ -1,4 +1,5 @@
-import { Draw, Modify } from "ol/interaction";
+import Modify from "ol/interaction/Modify";
+import Draw, { createBox } from "ol/interaction/Draw";
 import { EOxMap } from "../main";
 import { getArea, getLength } from "ol/sphere";
 import { LineString, Polygon } from "ol/geom";
@@ -6,18 +7,26 @@ import GeoJSON from "ol/format/GeoJSON";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
 
-export type DrawOptions = import("ol/interaction/Draw").Options & {
+
+export type Drawoptions = Omit<
+  import("ol/interaction/Draw").Options,
+  "type"
+> & {
   id: string | number;
+  type: "Point" | "LineString" | "Polygon" | "Circle" | "Box"
+  modify?: boolean
 };
 
 export function addDraw(
   EOxMap: EOxMap,
   layerId: string,
-  options: DrawOptions
+  options: Drawoptions
 ): void {
-  if (EOxMap.interactions[options.id]) {
-    throw Error(`Interaction with id: ${options.id} already exists.`);
+  const options_ = Object.assign({}, options);
+  if (EOxMap.interactions[options_.id]) {
+    throw Error(`Interaction with id: ${options_.id} already exists.`);
   }
+  options_.modify = typeof options_.modify === 'boolean' ? options_.modify : true;
 
   const map = EOxMap.map;
 
@@ -25,14 +34,15 @@ export function addDraw(
 
   const source = drawLayer.getSource();
 
-  const drawInteraction = new Draw({
-    ...options,
-    source,
-  });
+  if (options_.type === "Box") {
+    options_.geometryFunction = createBox();
+    options_.type = 'Circle';
+  }
 
-  const modifyInteraction = new Modify({
+  const drawInteraction = new Draw({
+    ...options_,
     source,
-  });
+  } as import("ol/interaction/Draw").Options);
 
   const format = new GeoJSON();
   drawInteraction.on("drawend", (e) => {
@@ -58,8 +68,16 @@ export function addDraw(
   });
 
   // identifier to retrieve the interaction
+  //@ts-ignore
   map.addInteraction(drawInteraction);
-  map.addInteraction(modifyInteraction);
-  EOxMap.interactions[options.id] = drawInteraction;
-  EOxMap.interactions[`${options.id}_modify`] = modifyInteraction;
+  EOxMap.interactions[options_.id] = drawInteraction;
+  
+  if (options_.modify) {
+    const modifyInteraction = new Modify({
+      source,
+    });
+    //@ts-ignore
+    map.addInteraction(modifyInteraction);
+    EOxMap.interactions[`${options_.id}_modify`] = modifyInteraction;
+  }
 }

--- a/elements/map/src/draw.ts
+++ b/elements/map/src/draw.ts
@@ -7,26 +7,26 @@ import GeoJSON from "ol/format/GeoJSON";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
 
-
-export type Drawoptions = Omit<
+export type DrawOptions = Omit<
   import("ol/interaction/Draw").Options,
   "type"
 > & {
   id: string | number;
-  type: "Point" | "LineString" | "Polygon" | "Circle" | "Box"
-  modify?: boolean
+  type: "Point" | "LineString" | "Polygon" | "Circle" | "Box";
+  modify?: boolean;
 };
 
 export function addDraw(
   EOxMap: EOxMap,
   layerId: string,
-  options: Drawoptions
+  options: DrawOptions
 ): void {
   const options_ = Object.assign({}, options);
   if (EOxMap.interactions[options_.id]) {
     throw Error(`Interaction with id: ${options_.id} already exists.`);
   }
-  options_.modify = typeof options_.modify === 'boolean' ? options_.modify : true;
+  options_.modify =
+    typeof options_.modify === "boolean" ? options_.modify : true;
 
   const map = EOxMap.map;
 
@@ -36,7 +36,7 @@ export function addDraw(
 
   if (options_.type === "Box") {
     options_.geometryFunction = createBox();
-    options_.type = 'Circle';
+    options_.type = "Circle";
   }
 
   const drawInteraction = new Draw({
@@ -71,7 +71,7 @@ export function addDraw(
   //@ts-ignore
   map.addInteraction(drawInteraction);
   EOxMap.interactions[options_.id] = drawInteraction;
-  
+
   if (options_.modify) {
     const modifyInteraction = new Modify({
       source,

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -74,10 +74,9 @@ describe("draw interaction", () => {
       simulateEvent(eoxMap.map, "pointerdown", 30, 20);
       simulateEvent(eoxMap.map, "pointerup", 30, 20);
 
-      const drawLayer = eoxMap.getLayerById(
-        "drawLayer"
-      ) as VectorLayer<VectorSource>;
-      const features = drawLayer.getSource().getFeatures();
+      const drawLayer = eoxMap.getLayerById("drawLayer") as import("ol/layer").Vector<import("ol/source").Vector>;
+      const source = drawLayer.getSource();
+      const features = source.getFeatures();
       expect(features).to.have.length(1);
     });
   });

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -35,6 +35,8 @@ describe("draw interaction", () => {
       const geometry = features[0].getGeometry() as Point;
       expect(features).to.have.length(1);
       expect(geometry.getCoordinates().length).to.be.equal(2);
+      const buffer = eoxMap.buffer(geometry.getExtent(), 100);
+      expect(Array.isArray(buffer), 'create buffer from point extent').to.be.true;
     });
   });
 

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -36,7 +36,8 @@ describe("draw interaction", () => {
       expect(features).to.have.length(1);
       expect(geometry.getCoordinates().length).to.be.equal(2);
       const buffer = eoxMap.buffer(geometry.getExtent(), 100);
-      expect(Array.isArray(buffer), 'create buffer from point extent').to.be.true;
+      expect(Array.isArray(buffer), "create buffer from point extent").to.be
+        .true;
     });
   });
 


### PR DESCRIPTION
This implements the feature to draw a "Box" (#172) by setting the `type` of the draw interaction to `Box`.

Additionally, this adds a solution to #149 exposing the extent function `buffer`. I am not certain what format the API in question expects, but using this as a starting-point we can send the buffer or single coordinates from the rectangle. Alternatively we can also expose a functionality to create a `GeoJSON` from the buffered extent.