### PR TITLE
fix: sorting with optional & hidden layers

### DIFF
--- a/elements/layercontrol/src/components/layerList.js
+++ b/elements/layercontrol/src/components/layerList.js
@@ -5,6 +5,7 @@ import { createSortable, getLayerType } from "../helpers";
 import "./layer";
 import "./layerGroup";
 import _debounce from "lodash.debounce";
+import { getUid } from "ol/util";
 /**
  * Display of a list of layers
  *
@@ -120,7 +121,7 @@ export class EOxLayerControlLayerList extends LitElement {
               (layer) => html`
                 <li
                   data-layer="${layer.get(this.idProperty)}"
-                  data-layer_uid="${layer.ol_uid}"
+                  data-layer_uid="${getUid(layer)}"
                   data-type="${getLayerType(layer, this.map)}"
                 >
                   ${

--- a/elements/layercontrol/src/components/layerList.js
+++ b/elements/layercontrol/src/components/layerList.js
@@ -1,11 +1,10 @@
 import { LitElement, html } from "lit";
 import { when } from "lit/directives/when.js";
 import { repeat } from "lit/directives/repeat.js";
-import { createSortable, getLayerType } from "../helpers";
+import { checkProperties, createSortable, getLayerType } from "../helpers";
 import "./layer";
 import "./layerGroup";
 import _debounce from "lodash.debounce";
-import { getUid } from "ol/util";
 /**
  * Display of a list of layers
  *
@@ -81,7 +80,13 @@ export class EOxLayerControlLayerList extends LitElement {
 
   firstUpdated() {
     if (this.layers) {
-      createSortable(this.renderRoot.querySelector("ul"), this.layers, this);
+      checkProperties(this.layers, this.idProperty, this.titleProperty);
+      createSortable(
+        this.renderRoot.querySelector("ul"),
+        this.layers,
+        this.idProperty,
+        this
+      );
     }
   }
 
@@ -121,7 +126,6 @@ export class EOxLayerControlLayerList extends LitElement {
               (layer) => html`
                 <li
                   data-layer="${layer.get(this.idProperty)}"
-                  data-layer_uid="${getUid(layer)}"
                   data-type="${getLayerType(layer, this.map)}"
                 >
                   ${

--- a/elements/layercontrol/src/components/layerList.js
+++ b/elements/layercontrol/src/components/layerList.js
@@ -120,6 +120,7 @@ export class EOxLayerControlLayerList extends LitElement {
               (layer) => html`
                 <li
                   data-layer="${layer.get(this.idProperty)}"
+                  data-layer_uid="${layer.ol_uid}"
                   data-type="${getLayerType(layer, this.map)}"
                 >
                   ${

--- a/elements/layercontrol/src/helpers.js
+++ b/elements/layercontrol/src/helpers.js
@@ -1,5 +1,4 @@
 import Sortable from "sortablejs";
-import { getUid } from "ol/util";
 
 /**
  *
@@ -94,10 +93,12 @@ export function checkProperties(collection, idProperty, titleProperty) {
   const layerArray = collection.getArray();
   layerArray.forEach((layer) => {
     if (!layer.get(idProperty)) {
-      layer.set(idProperty, getUid(layer));
+      //@ts-ignore
+      layer.set(idProperty, layer.ol_uid);
     }
     if (!layer.get(titleProperty)) {
-      layer.set(titleProperty, `layer ${getUid(layer)}`);
+      //@ts-ignore
+      layer.set(titleProperty, `layer ${layer.ol_uid}`);
     }
   });
 }

--- a/elements/layercontrol/src/helpers.js
+++ b/elements/layercontrol/src/helpers.js
@@ -5,9 +5,10 @@ import { getUid } from "ol/util";
  *
  * @param {HTMLElement} element
  * @param {import("ol").Collection<import("ol/layer").Layer | import("ol/layer").Group>} collection
+ * @param {string} idProperty
  * @param {import("lit").LitElement} that
  */
