### PR TITLE
fix: loop through layers and remove/add via index

### DIFF
--- a/elements/layercontrol/test/_mockMap.js
+++ b/elements/layercontrol/test/_mockMap.js
@@ -91,6 +91,9 @@ class MockCollection {
       return undefined;
     }
   }
+  removeAt(index) {
+    this.layers = [...this.layers.slice(index)];
+  }
   insertAt(index, layer) {
     layer = new MockLayer(layer);
     this.layers = [


### PR DESCRIPTION
This method of looping through the layers and adding/removing based on index seems to do the trick. It was a bit finnicky with the index as we have our layers reversed, but it seems to work.

Tested:

- [x] Without hidden/optional layers
- [x] With hidden layer
- [x] Android/Chrome
- [x] iOS/Safari
- [x] Mac/Safari