### PR TITLE
chore: introduce node >20

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
 
     steps:
       - name: Checkout 🛎

--- a/.github/workflows/check_linting.yml
+++ b/.github/workflows/check_linting.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
 
     steps:
       - name: Checkout 🛎

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up NPM 🔧
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.releases_created }}
       - name: Install dependencies 🔧

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
 
     steps:
       - name: Checkout 🛎

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "storybook": "^7.4.6"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=20.9.0"
       }
     },
     "elements/chart": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "storybook": "^7.4.6"
   },
   "engines": {
-    "node": ">=18.16.0"
+    "node": ">=20.9.0"
   },
   "dependencies": {
     "eslint-plugin-cypress": "^2.14.0"


### PR DESCRIPTION
This PR introduces Node 20 for all CI pipelines, and sets the minimum required Node version for a `npm install` to `v20.9.0 (LTS)`.

It seems that all pipelines and scripts run normally, will do some more testing before merging.

https://nodejs.org/en/