-export const createSortable = (element, collection, that) => {
+export const createSortable = (element, collection, idProperty, that) => {
   /**
    * @type {any[]}
    */
@@ -52,15 +53,13 @@ export const createSortable = (element, collection, that) => {
       const layers = collection.getArray();
       const layer = layers.find(
         (l) =>
-          getUid(l) ===
-          getUid(
-            /** @type Element & {layer: import("ol/layer").Layer} */ (
-              e.item.querySelector("eox-layercontrol-layer")
-            ).layer
-          )
+          l.get(idProperty) ===
+          /** @type Element & {layer: import("ol/layer").Layer} */ (
+            e.item.querySelector("eox-layercontrol-layer")
+          ).layer.get(idProperty)
       );
       const relatedLayer = layers.find(
-        (layer) => getUid(layer) == related.dataset.layer_uid
+        (layer) => layer.get(idProperty) == related.dataset.layer
       );
       let draggedIndex;
       let dropIndex;
@@ -82,6 +81,26 @@ export const createSortable = (element, collection, that) => {
   });
 };
 
+/**
+ * Initially check if all layers have an id and title,
+ * fill in some backup in case they haven't
+ *
+ * @param {import("ol").Collection<import("ol/layer").Layer | import("ol/layer").Group>} collection
+ * @param {string} idProperty
+ * @param {string} titleProperty
+ */
+//
+export function checkProperties(collection, idProperty, titleProperty) {
+  const layerArray = collection.getArray();
+  layerArray.forEach((layer) => {
+    if (!layer.get(idProperty)) {
+      layer.set(idProperty, getUid(layer));
+    }
+    if (!layer.get(titleProperty)) {
+      layer.set(titleProperty, `layer ${getUid(layer)}`);
+    }
+  });
+}
 /**
  * Filter all map layers by property
  *

--- a/elements/layercontrol/src/helpers.js
+++ b/elements/layercontrol/src/helpers.js
@@ -1,4 +1,5 @@
 import Sortable from "sortablejs";
+import { getUid } from "ol/util";
 
 /**
  *
@@ -51,15 +52,15 @@ export const createSortable = (element, collection, that) => {
       const layers = collection.getArray();
       const layer = layers.find(
         (l) =>
-          // @ts-ignore
-          l.ol_uid ===
-          /** @type Element & {layer: import("ol/layer").Layer} */ (
-            e.item.querySelector("eox-layercontrol-layer")
-            // @ts-ignore
-          ).layer.ol_uid
+          getUid(l) ===
+          getUid(
+            /** @type Element & {layer: import("ol/layer").Layer} */ (
+              e.item.querySelector("eox-layercontrol-layer")
+            ).layer
+          )
       );
       const relatedLayer = layers.find(
-        (layer) => layer.ol_uid == related.dataset.layer_uid
+        (layer) => getUid(layer) == related.dataset.layer_uid
       );
       let draggedIndex;
       let dropIndex;

--- a/elements/layercontrol/src/helpers.js
+++ b/elements/layercontrol/src/helpers.js
@@ -11,6 +11,10 @@ export const createSortable = (element, collection, that) => {
    * @type {any[]}
    */
   let childNodes = [];
+  /**
+   * @type {HTMLElement}
+   */
+  let related = null;
   /** @type HTMLElement & {_sortable: import("sortablejs")}*/ (
     element
   )._sortable = Sortable.create(element, {
@@ -30,6 +34,9 @@ export const createSortable = (element, collection, that) => {
           node.nodeType != Node.ELEMENT_NODE ||
           !node.classList.contains("sortable-fallback")
       );
+    },
+    onMove(e) {
+      related = e.related;
     },
     onEnd: (e) => {
       // Undo DOM changes by re-adding all children in their original order.
@@ -51,27 +58,19 @@ export const createSortable = (element, collection, that) => {
             // @ts-ignore
           ).layer.ol_uid
       );
-      const numberOfHiddenLayers = layers.filter(
-        (l) => l.get("layerControlHide") || l.get("layerControlOptional")
-      ).length;
-      const target =
-        layers[layers.length - 1 - e.newIndex - numberOfHiddenLayers];
+      const relatedLayer = layers.find(
+        (layer) => layer.ol_uid == related.dataset.layer_uid
+      );
       let draggedIndex;
       let dropIndex;
-      // remove dragged layer from collection
-      for (
-        draggedIndex = layers.length - 1;
-        draggedIndex > -1;
-        draggedIndex--
-      ) {
+      for (draggedIndex = 0; draggedIndex < layers.length; draggedIndex++) {
         if (layers[draggedIndex] == layer) {
           collection.removeAt(draggedIndex);
           break;
         }
       }
-      // re-add dragged layer at position of layer that has beend dropped on
-      for (dropIndex = layers.length - 1; dropIndex > -1; dropIndex--) {
-        if (layers[dropIndex] === target) {
+      for (dropIndex = 0; dropIndex < layers.length; dropIndex++) {
+        if (layers[dropIndex] === relatedLayer) {
           if (draggedIndex > dropIndex) collection.insertAt(dropIndex, layer);
           else collection.insertAt(dropIndex + 1, layer);
           break;


### PR DESCRIPTION
This solves the following issues for `eox-layercontrol-layer-list`:
1. sorting lists that contain layers that are not displayed.
2. sets `idProperty` & `titleProperty` if not assigned.