### PR TITLE
fix: inline mode improvements

### DIFF
--- a/elements/itemfilter/src/autocomplete.ts
+++ b/elements/itemfilter/src/autocomplete.ts
@@ -97,6 +97,9 @@ export class EOxAutocomplete extends LitElement {
     // }
     if (key === "ArrowDown" || key === "ArrowUp") {
       this.renderRoot.querySelector("eox-dropdown").open = true;
+      if (this.parentElement?.inline) {
+        this.renderRoot.querySelector("eox-selectionlist")._handleKeyboard(key);
+      }
     }
     // if (key === "ArrowLeft" || key === "ArrowRight") {
     //   if (this.renderRoot.querySelectorAll(".chip").length < 1) {

--- a/elements/itemfilter/src/autocomplete.ts
+++ b/elements/itemfilter/src/autocomplete.ts
@@ -317,7 +317,6 @@ export class EOxAutocomplete extends LitElement {
               this.items.length > 0,
               () => html`
                 <eox-selectionlist
-                  id="ac-selection-list"
                   slot="content"
                   .filter=${this.inputText}
                   .idProperty=${this.idProperty}

--- a/elements/itemfilter/src/autocomplete.ts
+++ b/elements/itemfilter/src/autocomplete.ts
@@ -129,6 +129,15 @@ export class EOxAutocomplete extends LitElement {
     //   ].classList.add("highlighted");
     // }
     this.renderRoot.querySelector("input").select();
+    if ((<HTMLElement & { inline: boolean }>this.parentElement)?.inline) {
+      if (!["ArrowUp", "ArrowDown"].includes(key)) {
+        (<HTMLInputElement>(
+          this.parentElement.parentElement?.parentElement?.querySelector(
+            "#inline-input"
+          )
+        )).focus();
+      }
+    }
   }
 
   _handleHighlight(items: Array<any>) {

--- a/elements/itemfilter/src/autocomplete.ts
+++ b/elements/itemfilter/src/autocomplete.ts
@@ -317,6 +317,7 @@ export class EOxAutocomplete extends LitElement {
               this.items.length > 0,
               () => html`
                 <eox-selectionlist
+                  id="ac-selection-list"
                   slot="content"
                   .filter=${this.inputText}
                   .idProperty=${this.idProperty}

--- a/elements/itemfilter/src/chips.ts
+++ b/elements/itemfilter/src/chips.ts
@@ -94,7 +94,10 @@ export class EOxItemFilterChips extends LitElement {
       "keydown",
       (event) => {
         const { code } = <KeyboardEvent>event;
-        if (code !== "Escape") {
+        if (code === "Space") {
+          event.preventDefault();
+        }
+        if (!["Escape", "Space"].includes(code)) {
           event.stopPropagation();
         }
         if (["ArrowLeft", "ArrowRight", "Escape", "Backspace"].includes(code)) {

--- a/elements/itemfilter/src/chips.ts
+++ b/elements/itemfilter/src/chips.ts
@@ -97,7 +97,7 @@ export class EOxItemFilterChips extends LitElement {
         if (code === "Space") {
           event.preventDefault();
         }
-        if (!["Escape", "Space"].includes(code)) {
+        if (!["Escape", "Space", "Enter"].includes(code)) {
           event.stopPropagation();
         }
         if (["ArrowLeft", "ArrowRight", "Escape", "Backspace"].includes(code)) {

--- a/elements/itemfilter/src/chips.ts
+++ b/elements/itemfilter/src/chips.ts
@@ -22,14 +22,14 @@ export class EOxItemFilterChips extends LitElement {
     );
   }
 
-  _handleKeyboard(key: string) {
+  _handleKeyboard(key: string, textValue: string) {
     const highlightedChip = this.renderRoot.querySelector(".chip.highlighted");
-    if (key === "Escape") {
+    if (key === "Escape" || textValue) {
       if (highlightedChip) {
         highlightedChip.classList.remove("highlighted");
       }
     }
-    if (key === "Backspace") {
+    if (key === "Backspace" && !textValue) {
       if (this.items.length) {
         if (highlightedChip) {
           this.items.splice(
@@ -54,7 +54,7 @@ export class EOxItemFilterChips extends LitElement {
       }
       this._dispatchEvent();
     }
-    if (key === "ArrowLeft" || key === "ArrowRight") {
+    if ((key === "ArrowLeft" || key === "ArrowRight") && !textValue) {
       if (this.renderRoot.querySelectorAll(".chip").length < 1) {
         return;
       }
@@ -94,8 +94,14 @@ export class EOxItemFilterChips extends LitElement {
       "keydown",
       (event) => {
         const { code } = <KeyboardEvent>event;
+        if (code !== "Escape") {
+          event.stopPropagation();
+        }
         if (["ArrowLeft", "ArrowRight", "Escape", "Backspace"].includes(code)) {
-          this._handleKeyboard(code);
+          this._handleKeyboard(
+            code,
+            (<HTMLInputElement>event.target).value ?? ""
+          );
         }
       }
     );

--- a/elements/itemfilter/src/filters/text.ts
+++ b/elements/itemfilter/src/filters/text.ts
@@ -33,6 +33,7 @@ export class EOxItemFilterText extends LitElement {
     );
     searchInput.value = "";
     resetFilter(this.filterObject);
+    this.filterObject.dirty = false;
     this.requestUpdate();
   }
 

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -69,6 +69,9 @@ export class EOxItemFilterInline extends LitElement {
       delete item._inProgress;
       delete item.stringifiedState;
     });
+    this.renderRoot
+    .querySelector("[slot=content]")
+    .classList.remove("hidden");
     this.requestUpdate();
     this.dispatchEvent(new CustomEvent("filter"));
   }
@@ -217,6 +220,8 @@ export class EOxItemFilterInline extends LitElement {
                       const items = evt.detail;
                       if (items.length > 0) {
                         items[items.length - 1]._inProgress = true;
+                        this.renderRoot.querySelector('input[slot=trigger]').value = ''
+                        this.inputText = ''
                         this.requestUpdate();
                       }
 

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -168,6 +168,7 @@ export class EOxItemFilterInline extends LitElement {
         <div class="input-container">
           <eox-dropdown .parent=${this} .unstyled=${this.unstyled}>
             <input
+              id="inline-input"
               slot="trigger"
               type="text"
               placeholder="Type something..."

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -51,17 +51,22 @@ export class EOxItemFilterInline extends LitElement {
     const inProgressItem = this.items.find((i) => i._inProgress);
     const textInProgress =
       inProgressItem?.type === "text" && inProgressItem?.dirty;
+    const inputEl = this.renderRoot.querySelector(
+      "#inline-input"
+    ) as HTMLInputElement;
     const highlightedLiItem = this.renderRoot
       ?.querySelector("[data-filter]")
       ?.querySelector("eox-autocomplete")
       ?.renderRoot?.querySelector("eox-selectionlist")
       ?.renderRoot?.querySelector("li.highlighted");
 
-    if (key == "Enter" && highlightedLiItem) {
-      const checkboxEl = highlightedLiItem.querySelector(
-        "input[type=checkbox]"
-      );
-      checkboxEl.checked = !checkboxEl?.checked;
+    if (key == "Enter" && highlightedLiItem && inputEl.selectionStart) {
+      highlightedLiItem
+        .querySelector("input[type=checkbox]")
+        .dispatchEvent(new Event("change"));
+      inputEl.selectionStart = 0;
+      inputEl.value = "";
+      inputEl.focus();
     }
     if (
       ["Escape", "Space"].includes(key) ||
@@ -99,6 +104,8 @@ export class EOxItemFilterInline extends LitElement {
     this._keyboardEventListener = this.getRootNode().addEventListener(
       "keydown",
       (event) => {
+        console.log(event.target);
+
         if (["Enter", "Escape", "Space"].includes(event.code)) {
           this._handleKeyboard(event.code);
         }

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -47,7 +47,7 @@ export class EOxItemFilterInline extends LitElement {
     //     }
     //   }
     // }
-    if (key === "Escape") {
+    if (key === "Escape" || key === "Space") {
       const inProgressItem = this.items.find((i) => i._inProgress);
       if (inProgressItem) {
         delete inProgressItem._inProgress;
@@ -85,6 +85,7 @@ export class EOxItemFilterInline extends LitElement {
           [
             // "Enter",
             "Escape",
+            "Space",
           ].includes(event.code)
         ) {
           this._handleKeyboard(event.code);

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -104,8 +104,6 @@ export class EOxItemFilterInline extends LitElement {
     this._keyboardEventListener = this.getRootNode().addEventListener(
       "keydown",
       (event) => {
-        console.log(event.target);
-
         if (["Enter", "Escape", "Space"].includes(event.code)) {
           this._handleKeyboard(event.code);
         }

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -69,9 +69,7 @@ export class EOxItemFilterInline extends LitElement {
       delete item._inProgress;
       delete item.stringifiedState;
     });
-    this.renderRoot
-    .querySelector("[slot=content]")
-    .classList.remove("hidden");
+    this.renderRoot.querySelector("[slot=content]").classList.remove("hidden");
     this.requestUpdate();
     this.dispatchEvent(new CustomEvent("filter"));
   }
@@ -220,8 +218,10 @@ export class EOxItemFilterInline extends LitElement {
                       const items = evt.detail;
                       if (items.length > 0) {
                         items[items.length - 1]._inProgress = true;
-                        this.renderRoot.querySelector('input[slot=trigger]').value = ''
-                        this.inputText = ''
+                        this.renderRoot.querySelector(
+                          "input[slot=trigger]"
+                        ).value = "";
+                        this.inputText = "";
                         this.requestUpdate();
                       }
 

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -56,7 +56,7 @@ export class EOxItemFilterInline extends LitElement {
       ?.querySelector("eox-autocomplete")
       ?.renderRoot?.querySelector("eox-selectionlist")
       ?.renderRoot?.querySelector("li.highlighted");
-      
+
     if (key == "Enter" && highlightedLiItem) {
       const checkboxEl = highlightedLiItem.querySelector(
         "input[type=checkbox]"

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -50,7 +50,19 @@ export class EOxItemFilterInline extends LitElement {
 
     const inProgressItem = this.items.find((i) => i._inProgress);
     const textInProgress =
-      inProgressItem.type === "text" && inProgressItem.dirty;
+      inProgressItem?.type === "text" && inProgressItem?.dirty;
+    const highlightedLiItem = this.renderRoot
+      ?.querySelector("[data-filter]")
+      ?.querySelector("eox-autocomplete")
+      ?.renderRoot?.querySelector("eox-selectionlist")
+      ?.renderRoot?.querySelector("li.highlighted");
+      
+    if (key == "Enter" && highlightedLiItem) {
+      const checkboxEl = highlightedLiItem.querySelector(
+        "input[type=checkbox]"
+      );
+      checkboxEl.checked = !checkboxEl?.checked;
+    }
     if (
       ["Escape", "Space"].includes(key) ||
       (key == "Enter" && textInProgress)

--- a/elements/itemfilter/src/inline.ts
+++ b/elements/itemfilter/src/inline.ts
@@ -47,8 +47,14 @@ export class EOxItemFilterInline extends LitElement {
     //     }
     //   }
     // }
-    if (key === "Escape" || key === "Space") {
-      const inProgressItem = this.items.find((i) => i._inProgress);
+
+    const inProgressItem = this.items.find((i) => i._inProgress);
+    const textInProgress =
+      inProgressItem.type === "text" && inProgressItem.dirty;
+    if (
+      ["Escape", "Space"].includes(key) ||
+      (key == "Enter" && textInProgress)
+    ) {
       if (inProgressItem) {
         delete inProgressItem._inProgress;
         this.requestUpdate();
@@ -81,13 +87,7 @@ export class EOxItemFilterInline extends LitElement {
     this._keyboardEventListener = this.getRootNode().addEventListener(
       "keydown",
       (event) => {
-        if (
-          [
-            // "Enter",
-            "Escape",
-            "Space",
-          ].includes(event.code)
-        ) {
+        if (["Enter", "Escape", "Space"].includes(event.code)) {
           this._handleKeyboard(event.code);
         }
       }

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -193,7 +193,7 @@ export class EOxItemFilter extends TemplateElement {
             ...filterProperty.state,
           },
           ...(filterProperty.state && {
-            dirty: true,
+            dirty: false,
           }),
           ...(filterProperty.type === "range" && {
             min: (<RangeFilterObject>filterKeys).min,


### PR DESCRIPTION
this PR includes the following fixes for itemfilter inline mode:
- removing input text using backspace without deleting chips.
- removing input text on filter type selection.
- opening drop down on chip removal.
- commit text search using enter key.
- commit filter or reset filter choice using space bar.
- selecting checkbox of multiselect filter using enter key, after searching for the filter.