### PR TITLE
Layercontrol v0.6.8

### DIFF
--- a/elements/layercontrol/layercontrol.stories.js
+++ b/elements/layercontrol/layercontrol.stories.js
@@ -2,6 +2,122 @@ import { html } from "lit";
 import "../map/main";
 import "./src/main";
 
+const map = html` <eox-map
+  style="width: 400px; height: 300px; margin-left: 7px;"
+  zoom="3"
+  layers='[
+  {
+    "type": "Group",
+    "properties": {
+      "id": "group2",
+      "title": "Data Layers",
+      "layerControlExpand": true
+    },
+    "layers": [
+      {
+        "type": "Tile",
+        "properties": {
+          "id": "WIND",
+          "title": "WIND"
+        },
+        "source": {
+          "type": "TileWMS",
+          "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
+          "params": {
+            "LAYERS": "AWS_VIS_WIND_V_10M"
+          }
+        }
+      },
+      {
+        "type": "Tile",
+        "properties": {
+          "id": "NO2",
+          "title": "NO2"
+        },
+        "source": {
+          "type": "TileWMS",
+          "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
+          "params": {
+            "LAYERS": "AWS_NO2-VISUALISATION"
+          }
+        }
+      },
+      {
+        "type": "Vector",
+        "properties": {
+          "title": "Regions",
+          "id": "regions"
+
+        },
+        "source": {
+          "type": "Vector",
+          "url": "https://openlayers.org/data/vector/ecoregions.json",
+          "format": "GeoJSON",
+          "attributions": "Regions: @ openlayers.org"
+        }
+      }
+    ]
+  },
+  {
+    "type": "Group",
+    "properties": {
+      "id": "group1",
+      "title": "Background Layers"
+    },
+    "layers": [
+      {
+        "type": "WebGLTile",
+        "properties": {
+          "id": "s2",
+          "layerControlExclusive": true,
+          "title": "s2"
+        },
+        "style": {
+          "variables": {
+            "red": 1,
+            "green": 2,
+            "blue": 3,
+            "redMax": 3000,
+            "greenMax": 3000,
+            "blueMax": 3000
+          },
+          "color": [
+            "array",
+            ["/", ["band", ["var", "red"]], ["var", "redMax"]],
+            ["/", ["band", ["var", "green"]], ["var", "greenMax"]],
+            ["/", ["band", ["var", "blue"]], ["var", "blueMax"]],
+            1
+          ],
+          "gamma": 1.1
+        },
+        "source": {
+          "type": "GeoTIFF",
+          "normalize": false,
+          "sources": [
+            {
+              "url": "https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Tile",
+        "properties": {
+          "id": "osm",
+          "title": "Open Street Map",
+          "layerControlExclusive": true
+        },
+        "visible": false,
+        "opacity": 0.5,
+        "source": {
+          "type": "OSM"
+        }
+      }
+    ]
+  }
+]'
+></eox-map>`;
+
 export default {
   title: "Elements/eox-layercontrol",
   tags: ["autodocs"],
@@ -10,123 +126,215 @@ export default {
     componentSubtitle: "Manage and configure OpenLayers map layers",
     layout: "centered",
   },
-  render: () => html`
-<eox-map
-  style="width: 400px; height: 300px; zoom="3"
-  layers='[
-    {
-      "type": "Group",
-      "properties": {
-        "id": "group2",
-        "title": "Data Layers"
-      },
-      "layers": [
-        {
-          "type": "Tile",
-          "properties": {
-            "id": "WIND",
-            "title": "WIND"
-          },
-          "source": {
-            "type": "TileWMS",
-            "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
-            "params": {
-              "LAYERS": "AWS_VIS_WIND_V_10M"
-            }
-          }
-        },
-        {
-          "type": "Tile",
-          "properties": {
-            "id": "NO2",
-            "title": "NO2"
-          },
-          "source": {
-            "type": "TileWMS",
-            "url": "https://services.sentinel-hub.com/ogc/wms/0635c213-17a1-48ee-aef7-9d1731695a54",
-            "params": {
-              "LAYERS": "AWS_NO2-VISUALISATION"
-            }
-          }
-        },
-        {
-          "type": "Vector",
-          "properties": {
-            "title": "Regions",
-            "id": "regions"
-
-          },
-          "source": {
-            "type": "Vector",
-            "url": "https://openlayers.org/data/vector/ecoregions.json",
-            "format": "GeoJSON",
-            "attributions": "Regions: @ openlayers.org"
-          }
-        }
-      ]
-    },
-    {
-      "type": "Group",
-      "properties": {
-        "id": "group1",
-        "title": "Background Layers"
-      },
-      "layers": [
-        {
-          "type": "WebGLTile",
-          "properties": {
-            "id": "s2",
-            "layerControlExclusive": true,
-            "title": "s2"
-          },
-          "style": {
-            "variables": {
-              "red": 1,
-              "green": 2,
-              "blue": 3,
-              "redMax": 3000,
-              "greenMax": 3000,
-              "blueMax": 3000
-            },
-            "color": [
-              "array",
-              ["/", ["band", ["var", "red"]], ["var", "redMax"]],
-              ["/", ["band", ["var", "green"]], ["var", "greenMax"]],
-              ["/", ["band", ["var", "blue"]], ["var", "blueMax"]],
-              1
-            ],
-            "gamma": 1.1
-          },
-          "source": {
-            "type": "GeoTIFF",
-            "normalize": false,
-            "sources": [
-              {
-                "url": "https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif"
-              }
-            ]
-          }
-        },
-        {
-          "type": "Tile",
-          "properties": {
-            "id": "osm",
-            "title": "Open Street Map",
-            "layerControlExclusive": true
-          },
-          "visible": false,
-          "opacity": 0.5,
-          "source": {
-            "type": "OSM"
-          }
-        }
-      ]
-    }
-  ]'
-></eox-map>
-<eox-layercontrol for="eox-map" layerIdentifier="id"></eox-layercontrol>`,
 };
 
