### PR TITLE
fix: optional list update after layer removal

### DIFF
--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -131,23 +131,6 @@ export class EOxLayerControl extends LitElement {
                 }
               }
             }
-            @changed=${
-              /**
-               * @param {CustomEvent & {target: Element}} e
-               */
-              (e) => {
-                this.requestUpdate();
-                if (e.target.tagName === "EOX-LAYERCONTROL-LAYER-TOOLS") {
-                  /**
-                   * @type Element & { requestUpdate: function }
-                   */
-                  const optionalListEl = this.renderRoot.querySelector(
-                    "eox-layercontrol-optional-list"
-                  );
-                  optionalListEl?.requestUpdate();
-                }
-              }
-            }
           ></eox-layercontrol-layer-list>
         `
       )}

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -114,16 +114,23 @@ export class EOxLayerControl extends LitElement {
             .titleProperty=${this.titleProperty}
             .tools=${this.tools}
             .unstyled=${this.unstyled}
-            @changed=${() => {
-              this.requestUpdate();
+            @changed=${
               /**
-               * @type Element & { requestUpdate: function }
+               * @param {CustomEvent & {target: Element}} e
                */
-              const optionalListEl = this.renderRoot.querySelector(
-                "eox-layercontrol-optional-list"
-              );
-              optionalListEl.requestUpdate();
-            }}
+              (e) => {
+                this.requestUpdate();
+                if (e.target.tagName === "EOX-LAYERCONTROL-LAYER-TOOLS") {
+                  /**
+                   * @type Element & { requestUpdate: function }
+                   */
+                  const optionalListEl = this.renderRoot.querySelector(
+                    "eox-layercontrol-optional-list"
+                  );
+                  optionalListEl?.requestUpdate();
+                }
+              }
+            }
           ></eox-layercontrol-layer-list>
         `
       )}

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -114,7 +114,16 @@ export class EOxLayerControl extends LitElement {
             .titleProperty=${this.titleProperty}
             .tools=${this.tools}
             .unstyled=${this.unstyled}
-            @changed=${() => this.requestUpdate()}
+            @changed=${() => {
+              this.requestUpdate();
+              /**
+               * @type Element & { requestUpdate: function }
+               */
+              const optionalListEl = this.renderRoot.querySelector(
+                "eox-layercontrol-optional-list"
+              );
+              optionalListEl.requestUpdate();
+            }}
           ></eox-layercontrol-layer-list>
         `
       )}


### PR DESCRIPTION
this PR closes #342; `eox-layercontrol-optional-list` gets updated after any layer removal.