### PR TITLE
feat: enable modify via property

### DIFF
--- a/elements/drawtools/drawtools.stories.js
+++ b/elements/drawtools/drawtools.stories.js
@@ -12,7 +12,6 @@ export const Primary = {
   args: {
     allowModify: false,
     multipleFeatures: false,
-  render: () => html` <eox-map
   },
   render: (args) => html` <eox-map
       id="primary"
@@ -25,8 +24,8 @@ export const Primary = {
       for="eox-map#primary"
       .allowModify=${args.allowModify}
       .multipleFeatures=${args.multipleFeatures}
-    <eox-drawtools for="eox-map#primary"></eox-drawtools>`,
-    ></eox-drawtools>`,
+    >
+    </eox-drawtools>`,
 };
 
 /**

--- a/elements/drawtools/drawtools.stories.js
+++ b/elements/drawtools/drawtools.stories.js
@@ -9,14 +9,24 @@ export default {
 };
 
 export const Primary = {
+  args: {
+    allowModify: false,
+    multipleFeatures: false,
   render: () => html` <eox-map
+  },
+  render: (args) => html` <eox-map
       id="primary"
       style="width: 400px; height: 300px;"
       layers='[
     {"type":"Tile","source":{"type":"OSM"}}
   ]'
     ></eox-map>
+    <eox-drawtools
+      for="eox-map#primary"
+      .allowModify=${args.allowModify}
+      .multipleFeatures=${args.multipleFeatures}
     <eox-drawtools for="eox-map#primary"></eox-drawtools>`,
+    ></eox-drawtools>`,
 };
 
 /**
@@ -32,6 +42,25 @@ export const MultiPolygon = {
     ]'
     ></eox-map>
     <eox-drawtools for="eox-map#multi" multiple-features></eox-drawtools>`,
+};
+
+/**
+ * By setting the `allow-modify` attribute or `allowModify` property,
+ * the user can modify features after drawing
+ */
+export const ModifyFeatures = {
+  render: () => html` <eox-map
+      id="modify"
+      style="width: 400px; height: 300px;"
+      layers='[
+      {"type":"Tile","source":{"type":"OSM"}}
+    ]'
+    ></eox-map>
+    <eox-drawtools
+      for="eox-map#modify"
+      multiple-features
+      allow-modify
+    ></eox-drawtools>`,
 };
 
 /**

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -10,6 +10,7 @@ import { styleEOX } from "./style.eox";
 export class EOxDrawTools extends LitElement {
   static get properties() {
     return {
+      allowModify: { attribute: "allow-modify", type: Boolean },
       for: { type: String },
       currentlyDrawing: { attribute: false, state: true, type: Boolean },
       draw: { attribute: false, state: true },
@@ -34,6 +35,11 @@ export class EOxDrawTools extends LitElement {
 
   constructor() {
     super();
+
+    /**
+     * Allow modifying the drawn feature(s)
+     */
+    this.allowModify = false;
 
     /**
      * The query selector for the map
@@ -118,7 +124,7 @@ export class EOxDrawTools extends LitElement {
                   active: false,
                   id: "drawInteraction",
                   type: "Polygon",
-                  modify: true,
+                  modify: this.allowModify,
                   stopClick: true,
                 },
               },


### PR DESCRIPTION
This PR adds the `allowModify` property, which allows to configure if the drawn feature(s) should be modifiable after drawing or not.