### PR TITLE
feat: remove the overlay when pointer leaves

### DIFF
--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -60,6 +60,19 @@ export class EOxSelectInteraction {
         ...options.overlay,
       });
       this.eoxMap.map.addOverlay(overlay);
+
+      const pointerLeaveListener = () => {
+        overlay.setPosition(undefined);
+      };
+      eoxMap.map.on("change:target", (e) => {
+        e.oldValue.removeEventListener("pointerleave", pointerLeaveListener);
+        e.target
+          .getTargetElement()
+          .addEventListener("pointerleave", pointerLeaveListener);
+      });
+      eoxMap.map
+        .getTargetElement()
+        .addEventListener("pointerleave", pointerLeaveListener);
     }
 
     // a layer that only contains the selected features, for displaying purposes only

--- a/elements/map/test/hoverInteraction.cy.ts
+++ b/elements/map/test/hoverInteraction.cy.ts
@@ -8,7 +8,9 @@ describe("select interaction with hover", () => {
       fixture: "/ecoregions.json",
     });
     cy.mount(
-      `<eox-map layers='${JSON.stringify(vectorLayerStyleJson)}'></eox-map>`
+      `<eox-map layers='${JSON.stringify(
+        vectorLayerStyleJson
+      )}'><eox-map-tooltip></eox-map-tooltip></eox-map>`
     ).as("eox-map");
     cy.get("eox-map").and(($el) => {
       const eoxMap = <EOxMap>$el[0];


### PR DESCRIPTION
This PR implements the in #351 documented issue of sticky tooltips in the hover-selection. 

closes #351