### PR TITLE
fix: select style layer attributes

### DIFF
--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -142,7 +142,7 @@ export function updateLayer(
   if (
     ["Vector", "VectorTile"].includes(newLayerDefinition.type) &&
     JSON.stringify(newLayerDefinition.style) !==
-    JSON.stringify(existingJsonDefintion.style)
+      JSON.stringify(existingJsonDefintion.style)
   ) {
     //@ts-ignore
     existingLayer.setStyle(newLayer.getStyle());

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -53,6 +53,10 @@ export type EoxLayer = {
   properties: object & {
     id: string;
   };
+  minZoom?: number;
+  maxZoom?: number;
+  minResolution?: number;
+  maxResolution?: number;
   opacity?: number;
   visible?: boolean;
   source?: { type: sourceType };
@@ -138,7 +142,7 @@ export function updateLayer(
   if (
     ["Vector", "VectorTile"].includes(newLayerDefinition.type) &&
     JSON.stringify(newLayerDefinition.style) !==
-      JSON.stringify(existingJsonDefintion.style)
+    JSON.stringify(existingJsonDefintion.style)
   ) {
     //@ts-ignore
     existingLayer.setStyle(newLayer.getStyle());

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -68,17 +68,16 @@ export class EOxSelectInteraction {
     if (this.options.layer) {
       layerDefinition = this.options.layer;
     } else {
-      const type =
-        this.selectLayer instanceof VectorLayer ? "Vector" : "VectorTile";
       // a layer can be defined by only its style property as a shorthand.
+      const originalJsonDefinition = this.selectLayer.get("_jsonDefinition");
       layerDefinition = {
+        ...originalJsonDefinition,
         style: options.style,
-        type,
         properties: {
           id: layerId + "_select",
         },
         source: {
-          type,
+          type: originalJsonDefinition.type,
         },
       } as EoxLayer;
     }


### PR DESCRIPTION
This PR handles the in #267 described that some attributes did not get carried over from the original layer when creating the select-style-layer, as a (too much) simplified layer generation method was used. Now the same definition-JSON is used, only simplifying the Source as well as overriding the style and id.

Additionally, the type of `EoxLayer` was crudely improved, to underline the fact that ol-layer-attributes like `minZoom` are in fact allowed properties for EoxLayers.