### PR TITLE
feat!: extract advanced layers & sources into separate bundle

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
   "plugins": ["cypress", "@typescript-eslint"],
   "root": true,
   "rules": {
-    "@typescript-eslint/ban-ts-comment": "warn"
+    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/no-explicit-any": "warn"
   }
 }

--- a/elements/map/README.md
+++ b/elements/map/README.md
@@ -16,19 +16,11 @@ import "@eox/map"
 <eox-map></eox-map>
 ```
 
-// TODO: add documentation
+Please refer to the [map docs](https://eox-a.github.io/EOxElements/?path=/docs/elements-eox-map--docs) for more details.
 
-## Contribute
+## Development
 
-```
-npm watch
-(on root) npm run cypress
-(on root) npm run format
-
-npm version <new version>
-npm run build
-npm publish (requires OTP)
-```
+For a development setup, please check the [root-level readme](../../README.md).
 
 ## Changelog
 

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -18,6 +18,34 @@ import {
 import { buffer } from "ol/extent";
 import "./src/compare";
 
+/**
+ * The `eox-map` is a wrapper for the library OpenLayers with additional features and helper functions.
+ *
+ * Basic usage:
+ *
+ * ```
+ * import "@eox/map"
+ *
+ * <eox-map [...]></eox-map>
+ * ```
+ *
+ * Some basic layers, sources and formats are included in the default bundle, for advanced usage it is
+ * required to import the `advanced-layers-and-sources` plugin.
+ *
+ * Included in the base bundle:
+ * - Formats: `GeoJSON`, `MVT`
+ * - Layers: `Group`, `Image`, `Tile`, `Vector`, `VectorTile`,
+ * - Sources: `ImageWMS`, `OSM`, `Tile`, `TileWMS`, `Vector`, `VectorTile`, `WMTS`, `XYZ`
+ *
+ * In order to use all formats, layers and sources provided by OpenLayers, import the plugin as well:
+ *
+ * ```
+ * import "@eox/map/dist/eox-map-advanced-layers-and-sources.js"
+ * import "@eox/map/dist/eox-map.js"
+ *
+ * <eox-map [...]></eox-map>
+ * ```
+ */
 @customElement("eox-map")
 export class EOxMap extends LitElement {
   /**

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -19,7 +19,7 @@ import { buffer } from "ol/extent";
 import "./src/compare";
 
 /**
- * The `eox-map` is a wrapper for the library OpenLayers with additional features and helper functions.
+ * The `eox-map` is a wrapper for the library [OpenLayers](https://openlayers.org/) with additional features and helper functions.
  *
  * Basic usage:
  *
@@ -34,10 +34,10 @@ import "./src/compare";
  *
  * Included in the base bundle:
  * - Formats: `GeoJSON`, `MVT`
- * - Layers: `Group`, `Image`, `Tile`, `Vector`, `VectorTile`,
+ * - Layers: `Group`, `Image`, `Tile`, `Vector`, `VectorTile`
  * - Sources: `ImageWMS`, `OSM`, `Tile`, `TileWMS`, `Vector`, `VectorTile`, `WMTS`, `XYZ`
  *
- * In order to use all formats, layers and sources provided by OpenLayers, import the plugin as well:
+ * In order to use the rest of the layers and sources provided by OpenLayers, import the plugin as well:
  *
  * ```
  * import "@eox/map/dist/eox-map-advanced-layers-and-sources.js"