+/**
+ * Basic layercontrol setup.
+ */
 export const Primary = {
   args: {},
+  render: (args, test) => html`
+    <div style="display: flex">
+      <eox-layercontrol for="eox-map"></eox-layercontrol>
+      ${map}
+    </div>
+  `,
+};
+
+/**
+ * By adding the `layerControlExclusive` property to map layers,
+ * only one of them at a time can be visualized.
+ */
+export const ExclusiveLayers = {
+  args: {},
+  render: (args, test) => html`
+    <div style="display: flex">
+      <eox-layercontrol for="eox-map#exclusive"></eox-layercontrol>
+      <eox-map
+        id="exclusive"
+        style="width: 400px; height: 300px; margin-left: 7px;"
+        layers=${JSON.stringify([
+          {
+            type: "Tile",
+            properties: {
+              title: "Terrain Light",
+              layerControlExclusive: true,
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+          },
+          {
+            type: "Tile",
+            properties: {
+              title: "EOxCloudless",
+              layerControlExclusive: true,
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2021_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+            visible: false,
+          },
+        ])}
+      >
+      </eox-map>
+    </div>
+  `,
+};
+
+/**
+ * By adding the `layerControlOptional` property to map layers,
+ * they are not initially rendered in the layer list, but in a
+ * selection interface. They can be added to the layer list manually.
+ * Removing a layer puts it back into the optional list.
+ */
+export const OptionalLayers = {
+  args: {},
+  render: (args, test) => html`
+    <div style="display: flex">
+      <eox-layercontrol for="eox-map#optional"></eox-layercontrol>
+      <eox-map
+        id="optional"
+        style="width: 400px; height: 300px; margin-left: 7px;"
+        layers=${JSON.stringify([
+          {
+            type: "Tile",
+            properties: {
+              title: "Terrain Light",
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+          },
+          {
+            type: "Tile",
+            properties: {
+              title: "EOxCloudless 2021",
+              layerControlOptional: true,
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2021_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+            visible: false,
+          },
+          {
+            type: "Tile",
+            properties: {
+              title: "EOxCloudless 2020",
+              layerControlOptional: true,
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2020_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+            visible: false,
+          },
+          {
+            type: "Tile",
+            properties: {
+              title: "EOxCloudless 2019",
+              layerControlOptional: true,
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2019_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+            visible: false,
+          },
+        ])}
+      >
+      </eox-map>
+    </div>
+  `,
+};
+
+/**
+ * By adding the `layerControlExpand` property to map layers,
+ * they render in the layer control as opened.
+ */
+export const ExpandedLayers = {
+  args: {},
+  render: (args, test) => html`
+    <div style="display: flex">
+      <eox-layercontrol for="eox-map#expanded"></eox-layercontrol>
+      <eox-map
+        id="expanded"
+        style="width: 400px; height: 300px; margin-left: 7px;"
+        layers=${JSON.stringify([
+          {
+            type: "Tile",
+            properties: {
+              title: "Terrain Light",
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+          },
+          {
+            type: "Tile",
+            properties: {
+              title: "EOxCloudless",
+              layerControlExpand: true,
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2021_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+            visible: false,
+          },
+        ])}
+      >
+      </eox-map>
+    </div>
+  `,
+};
+
+/**
+ * By adding the `layerControlHide` property to map layers,
+ * they aren't displayed in the layer control at all (but may
+ * be still rendered on the map).
+ */
+export const HiddenLayers = {
+  args: {},
+  render: (args, test) => html`
+    <div style="display: flex">
+      <eox-layercontrol for="eox-map#hidden"></eox-layercontrol>
+      <eox-map
+        id="hidden"
+        style="width: 400px; height: 300px; margin-left: 7px;"
+        layers=${JSON.stringify([
+          {
+            type: "Vector",
+            properties: {
+              title: "Regions",
+              id: "regions",
+              layerControlHide: true,
+            },
+            source: {
+              type: "Vector",
+              url: "https://openlayers.org/data/vector/ecoregions.json",
+              format: "GeoJSON",
+              attributions: "Regions: @ openlayers.org",
+            },
+          },
+          {
+            type: "Tile",
+            properties: {
+              title: "Terrain Light",
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpg",
+            },
+          },
+        ])}
+      >
+      </eox-map>
+    </div>
+  `,
 };

