### PR TITLE
Map/feature/select by

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -5,7 +5,7 @@ import View from "ol/View.js";
 // @ts-ignore
 import olCss from "ol/ol.css?inline";
 import { DrawOptions, addDraw } from "./src/draw";
-import { SelectOptions, addSelect } from "./src/select";
+import { EoxSelectInteraction, SelectOptions, addSelect } from "./src/select";
 import {
   generateLayers,
   EoxLayer,
@@ -73,6 +73,12 @@ export class EOxMap extends LitElement {
   interactions: { [index: string]: Draw | Modify } = {};
 
   /**
+   * dictionary of select interactions.
+   */
+  @state()
+  selectInteractions: { [index: string]: EoxSelectInteraction } = {};
+
+  /**
    * dictionary of ol controls associated with the map.
    */
   @state()
@@ -128,12 +134,21 @@ export class EOxMap extends LitElement {
   };
 
   /**
-   * removes a given interaction from the map. Layer have to be removed seperately
+   * removes a given ol-interaction from the map. Layer have to be removed seperately
    * @param id id of the interaction
    */
   removeInteraction = (id: string) => {
     this.map.removeInteraction(this.interactions[id]);
     delete this.interactions[id];
+  };
+
+  /**
+   * removes a given EOxSelectInteraction from the map.
+   * @param id id of the interaction
+   */
+  removeSelect = (id: string) => {
+    this.selectInteractions[id].remove();
+    delete this.selectInteractions[id];
   };
 
   /**

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -5,7 +5,7 @@ import View from "ol/View.js";
 // @ts-ignore
 import olCss from "ol/ol.css?inline";
 import { DrawOptions, addDraw } from "./src/draw";
-import { EoxSelectInteraction, SelectOptions, addSelect } from "./src/select";
+import { EOxSelectInteraction, SelectOptions, addSelect } from "./src/select";
 import {
   generateLayers,
   EoxLayer,
@@ -76,7 +76,7 @@ export class EOxMap extends LitElement {
    * dictionary of select interactions.
    */
   @state()
-  selectInteractions: { [index: string]: EoxSelectInteraction } = {};
+  selectInteractions: { [index: string]: EOxSelectInteraction } = {};
 
   /**
    * dictionary of ol controls associated with the map.

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -181,7 +181,7 @@ function setSyncListeners(olLayer: olLayers.Layer, eoxLayer: EoxLayer) {
   olLayer.on("change:visible", () => {
     eoxLayer.visible = olLayer.getVisible();
   });
-  olLayer.on("change:zIndex", (e) => {
+  olLayer.on("change:zIndex", () => {
     // TO DO
   });
   olLayer.on("propertychange", (e) => {

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -183,7 +183,6 @@ function setSyncListeners(olLayer: olLayers.Layer, eoxLayer: EoxLayer) {
   });
   olLayer.on("change:zIndex", (e) => {
     // TO DO
-    console.log(e);
   });
   olLayer.on("propertychange", (e) => {
     if (e.key === "map") {

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -20,34 +20,161 @@ export type SelectOptions = Omit<
   layer?: EoxLayer;
   style?: import("ol/style/flat.js").FlatStyleLike;
   overlay?: import("ol/Overlay").Options;
+  active: boolean;
 };
 
-export function addSelect(
-  EOxMap: EOxMap,
-  layerId: string,
-  options: SelectOptions
-) {
-  if (EOxMap.interactions[options.id]) {
-    throw Error(`Interaction with id: ${options.id} already exists.`);
+export const EoxSelectInteraction = class {
+  eoxMap: EOxMap;
+  layerId: string;
+  options: SelectOptions;
+  active: boolean;
+  tooltip: HTMLElement;
+  selectedFid: string | number;
+  selectLayer: VectorTileLayer | VectorLayer<VectorSource>;
+  selectStyleLayer: VectorTileLayer | VectorLayer<VectorSource>;
+  layerDefinition: any;
+
+  constructor(eoxMap: EOxMap, layerId: string, options: SelectOptions) {
+    this.eoxMap = eoxMap;
+    this.layerId = layerId;
+    this.options = options;
+    this.active = options.active;
+
+    this.tooltip =
+      this.eoxMap.querySelector("eox-map-tooltip") || options.overlay?.element;
+    let overlay: Overlay;
+    this.selectedFid = null;
+    this.selectLayer = this.eoxMap.getLayerById(layerId) as
+      | VectorTileLayer
+      | VectorLayer<VectorSource>;
+
+    if (this.tooltip) {
+      overlay = new Overlay({
+        element: this.tooltip,
+        position: undefined,
+        offset: [0, 0],
+        positioning: "top-left",
+        className: "eox-map-tooltip",
+        ...options.overlay,
+      });
+      this.eoxMap.map.addOverlay(overlay);
+    }
+
+    // a layer that only contains the selected features, for displaying purposes only
+    // unmanaged by the map
+    let layerDefinition;
+    if (this.options.layer) {
+      layerDefinition = this.options.layer;
+    } else {
+      const type =
+        this.selectLayer instanceof VectorLayer ? "Vector" : "VectorTile";
+      // a layer can be defined by only its style property as a shorthand.
+      layerDefinition = {
+        style: options.style,
+        type,
+        properties: {
+          id: layerId + "_select",
+        },
+        source: {
+          type,
+        },
+      } as EoxLayer;
+    }
+    //@ts-ignore
+    layerDefinition.renderMode = "vector";
+
+    this.selectStyleLayer = createLayer(layerDefinition as EoxLayer) as
+      | VectorTileLayer
+      | VectorLayer<VectorSource>;
+    //@ts-ignore
+    this.selectStyleLayer.setSource(this.selectLayer.getSource());
+    this.selectStyleLayer.setMap(this.eoxMap.map);
+
+    const initialStyle = this.selectStyleLayer.getStyleFunction();
+
+    this.selectStyleLayer.setStyle((feature, resolution) => {
+      if (this.selectedFid && this.getId(feature) === this.selectedFid) {
+        return initialStyle(feature, resolution);
+      }
+      return null;
+    });
+
+    const listener = (event: MapBrowserEvent<any>) => {
+      if (event.dragging) {
+        return;
+      }
+      this.selectLayer
+        .getFeatures(event.pixel)
+        .then((features: Array<Feature | RenderFeature>) => {
+          const feature = features.length ? features[0] : null;
+          this.selectedFid = feature ? this.getId(feature) : null;
+          this.selectStyleLayer.changed();
+
+          if (overlay) {
+            const xPosition =
+              event.pixel[0] > this.eoxMap.offsetWidth / 2 ? "right" : "left";
+            const yPosition =
+              event.pixel[1] > this.eoxMap.offsetHeight / 2 ? "bottom" : "top";
+            overlay.setPositioning(`${yPosition}-${xPosition}`);
+            overlay.setPosition(feature ? event.coordinate : null);
+            if (feature && (<EOxMapTooltip>this.tooltip).renderContent) {
+              (<EOxMapTooltip>this.tooltip).renderContent(
+                feature.getProperties()
+              );
+            }
+          }
+
+          const selectdEvt = new CustomEvent("select", {
+            detail: {
+              id: options.id,
+              originalEvent: event,
+              feature: feature,
+            },
+          });
+          this.eoxMap.dispatchEvent(selectdEvt);
+        });
+    };
+    this.eoxMap.map.on(options.condition || "click", listener);
+
+    // if the parent layer changes, also change the selection layer.
+    this.selectLayer.on("change:opacity", () => {
+      this.selectStyleLayer.setOpacity(this.selectLayer.getOpacity());
+    });
+
+    this.selectLayer.on("change:visible", () => {
+      const visible = this.selectLayer.getVisible();
+      this.selectStyleLayer.setVisible(visible);
+      if (overlay) {
+        if (visible) {
+          this.eoxMap.map.addOverlay(overlay);
+        } else {
+          this.eoxMap.map.removeOverlay(overlay);
+        }
+      }
+    });
+
+    this.selectLayer.on("change:source", () => {
+      //@ts-ignore
+      selectStyleLayer.setSource(selectLayer.getSource());
+    });
+
+    this.eoxMap.map.getLayers().on("remove", () => {
+      if (!this.eoxMap.getLayerById(layerId)) {
+        this.selectStyleLayer.setMap(null);
+        if (overlay) {
+          this.eoxMap.map.removeOverlay(overlay);
+        }
+      }
+    });
   }
 
-  const tooltip: HTMLElement =
-    EOxMap.querySelector("eox-map-tooltip") || options.overlay?.element;
-  let overlay: Overlay;
-  let selectedFid: string | number = null;
+  setActive(active: boolean) {
+    this.active = active;
+  }
 
-  const map = EOxMap.map;
-
-  if (tooltip) {
-    overlay = new Overlay({
-      element: tooltip,
-      position: undefined,
-      offset: [0, 0],
-      positioning: "top-left",
-      className: "eox-map-tooltip",
-      ...options.overlay,
-    });
-    map.addOverlay(overlay);
+  selectById(id: string | number) {
+    console.log("selecting by id");
+    this.selectedFid = id;
   }
 
   /**
@@ -55,9 +182,9 @@ export function addSelect(
    * @param feature
    * @returns {number | string} ID value of feature
    */
-  function getId(feature: Feature | RenderFeature) {
-    if (options.idProperty) {
-      return feature.get(options.idProperty);
+  getId(feature: Feature | RenderFeature) {
+    if (this.options.idProperty) {
+      return feature.get(this.options.idProperty);
     }
     if (feature.getId() !== undefined) {
       return feature.getId();
@@ -69,111 +196,15 @@ export function addSelect(
       "No feature id found. Please provide which feature property should be taken instead using idProperty."
     );
   }
+};
 
-  const selectLayer = EOxMap.getLayerById(layerId);
-
-  // a layer that only contains the selected features, for displaying purposes only
-  // unmanaged by the map
-  let layerDefinition;
-  if (options.layer) {
-    layerDefinition = options.layer;
-  } else {
-    const type = selectLayer instanceof VectorLayer ? "Vector" : "VectorTile";
-    // a layer can be defined by only its style property as a shorthand.
-    layerDefinition = {
-      style: options.style,
-      type,
-      properties: {
-        id: layerId + "_select",
-      },
-      source: {
-        type,
-      },
-    } as EoxLayer;
+export function addSelect(
+  EOxMap: EOxMap,
+  layerId: string,
+  options: SelectOptions
+) {
+  if (EOxMap.interactions[options.id]) {
+    throw Error(`Interaction with id: ${options.id} already exists.`);
   }
-  //@ts-ignore
-  layerDefinition.renderMode = "vector";
-
-  const selectStyleLayer = createLayer(layerDefinition as EoxLayer) as
-    | VectorTileLayer
-    | VectorLayer<VectorSource>;
-  //@ts-ignore
-  selectStyleLayer.setSource(selectLayer.getSource());
-  selectStyleLayer.setMap(map);
-
-  const initialStyle = selectStyleLayer.getStyleFunction();
-
-  selectStyleLayer.setStyle((feature, resolution) => {
-    if (selectedFid && getId(feature) === selectedFid) {
-      return initialStyle(feature, resolution);
-    }
-    return null;
-  });
-
-  const listener = (event: MapBrowserEvent<any>) => {
-    if (event.dragging) {
-      return;
-    }
-    selectLayer
-      .getFeatures(event.pixel)
-      .then(function (features: Array<Feature | RenderFeature>) {
-        const feature = features.length ? features[0] : null;
-        selectedFid = feature ? getId(feature) : null;
-        selectStyleLayer.changed();
-
-        if (overlay) {
-          const xPosition =
-            event.pixel[0] > EOxMap.offsetWidth / 2 ? "right" : "left";
-          const yPosition =
-            event.pixel[1] > EOxMap.offsetHeight / 2 ? "bottom" : "top";
-          overlay.setPositioning(`${yPosition}-${xPosition}`);
-          overlay.setPosition(feature ? event.coordinate : null);
-          if (feature && (<EOxMapTooltip>tooltip).renderContent) {
-            (<EOxMapTooltip>tooltip).renderContent(feature.getProperties());
-          }
-        }
-
-        const selectdEvt = new CustomEvent("select", {
-          detail: {
-            id: options.id,
-            originalEvent: event,
-            feature: feature,
-          },
-        });
-        EOxMap.dispatchEvent(selectdEvt);
-      });
-  };
-  map.on(options.condition || "click", listener);
-
-  // if the parent layer changes, also change the selection layer.
-
-  selectLayer.on("change:opacity", () => {
-    selectStyleLayer.setOpacity(selectLayer.getOpacity());
-  });
-
-  selectLayer.on("change:visible", () => {
-    const visible = selectLayer.getVisible();
-    selectStyleLayer.setVisible(visible);
-    if (overlay) {
-      if (visible) {
-        map.addOverlay(overlay);
-      } else {
-        map.removeOverlay(overlay);
-      }
-    }
-  });
-
-  selectLayer.on("change:source", () => {
-    //@ts-ignore
-    selectStyleLayer.setSource(selectLayer.getSource());
-  });
-
-  map.getLayers().on("remove", () => {
-    if (!EOxMap.getLayerById(layerId)) {
-      selectStyleLayer.setMap(null);
-      if (overlay) {
-        map.removeOverlay(overlay);
-      }
-    }
-  });
+  const selectInteraction = new EoxSelectInteraction(EOxMap, layerId, options);
 }

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -20,10 +20,10 @@ export type SelectOptions = Omit<
   layer?: EoxLayer;
   style?: import("ol/style/flat.js").FlatStyleLike;
   overlay?: import("ol/Overlay").Options;
-  active: boolean;
+  active?: boolean;
 };
 
-export const EoxSelectInteraction = class {
+export class EoxSelectInteraction {
   eoxMap: EOxMap;
   layerId: string;
   options: SelectOptions;

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -23,7 +23,7 @@ export type SelectOptions = Omit<
   active?: boolean;
 };
 
-export class EoxSelectInteraction {
+export class EOxSelectInteraction {
   eoxMap: EOxMap;
   layerId: string;
   options: SelectOptions;
@@ -224,7 +224,7 @@ export function addSelect(
   if (EOxMap.interactions[options.id]) {
     throw Error(`Interaction with id: ${options.id} already exists.`);
   }
-  EOxMap.selectInteractions[options.id] = new EoxSelectInteraction(
+  EOxMap.selectInteractions[options.id] = new EOxSelectInteraction(
     EOxMap,
     layerId,
     options

--- a/elements/map/test/syncProperties.cy.ts
+++ b/elements/map/test/syncProperties.cy.ts
@@ -13,7 +13,6 @@ describe("layers", () => {
     cy.get("eox-map").and(($el) => {
       const eoxMap = <EOxMap>$el[0];
       const layer = eoxMap.getLayerById("regions");
-      console.log(layer.getVisible());
       expect(layer.getVisible(), "set default visibility").to.be.equal(false);
       const jsonDefinition = layer.get("_jsonDefinition");
       layer.setVisible(true);


### PR DESCRIPTION
This PR implements the map-part of the in #226 defined programmatic selection.

This includes:
 - refactoring of the selection to class structure
 - storing select-interactions in a dictionary
 - ability to remove select-interactions from the map
 - ability to set interactions active state via `selectInteraction.setActive()`
 - ability to highlight one or more features via `selectInteraction.highlightById([id])`

This programmatic highlighting is purely visual and does not fire a `select`-CustomEvent, as the manual selection does, as additional UI-actions are meant to be handled by the parent application.
Since the highlighting is purely visual, no additional tests are added.