@@ -45,6 +45,10 @@ import "./src/compare";
  *
  * <eox-map [...]></eox-map>
  * ```
+ * Included in the advanced plugin bundle:
+ * - Layers: All OpenLayers layer types, plus [STAC](https://github.com/m-mohr/ol-stac)
+ * - Sources: All OpenLayers source types
+ * - Reprojection through [proj4](https://github.com/proj4js/proj4js)
  */
 @customElement("eox-map")
 export class EOxMap extends LitElement {

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import "./src/plugins/advancedLayersAndSources/index";
 import "./main";
 
 export default {

--- a/elements/map/package.json
+++ b/elements/map/package.json
@@ -27,8 +27,8 @@
   ],
   "main": "./dist/eox-map.js",
   "scripts": {
-    "build": "tsc && vite build",
-    "watch": "tsc && vite build --watch",
+    "build": "tsc && vite build --config vite.config.advancedLayersAndSources.ts && vite build --config vite.config.ts",
+    "watch": "tsc && vite build --config vite.config.advancedLayersAndSources.ts && vite build --config vite.config.ts --watch",
     "format": "prettier --write .",
     "lint": "eslint --ext .js,.ts .",
     "lint:fix": "eslint --ext .js,.ts . --fix"

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -147,7 +147,7 @@ export function createLayer(
   if (!newLayer) {
     if (!window.eoxMapAdvancedOlLayers) {
       throw new Error(
-        `Layer type ${layer.type} not created! Forgot to import advanced layers & sources plugin?`
+        `Layer type ${layer.type} not created! Forgot to import advanced layers & sources plugin from @eox/map/dist/eox-map-advanced-layers-and-sources.js?`
       );
     } else {
       throw new Error(`Layer type ${layer.type} not supported!`);
@@ -156,7 +156,7 @@ export function createLayer(
   if (layer.source && !newSource) {
     if (!window.eoxMapAdvancedOlSources) {
       throw new Error(
-        `Source type ${layer.source.type} not created! Forgot to import advanced layers & sources plugin?`
+        `Source type ${layer.source.type} not created! Forgot to import advanced layers & sources plugin from @eox/map/dist/eox-map-advanced-layers-and-sources.js?`
       );
     } else {
       throw new Error(`Source type ${layer.source.type} not supported!`);

--- a/elements/map/src/plugins/advancedLayersAndSources/formats.ts
+++ b/elements/map/src/plugins/advancedLayersAndSources/formats.ts
@@ -1,0 +1,3 @@
+import * as olFormats from "ol/format";
+
+window.eoxMapAdvancedOlFormats = olFormats;

--- a/elements/map/src/plugins/advancedLayersAndSources/index.ts
+++ b/elements/map/src/plugins/advancedLayersAndSources/index.ts
@@ -1,0 +1,3 @@
+import "./formats";
+import "./layers";
+import "./sources";

--- a/elements/map/src/plugins/advancedLayersAndSources/layers.ts
+++ b/elements/map/src/plugins/advancedLayersAndSources/layers.ts
@@ -1,0 +1,11 @@
+import * as olLayers from "ol/layer";
+import STAC from "ol-stac";
+import { register } from "ol/proj/proj4.js";
+import proj4 from "proj4";
+
+register(proj4); // required to support source reprojection
+
+window.eoxMapAdvancedOlLayers = {
+  ...olLayers,
+  STAC,
+};

--- a/elements/map/src/plugins/advancedLayersAndSources/sources.ts
+++ b/elements/map/src/plugins/advancedLayersAndSources/sources.ts
@@ -1,0 +1,3 @@
+import * as olSources from "ol/source";
+
+window.eoxMapAdvancedOlSources = olSources;

--- a/elements/map/test/stacLayer.cy.ts
+++ b/elements/map/test/stacLayer.cy.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import "../src/plugins/advancedLayersAndSources/index";
 import "../main";
 import stacLayerJson from "./stacLayer.json";
 

--- a/elements/map/typings.d.ts
+++ b/elements/map/typings.d.ts
@@ -5,3 +5,11 @@ declare global {
 
 declare module "*.css";
 declare module "vite";
+
+declare global {
+  interface Window {
+    eoxMapAdvancedOlFormats: any;
+    eoxMapAdvancedOlLayers: any;
+    eoxMapAdvancedOlSources: any;
+  }
+}

--- a/elements/map/vite.config.advancedLayersAndSources.ts
+++ b/elements/map/vite.config.advancedLayersAndSources.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    emptyOutDir: false,
     lib: {
       entry: "./src/plugins/advancedLayersAndSources/index.ts",
       name: "eox-map-advanced-layers-and-sources",

--- a/elements/map/vite.config.advancedLayersAndSources.ts
+++ b/elements/map/vite.config.advancedLayersAndSources.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: "./src/plugins/advancedLayersAndSources/index.ts",
+      name: "eox-map-advanced-layers-and-sources",
+      // the proper extensions will be added
+      fileName: "eox-map-advanced-layers-and-sources",
+    },
+  },
+});

--- a/elements/map/vite.config.ts
+++ b/elements/map/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
+    emptyOutDir: false,
     lib: {
       entry: "./main.ts",
       name: "eox-map",


### PR DESCRIPTION
This PR splits up OpenLayers `formats`, `layers` and `sources` to include only the most basic ones, while advanced ones can be added as a separate plugin. This is in order to reduce the bundle size for the most common use cases.

## Before
![image](https://github.com/EOX-A/EOxElements/assets/26576876/43cdefc7-ee1a-4f79-aa2a-17ec2c1007c7)
![image](https://github.com/EOX-A/EOxElements/assets/26576876/e3da3105-42db-4b39-9896-aed480708adb)

## After
![image](https://github.com/EOX-A/EOxElements/assets/26576876/dd57bec1-7387-46bb-881b-0ac63686db9e)
![image](https://github.com/EOX-A/EOxElements/assets/26576876/4ea7866d-4804-4396-8759-f9eb883a35a1)

Included in the base bundle:
- Formats: `GeoJSON`, `MVT`
- Layers: `Group`, `Image`, `Tile`, `Vector`, `VectorTile`,
- Sources: `ImageWMS`, `OSM`, `Tile`, `TileWMS`, `Vector`, `VectorTile`, `WMTS`, `XYZ`

## Usage
In order to use all formats, layers and sources provided by OpenLayers, import the plugin as well:
```
import "@eox/map/dist/eox-map-advanced-layers-and-sources.js"
import "@eox/map/dist/eox-map.js"
<eox-map [... GeoTIFF sources, STAC layers etc ...]></eox-map>
```

If the developer forgets to import the bundle but tries to use an advanced format, layer or source, a console error is thrown:
![image](https://github.com/EOX-A/EOxElements/assets/26576876/c973ba07-95dc-4203-a848-49d8158f0dde)


Closes #495