### PR TITLE
Map/feature/handle layers

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -6,7 +6,7 @@ import View from "ol/View.js";
 import olCss from "ol/ol.css";
 import { DrawOptions, addDraw } from "./src/draw";
 import { SelectOptions, addSelect } from "./src/select";
-import { generateLayers, EoxLayer } from "./src/generate";
+import { generateLayers, EoxLayer, createLayer } from "./src/generate";
 import { Draw, Modify } from "ol/interaction";
 import Control from "ol/control/Control";
 import { getLayerById, getFlatLayersArray } from "./src/layer";
@@ -75,11 +75,32 @@ export class EOxMap extends LitElement {
 
   /**
    * Apply layers from Mapbox Style JSON
-   * @param json a Mapbox Style JSON
+   * @param json array of EoxLayer JSONs
    * @returns the array of layers
    */
   setLayers = (json: Array<EoxLayer>) => {
-    this.map.setLayers(generateLayers(json));
+    const layers = generateLayers(json);
+    this.map.setLayers(layers);
+    return layers;
+  };
+
+  /**
+   * creates or updates an existing layer
+   * will update an layer if the ID already exists
+   * @param json EoxLayer JSON definition
+   * @returns the created or updated ol layer
+   */
+  addOrUpdateLayer = (json: EoxLayer) => {
+    const id = json.properties?.id;
+    const existingLayer = getLayerById(this, id);
+    let layer;
+    if (existingLayer) {
+      // to do: update layer
+    } else {
+      layer = createLayer(json);
+      this.map.addLayer(layer);
+    }
+    return layer;
   };
 
   /**

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -6,7 +6,12 @@ import View from "ol/View.js";
 import olCss from "ol/ol.css";
 import { DrawOptions, addDraw } from "./src/draw";
 import { SelectOptions, addSelect } from "./src/select";
-import { generateLayers, EoxLayer, createLayer } from "./src/generate";
+import {
+  generateLayers,
+  EoxLayer,
+  createLayer,
+  updateLayer,
+} from "./src/generate";
 import { Draw, Modify } from "ol/interaction";
 import Control from "ol/control/Control";
 import { getLayerById, getFlatLayersArray } from "./src/layer";
@@ -90,14 +95,16 @@ export class EOxMap extends LitElement {
    * @param json EoxLayer JSON definition
    * @returns the created or updated ol layer
    */
-  addOrUpdateLayer = (json: EoxLayer) => {
+  addOrUpdateLayer = async (json: EoxLayer) => {
     const id = json.properties?.id;
     const existingLayer = getLayerById(this, id);
     let layer;
     if (existingLayer) {
-      // to do: update layer
+      await updateLayer(json, existingLayer);
+      layer = existingLayer;
     } else {
       layer = createLayer(json);
+      await layer.get("sourcePromise");
       this.map.addLayer(layer);
     }
     return layer;

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -100,7 +100,6 @@ export function createLayer(layer: EoxLayer): olLayers.Layer {
   }
 
   if (layer.style) {
-    console.log(layer.style);
     if ("version" in layer.style) {
       const mapboxStyle: mapboxgl.Style = layer.style;
       // existing layer source will not get overridden by "style" property
@@ -165,7 +164,6 @@ function setSyncListeners(olLayer: olLayers.Layer, eoxLayer: EoxLayer) {
   });
   olLayer.on("change:zIndex", (e) => {
     // TO DO
-    console.log(e);
   });
   olLayer.on("propertychange", (e) => {
     //@ts-ignore

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -166,6 +166,10 @@ function setSyncListeners(olLayer: olLayers.Layer, eoxLayer: EoxLayer) {
     // TO DO
   });
   olLayer.on("propertychange", (e) => {
+    if (e.key === "map") {
+      // do not sync property when setting the "map" of the layer
+      return;
+    }
     //@ts-ignore
     eoxLayer.properties[e.key] = e.target.get(e.key);
   });

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -53,9 +53,9 @@ export type EoxLayer = {
   type: layerType;
   properties: object & {
     id: string;
-    opacity?: number;
-    visible?: boolean;
   };
+  opacity?: number;
+  visible?: boolean;
   source?: { type: sourceType };
   layers?: Array<EoxLayer>;
   style?: mapboxgl.Style | FlatStyleLike;
@@ -200,10 +200,10 @@ export const generateLayers = (layerArray: Array<EoxLayer>) => {
  */
 function setSyncListeners(olLayer: olLayers.Layer, eoxLayer: EoxLayer) {
   olLayer.on("change:opacity", () => {
-    eoxLayer.properties.opacity = olLayer.getOpacity();
+    eoxLayer.opacity = olLayer.getOpacity();
   });
   olLayer.on("change:visible", () => {
-    eoxLayer.properties.visible = olLayer.getVisible();
+    eoxLayer.visible = olLayer.getVisible();
   });
   olLayer.on("change:zIndex", (e) => {
     // TO DO

--- a/elements/map/src/layer.ts
+++ b/elements/map/src/layer.ts
@@ -6,7 +6,7 @@ import Layer from "ol/layer/Layer";
  *
  * @param EOxMap instance of eox map class
  * @param layerId id of ol-layer or mapbox style layer
- * @returns Layer
+ * @returns Layer or `undefined` if layer does not exist
  */
 export function getLayerById(EOxMap: EOxMap, layerId: string) {
   const flatLayers = getFlatLayersArray(
@@ -19,9 +19,6 @@ export function getLayerById(EOxMap: EOxMap, layerId: string) {
     flatLayers
       .filter((l) => l.get("mapbox-layers"))
       .find((l) => l.get("mapbox-layers").includes(layerId));
-  if (!layer) {
-    throw Error(`Layer with id: ${layerId} does not exist.`);
-  }
   return layer;
 }
 

--- a/elements/map/test/addOrUpdateLayer.cy.ts
+++ b/elements/map/test/addOrUpdateLayer.cy.ts
@@ -1,0 +1,50 @@
+import "../main";
+import { EoxLayer } from "../src/generate";
+
+describe("Map", () => {
+  it("add and update layer", () => {
+    cy.mount(
+      `<eox-map layers='[{"type":"Tile","properties": {"id": "osm"}, "source":{"type":"OSM"}}]'></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(async ($el) => {
+      const layerDefinition = {
+        type: "Vector",
+        background: "#1366dd",
+        properties: {
+          id: "regions",
+          visible: true,
+          opacity: 0.3,
+        },
+        source: {
+          type: "Vector",
+          url: "https://openlayers.org/data/vector/ecoregions.json",
+          format: "GeoJSON",
+          attributions: "Regions: @ openlayers.org",
+        },
+      } as EoxLayer;
+      const eoxMap = <EOxMap>$el[0];
+      await eoxMap.addOrUpdateLayer(layerDefinition);
+      const layer = eoxMap.getLayerById("regions");
+      expect(layer).to.exist;
+
+      const updatedLayerDefinition = {
+        type: "Vector",
+        background: "#1366dd",
+        properties: {
+          id: "regions",
+          visible: true,
+          opacity: 1,
+        },
+        source: {
+          type: "Vector",
+          url: "https://openlayers.org/data/vector/ecoregions.json",
+          format: "GeoJSON",
+          attributions: "Regions: @ openlayers.org",
+        },
+      } as EoxLayer;
+
+      await eoxMap.addOrUpdateLayer(updatedLayerDefinition);
+      expect(layer.getOpacity()).to.be.equal(1);
+    });
+  });
+});

--- a/elements/map/test/addOrUpdateLayer.cy.ts
+++ b/elements/map/test/addOrUpdateLayer.cy.ts
@@ -12,9 +12,9 @@ describe("Map", () => {
         background: "#1366dd",
         properties: {
           id: "regions",
-          visible: true,
-          opacity: 0.3,
         },
+        visible: true,
+        opacity: 0.3,
         source: {
           type: "Vector",
           url: "https://openlayers.org/data/vector/ecoregions.json",
@@ -26,15 +26,16 @@ describe("Map", () => {
       await eoxMap.addOrUpdateLayer(layerDefinition);
       const layer = eoxMap.getLayerById("regions");
       expect(layer).to.exist;
+      expect(layer.getOpacity()).to.be.equal(0.3);
 
       const updatedLayerDefinition = {
         type: "Vector",
         background: "#1366dd",
         properties: {
           id: "regions",
-          visible: true,
-          opacity: 1,
         },
+        visible: true,
+        opacity: 1,
         source: {
           type: "Vector",
           url: "https://openlayers.org/data/vector/ecoregions.json",

--- a/elements/map/test/selectInteraction.cy.ts
+++ b/elements/map/test/selectInteraction.cy.ts
@@ -5,39 +5,44 @@ import { simulateEvent } from "./utils/events";
 
 describe("select interaction on click", () => {
   it("adds a select interaction to VectorTile layer", () => {
-    cy.mount(
-      `<eox-map layers='${JSON.stringify(vectorTileLayerStyleJson)}'></eox-map>`
-    ).as("eox-map");
-    cy.get("eox-map").and(($el) => {
-      const eoxMap = <EOxMap>$el[0];
-      eoxMap.addEventListener("select", (evt) => {
-        //@ts-ignore
-        expect(evt.detail.feature).to.exist;
-      });
-      eoxMap
-        .addSelect("countries", {
-          id: "selectInteraction",
-          condition: "click",
-          idProperty: "formal_en",
-          layer: {
-            type: "VectorTile",
-            properties: {
-              id: "selectLayer",
-            },
-            source: {
-              type: "VectorTile",
-            },
-            style: {
-              "stroke-color": "white",
-              "stroke-width": 3,
-            },
-          },
-        })
-        .then(() => {
-          setTimeout(() => {
-            simulateEvent(eoxMap.map, "click", 120, -140);
-          }, 1000);
+    return new Cypress.Promise((resolve) => {
+      cy.mount(
+        `<eox-map layers='${JSON.stringify(
+          vectorTileLayerStyleJson
+        )}'></eox-map>`
+      ).as("eox-map");
+      cy.get("eox-map").and(($el) => {
+        const eoxMap = <EOxMap>$el[0];
+        eoxMap.addEventListener("select", (evt) => {
+          //@ts-ignore
+          expect(evt.detail.feature).to.exist;
+          resolve();
         });
+        eoxMap
+          .addSelect("countries", {
+            id: "selectInteraction",
+            condition: "click",
+            idProperty: "formal_en",
+            layer: {
+              type: "VectorTile",
+              properties: {
+                id: "selectLayer",
+              },
+              source: {
+                type: "VectorTile",
+              },
+              style: {
+                "stroke-color": "white",
+                "stroke-width": 3,
+              },
+            },
+          })
+          .then(() => {
+            setTimeout(() => {
+              simulateEvent(eoxMap.map, "click", 120, -140);
+            }, 1000);
+          });
+      });
     });
   });
   it("adds a select interaction to Vector layer", () => {

--- a/elements/map/test/syncProperties.cy.ts
+++ b/elements/map/test/syncProperties.cy.ts
@@ -1,0 +1,29 @@
+import "../main";
+import vectorLayerStyleJson from "./vectorLayer.json";
+
+describe("layers", () => {
+  it("loads a Vector Layer", () => {
+    vectorLayerStyleJson[0].properties.visible = false;
+    cy.mount(
+      `<eox-map layers='${JSON.stringify(vectorLayerStyleJson)}'></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      const layer = eoxMap.getLayerById("regions");
+      expect(layer.getVisible(), "set default visibility").to.be.equal(false);
+      const jsonDefinition = layer.get("_jsonDefinition");
+      layer.setVisible(true);
+      expect(jsonDefinition.properties.visible, "sync visible").to.be.equal(
+        true
+      );
+      layer.setOpacity(0.5);
+      expect(jsonDefinition.properties.opacity, "sync opacity").to.be.equal(
+        0.5
+      );
+      layer.set("foo", "bar");
+      expect(jsonDefinition.properties.foo, "sync properties").to.be.equal(
+        "bar"
+      );
+    });
+  });
+});

--- a/elements/map/test/syncProperties.cy.ts
+++ b/elements/map/test/syncProperties.cy.ts
@@ -3,23 +3,20 @@ import vectorLayerStyleJson from "./vectorLayer.json";
 
 describe("layers", () => {
   it("loads a Vector Layer", () => {
-    vectorLayerStyleJson[0].properties.visible = false;
+    vectorLayerStyleJson[0].visible = false;
     cy.mount(
       `<eox-map layers='${JSON.stringify(vectorLayerStyleJson)}'></eox-map>`
     ).as("eox-map");
     cy.get("eox-map").and(($el) => {
       const eoxMap = <EOxMap>$el[0];
       const layer = eoxMap.getLayerById("regions");
+      console.log(layer.getVisible());
       expect(layer.getVisible(), "set default visibility").to.be.equal(false);
       const jsonDefinition = layer.get("_jsonDefinition");
       layer.setVisible(true);
-      expect(jsonDefinition.properties.visible, "sync visible").to.be.equal(
-        true
-      );
+      expect(jsonDefinition.visible, "sync visible").to.be.equal(true);
       layer.setOpacity(0.5);
-      expect(jsonDefinition.properties.opacity, "sync opacity").to.be.equal(
-        0.5
-      );
+      expect(jsonDefinition.opacity, "sync opacity").to.be.equal(0.5);
       layer.set("foo", "bar");
       expect(jsonDefinition.properties.foo, "sync properties").to.be.equal(
         "bar"

--- a/elements/map/test/vectorLayer.json
+++ b/elements/map/test/vectorLayer.json
@@ -3,7 +3,8 @@
     "type": "Vector",
     "background": "#1366dd",
     "properties": {
-      "id": "regions"
+      "id": "regions",
+      "visible": true
     },
     "source": {
       "type": "Vector",

--- a/elements/map/test/vectorLayer.json
+++ b/elements/map/test/vectorLayer.json
@@ -3,9 +3,9 @@
     "type": "Vector",
     "background": "#1366dd",
     "properties": {
-      "id": "regions",
-      "visible": true
+      "id": "regions"
     },
+    "visible": true,
     "source": {
       "type": "Vector",
       "url": "https://openlayers.org/data/vector/ecoregions.json",


### PR DESCRIPTION
This PR includes syncing the ol-layers with their corresponding JSON-definition as well as the ability add and (somewhat) smartly update single layers.

 - Now sets the defining JSON-Structure to the layer itself. This can be retrieved by `layer.get('_jsonDefinition')`
 - `EoxMap.addOrUpdateLayer()` can add or update a single layer. Updating will look for a layer with the same ID. Will throw an error if the layer definitions are not compatible. Will create a new source if the JSON-Definitions of the sources differ. Same for the style and the properties. (This can probably be optimized in the future by only looking for changed keys)
 - Does not throw an error anymore when `getLayerById` does not find a layer (returns `undefined` instead)
 - added tests for both the syncing as well as the creating and updating of layers
 
 This does not yet consider the z-Index of the layers, as for now the layer ordering is handled by the map and the layers themself are agnostic of their position in relation to the other layers. Maybe layer ordering can be done via a map-definition, via layer zIndex, or as application logic.