### PR TITLE
feat: allow rendering HTML in properties via config

### DIFF
--- a/elements/stacinfo/package.json
+++ b/elements/stacinfo/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "eslint --ext .js,.ts . --fix"
   },
   "dependencies": {
-    "@radiantearth/stac-fields": "^1.2.0",
+    "@radiantearth/stac-fields": "^1.3.2",
     "lit": "^3.0.2"
   }
 }

--- a/elements/stacinfo/src/main.ts
+++ b/elements/stacinfo/src/main.ts
@@ -6,7 +6,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { html as staticHTML, unsafeStatic } from "lit/static-html.js";
 import { style } from "./style";
 import { styleEOX } from "./style.eox";
-import StacFields from "@radiantearth/stac-fields";
+import StacFields, { Formatters } from "@radiantearth/stac-fields";
 import { STAC } from "stac-js";
 
 /**
@@ -29,6 +29,12 @@ import { STAC } from "stac-js";
  */
 @customElement("eox-stacinfo")
 export class EOxStacInfo extends LitElement {
+  /**
+   * Allow HTML rendering in properties (such as description)
+   */
+  @property({ attribute: "allow-html" })
+  allowHtml: boolean;
+
   @property({ type: Boolean })
   unstyled: boolean;
 
@@ -76,6 +82,8 @@ export class EOxStacInfo extends LitElement {
   };
 
   buildProperties(stacArray: Array<typeof STAC>) {
+    Formatters.allowHtmlInCommonMark = this.allowHtml !== undefined;
+
     const parseEntries = (list: Array<string>) =>
       Object.entries(this.stacProperties)
         .filter(([key]) => {

--- a/elements/stacinfo/test/general.cy.js
+++ b/elements/stacinfo/test/general.cy.js
@@ -57,4 +57,43 @@ describe("Stacinfo", () => {
         cy.get("#properties ul.single-property").should("exist");
       });
   });
+
+  it("doesn't render HTML if not enabled", () => {
+    testBody({
+      type: "Collection",
+      description: "<button>click me</button>",
+    });
+    cy.mount(
+      `
+      <eox-stacinfo
+        for="/collection"
+        properties='["description"]'
+      ></eox-stacinfo>`
+    ).as("eox-stacinfo");
+    cy.get("eox-stacinfo")
+      .shadow()
+      .within(() => {
+        cy.get("#properties button").should("not.exist");
+      });
+  });
+
+  it("renders HTML if enabled", () => {
+    testBody({
+      type: "Collection",
+      description: "<button>click me</button>",
+    });
+    cy.mount(
+      `
+      <eox-stacinfo
+        for="/collection"
+        allow-html
+        properties='["description"]'
+      ></eox-stacinfo>`
+    ).as("eox-stacinfo");
+    cy.get("eox-stacinfo")
+      .shadow()
+      .within(() => {
+        cy.get("#properties button").should("exist");
+      });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
       "name": "@eox/stacinfo",
       "version": "0.2.1",
       "dependencies": {
-        "@radiantearth/stac-fields": "^1.2.0",
+        "@radiantearth/stac-fields": "^1.3.2",
         "lit": "^3.0.2"
       },
       "devDependencies": {
@@ -3390,9 +3390,9 @@
       }
     },
     "node_modules/@radiantearth/stac-fields": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.3.1.tgz",
-      "integrity": "sha512-Lq5tazIY5DvyrtT73DZqzthkoO239cTULjX9+1L+RZe/Nos5N38sykP+UVMKb2ElDGnCIiKWWaJs7urFJfjAJQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.3.2.tgz",
+      "integrity": "sha512-KiQxY4LKX/kFg4qnZ5+gD0EKCoGyuYMku3vkVyPm6QYr5WuHbu3Hx2LBsu7ru2Cp67dYKluKNcDZfvCIkHmLIg==",
       "dependencies": {
         "@musement/iso-duration": "^1.0.0",
         "commonmark": "^0.29.3",


### PR DESCRIPTION
Using `allow-html` attribute or `allowHtml` property, rendering of HTML can be enabled.