--- a/elements/layercontrol/package.json
+++ b/elements/layercontrol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eox/layercontrol",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "type": "module",
   "devDependencies": {
     "@eox/eslint-config": "^1.0.0",

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -267,7 +267,13 @@ export class EOxLayerControl extends LitElement {
                 .external=${this.externalLayerConfig}
                 .unstyled="${this.unstyled}"
                 @removeLayer=${() => {
-                  collection.remove(layer);
+                  if (this.optionalLayerArray?.length > 0) {
+                    layer.set("layerControlOptional", true);
+                    layer.setVisible(false);
+                    this.requestUpdate();
+                  } else {
+                    collection.remove(layer);
+                  }
                   const listitem = this.renderRoot.querySelector(
                     `[data-layer='${layer.get(this.layerIdentifier)}'`
                   );

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -34,7 +34,7 @@ type OlSource = Source & {
  * ### Introduction
  * This highly configurable layer control aims to provide fine-grained management of
  * map layers, while at the same time allowing to reduce complexity for the user.
- * 
+ *
  * The `eox-layercontrol` can attach to any **OpenLayers map** and provides the following functionalities:
  * - layer visibility: toggle on/off
  * - layer ordering

--- a/elements/layercontrol/src/main.ts
+++ b/elements/layercontrol/src/main.ts
@@ -225,7 +225,7 @@ export class EOxLayerControl extends LitElement {
       groupId: string,
       collection: Collection<BaseLayer>
     ) => html`
-      <details open="${layer.get("layerControlExpanded") ? true : nothing}">
+      <details open="${layer.get("layerControlExpand") ? true : nothing}">
         <summary>
           <div class="layer">
             <div class="left">

--- a/elements/layercontrol/test/_mockMap.ts
+++ b/elements/layercontrol/test/_mockMap.ts
@@ -23,7 +23,7 @@ const mockLayer = (
     id: layerId,
     layerControlDisable: undefined,
     layerControlExclusive: undefined,
-    layerControlExpanded: undefined,
+    layerControlExpand: undefined,
     layerControlHide: undefined,
     layerControlOptional: undefined,
     opacity: 1,

--- a/elements/layercontrol/test/general.cy.ts
+++ b/elements/layercontrol/test/general.cy.ts
@@ -86,11 +86,11 @@ describe("LayerControl", () => {
       });
   });
 
-  it("pre-opens a section if layerControlExpanded is present", () => {
+  it("pre-opens a section if layerControlExpand is present", () => {
     cy.get("mock-map").and(($el) => {
       (<MockMap>$el[0]).setLayers([
         { visible: true },
-        { layerControlExpanded: true },
+        { layerControlExpand: true },
       ]);
     });
     cy.get("eox-layercontrol")

--- a/elements/layercontrol/test/layersUpdate.cy.ts
+++ b/elements/layercontrol/test/layersUpdate.cy.ts
@@ -59,7 +59,7 @@ describe("LayerControl", () => {
         {
           title: "group",
           layers: [{ title: "foo" }],
-          layerControlExpanded: true,
+          layerControlExpand: true,
         },
         { title: "bar" },
       ]);
@@ -83,7 +83,7 @@ describe("LayerControl", () => {
   it("updates if a layer is removed from the root collection", () => {
     cy.get("mock-map").and(($el) => {
       (<MockMap>$el[0]).setLayers([
-        { id: "foo", layerControlExpanded: true },
+        { id: "foo", layerControlExpand: true },
         { id: "bar" },
       ]);
     });
@@ -113,7 +113,7 @@ describe("LayerControl", () => {
         {
           title: "group",
           layers: [{ title: "baz" }],
-          layerControlExpanded: true,
+          layerControlExpand: true,
         },
         { title: "bar" },
       ]);
@@ -137,7 +137,7 @@ describe("LayerControl", () => {
         {
           title: "group1",
           layers: [{ title: "title1" }],
-          layerControlExpanded: true,
+          layerControlExpand: true,
         },
         {
           title: "group2",
@@ -145,7 +145,7 @@ describe("LayerControl", () => {
             { title: "foo" },
             { title: "title2", layerControlOptional: true, visible: false },
           ],
-          layerControlExpanded: true,
+          layerControlExpand: true,
         },
       ]);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
     },
     "elements/layercontrol": {
       "name": "@eox/layercontrol",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "dayjs": "^1.11.8",
         "lit": "^2.7.4"


### PR DESCRIPTION
This PR introduces
- a renaming of the expand layer property: `layerControlExpanded` now is ``layerControlExpand` in order to harmonize with the other present-tense properties
- a new feature that pushes a layer back into the optional layers list instead of removing it from the collection