### PR TITLE
feat: introduce config object

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -18,6 +18,14 @@ import {
 import { buffer } from "ol/extent";
 import "./src/compare";
 
+type ConfigObject = {
+  controls: controlDictionary;
+  layers: Array<EoxLayer>;
+  view: {
+    center: Array<number>;
+    zoom: number;
+  };
+};
 @customElement("eox-map")
 export class EOxMap extends LitElement {
   /**
@@ -104,6 +112,25 @@ export class EOxMap extends LitElement {
   @property({ type: Array })
   get layers() {
     return this._layers;
+  }
+
+  private _config: ConfigObject;
+
+  set config(config: ConfigObject) {
+    this._config = config;
+    this.center = config.view?.center;
+    this.zoom = config?.view.zoom;
+    this.layers = config?.layers;
+    this.controls = config?.controls;
+  }
+
+  /**
+   * Config object, including `controls`, `layers` and `view`.
+   * Alternative way of defining the map config.
+   */
+  @property({ attribute: false, type: Object })
+  get config() {
+    return this._config;
   }
 
   /**

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -354,3 +354,25 @@ export const ABCompare = {
       </eox-map-compare>
     `,
 };
+
+export const ConfigObject = {
+  args: {
+    config: {
+      controls: {
+        Zoom: {},
+      },
+      layers: [{ type: "Tile", source: { type: "OSM" } }],
+      view: {
+        center: [16.8, 48.2],
+        zoom: 9,
+      },
+    },
+  },
+  render: (args) =>
+    html`
+      <eox-map
+        style="width: 100%; height: 300px;"
+        .config=${args.config}
+      ></eox-map>
+    `,
+};

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -13,7 +13,7 @@ describe("config property", () => {
           layers: [
             {
               type: "Tile",
-              properties: { id: "osm" },
+              properties: { id: "osm", title: "foo" },
               source: { type: "OSM" },
             },
           ],
@@ -38,6 +38,32 @@ describe("config property", () => {
       ]);
 
       expect(eoxMap.map.getView().getZoom()).to.be.equal(9);
+    });
+    cy.get("eox-map").and(async ($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      eoxMap.config = {
+        controls: {},
+        layers: [
+          {
+            type: "Tile",
+            // @ts-ignore
+            properties: { id: "osm", title: "bar" },
+            source: { type: "OSM" },
+          },
+        ],
+        view: {
+          center: [1113194, 2273030],
+          zoom: 10,
+        },
+      };
+
+      expect(eoxMap.map.getView().getZoom()).to.be.equal(10);
+      expect(eoxMap.map.getControls().getLength()).to.be.equal(0);
+      expect(eoxMap.map.getLayers().getArray().length).to.be.equal(1);
+      expect(eoxMap.map.getLayers().getArray()[0].get("title")).to.be.equal(
+        "bar"
+      );
     });
   });
 });

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -1,0 +1,43 @@
+import { html } from "lit";
+import "../main";
+
+describe("config property", () => {
+  it("sets controls, layers and view using the config object", () => {
+    cy.intercept(/^.*openstreetmap.*$/, { fixture: "/tiles/osm/0/0/0.png" });
+    cy.mount(
+      html`<eox-map
+        .config=${{
+          controls: {
+            Zoom: {},
+          },
+          layers: [
+            {
+              type: "Tile",
+              properties: { id: "osm" },
+              source: { type: "OSM" },
+            },
+          ],
+          view: {
+            center: [1113194, 2273030],
+            zoom: 9,
+          },
+        }}
+      ></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(async ($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      expect(eoxMap.map.getControls().getLength()).to.be.equal(1);
+
+      expect(eoxMap.map.getLayers().getArray().length).to.be.equal(1);
+
+      expect(eoxMap.map.getLayers().getArray()[0].get("id")).to.be.equal("osm");
+
+      expect(eoxMap.map.getView().getCenter()).to.deep.equal([
+        1113194, 2273030,
+      ]);
+
+      expect(eoxMap.map.getView().getZoom()).to.be.equal(9);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `config` property which is an alternative/short hand to define the map `controls`, `layers` and `view`. It is handy if the `eox-map` is used with vanilla JS or if an entire map config is to be fetched e.g. from an API or local storage.

## Usage
```
<eox-map
  .config=${{
    controls: {
      Zoom: {},
    },
    layers: [{ type: "Tile", source: { type: "OSM" } }],
    view: {
      center: [16.8, 48.2],
      zoom: 9,
    },
  }}
></eox-map>
```

This is the same as if using this:
```
<eox-map
  .controls=${{
      Zoom: {},
  }}
  .layers=${[{ type: "Tile", source: { type: "OSM" } }]}
  .center=${[16.8, 48.2]}
  .zoom=${9}
></eox-map>
```

Closes #284.