### PR TITLE
Fix: Handle `tileUrlFunction()` use case for `layerConfig`

### DIFF
--- a/elements/layercontrol/layercontrol.stories.js
+++ b/elements/layercontrol/layercontrol.stories.js
@@ -382,12 +382,13 @@ export const LayerConfig = {
       zoom="4"
       id="config"
       style="width: 400px; height: 300px;"
-      layers=${JSON.stringify([
+      .layers=${[
         {
           type: "Tile",
           properties: {
             id: "customId",
             title: "Tile XYZ",
+            layerControlToolsExpand: true,
             layerConfig: {
               schema: {
                 type: "object",
@@ -421,9 +422,14 @@ export const LayerConfig = {
           source: {
             type: "XYZ",
             url: "https://reccap2.api.dev.brockmann-consult.de/api/tiles/cop28~reccap2-9x108x139-0.0.1.zarr/deforested_biomass/{z}/{y}/{x}?crs=EPSG:3857&time=2018-01-01T00:00:00Z&vmin=0&vmax=3&cbar=rain",
-            params: { LAYERS: "topp:states", TILED: true },
-            ratio: 1,
-            serverType: "geoserver",
+            // tileUrlFunction: (tileCoord) => {
+            //   const url =
+            //     "https://reccap2.api.dev.brockmann-consult.de/api/tiles/cop28~reccap2-9x108x139-0.0.1.zarr/deforested_biomass/{z}/{y}/{x}?crs=EPSG%3A3857&time=2018-01-01T00%3A00%3A00Z&vmin=0&vmax=3&cbar=rain";
+            //   return url
+            //     .replace("{z}", tileCoord[0])
+            //     .replace("{x}", tileCoord[1])
+            //     .replace("{y}", tileCoord[2]);
+            // },
           },
         },
         {
@@ -431,7 +437,7 @@ export const LayerConfig = {
           source: { type: "OSM" },
           properties: { title: "Base Map" },
         },
-      ])}
+      ]}
     >
     </eox-map>
   `,

--- a/elements/layercontrol/src/components/layerConfig.js
+++ b/elements/layercontrol/src/components/layerConfig.js
@@ -27,6 +27,12 @@ export class EOxLayerControlLayerConfig extends LitElement {
    */
   #startVals = null;
 
+  /**
+   * Original tile url function, if it exist
+   * @type {Function}
+   */
+  #originalTileUrlFunction;
+
   constructor() {
     super();
 
@@ -60,10 +66,23 @@ export class EOxLayerControlLayerConfig extends LitElement {
    */
   #handleDataChange(e) {
     this.#data = e.detail;
-    // @ts-ignore
-    const url = this.layer.getSource().getUrls()[0];
 
-    updateUrl(url, this.#data, this.layer);
+    if (this.layer.getSource().getTileUrlFunction()) {
+      if (!this.#originalTileUrlFunction)
+        this.#originalTileUrlFunction = this.layer
+          .getSource()
+          .getTileUrlFunction();
+
+      this.layer
+        .getSource()
+        .setTileUrlFunction((...args) =>
+          updateUrl(this.#originalTileUrlFunction(...args), this.#data, false)
+        );
+    }
+
+    if (this.layer.getSource().getUrls())
+      updateUrl(this.layer.getSource().getUrls()[0], this.#data, this.layer);
+
     this.requestUpdate();
   }
 

--- a/elements/layercontrol/src/components/layerConfig.js
+++ b/elements/layercontrol/src/components/layerConfig.js
@@ -76,12 +76,12 @@ export class EOxLayerControlLayerConfig extends LitElement {
       this.layer
         .getSource()
         .setTileUrlFunction((...args) =>
-          updateUrl(this.#originalTileUrlFunction(...args), this.#data, false)
+          updateUrl(this.#originalTileUrlFunction(...args), this.#data)
         );
-    }
 
-    if (this.layer.getSource().getUrls())
-      updateUrl(this.layer.getSource().getUrls()[0], this.#data, this.layer);
+      // TODO dont be accessing protected methods!
+      this.layer.getSource().setKey(new Date());
+    }
 
     this.requestUpdate();
   }

--- a/elements/layercontrol/src/helpers.js
+++ b/elements/layercontrol/src/helpers.js
@@ -165,7 +165,7 @@ export const isLayerVisibleBasedOnZoomState = (
  * Update layer's URL using input values
  * @param {String} url
  * @param {Object} values
- * @param {import("ol/layer").Layer} layer
+ * @param {import("ol/layer").Layer | false} layer
  */
 export function updateUrl(url, values, layer) {
   const searchParams = new URL(url).searchParams;
@@ -183,7 +183,9 @@ export function updateUrl(url, values, layer) {
   const newUrl = `${urlWithPath}?${searchParamsStr}`;
 
   // @ts-ignore
-  layer.getSource().setUrl(newUrl);
+  if (layer) layer.getSource().setUrl(newUrl);
+
+  return newUrl;
 }
 
 /**
@@ -220,6 +222,8 @@ export function getNestedStartVals(schema, queryParams) {
  * @param {{[key: string]: any}} layerConfig
  */
 export function getStartVals(layer, layerConfig) {
+  if (!layer.getSource().getUrls()) return null;
+
   const url = new URL(layer.getSource().getUrls()[0]);
   const queryParams = Object.fromEntries(url.searchParams.entries());
   const startVals = getNestedStartVals(

--- a/elements/layercontrol/src/helpers.js
+++ b/elements/layercontrol/src/helpers.js
@@ -167,7 +167,7 @@ export const isLayerVisibleBasedOnZoomState = (
  * @param {Object} values
  * @param {import("ol/layer").Layer | false} layer
  */
-export function updateUrl(url, values, layer) {
+export function updateUrl(url, values) {
   const searchParams = new URL(url).searchParams;
 
   Object.entries(values).forEach(([key, value]) => {
@@ -181,9 +181,6 @@ export function updateUrl(url, values, layer) {
   const urlWithPath = url.split("?")[0];
   const searchParamsStr = searchParams.toString();
   const newUrl = `${urlWithPath}?${searchParamsStr}`;
-
-  // @ts-ignore
-  if (layer) layer.getSource().setUrl(newUrl);
 
   return newUrl;
 }
@@ -222,9 +219,9 @@ export function getNestedStartVals(schema, queryParams) {
  * @param {{[key: string]: any}} layerConfig
  */
 export function getStartVals(layer, layerConfig) {
-  if (!layer.getSource().getUrls()) return null;
+  if (!layer.getSource().getTileUrlFunction()) return null;
 
-  const url = new URL(layer.getSource().getUrls()[0]);
+  const url = new URL(layer.getSource().getTileUrlFunction()([0, 0, 0]));
   const queryParams = Object.fromEntries(url.searchParams.entries());
   const startVals = getNestedStartVals(
     layerConfig.schema?.properties || layerConfig.schema,


### PR DESCRIPTION
### What is this PR about (Based on https://github.com/EOX-A/EOxElements/issues/450)

- original `tileUrlFunction()` is called and then update it using layerConfig's `updateUrl()`