### PR TITLE
Fix: Remove interaction check from `drawtools`

### DIFF
--- a/elements/drawtools/src/methods/draw/init-draw-layer.js
+++ b/elements/drawtools/src/methods/draw/init-draw-layer.js
@@ -23,49 +23,43 @@ const initDrawLayerMethod = (EoxDrawTool) => {
     source: {
       type: "Vector",
     },
-    // check if the drawInteraction has already been added before adding again
-    // TEMP/TODO: this should probably be done by the map in the addOrUpdateLayer method
-    ...(EoxMap.interactions["drawInteraction"]
-      ? {}
-      : {
-          interactions: [
-            {
-              type: "draw",
-              options: {
-                active: false,
-                id: "drawInteraction",
-                type: EoxDrawTool.type,
-                modify: EoxDrawTool.allowModify,
-                stopClick: true,
-              },
-            },
-            {
-              type: "select",
-              options: {
-                id: "selectHover",
-                condition: "pointermove",
-                style: {
-                  "fill-color": "rgba(51, 153, 204,0.5)",
-                  "stroke-color": "#3399CC",
-                  "stroke-width": 2.5,
-                },
-              },
-            },
-            {
-              type: "select",
-              options: {
-                id: "selectClick",
-                condition: "click",
-                panIn: true,
-                style: {
-                  "fill-color": "rgba(51, 153, 204,0.5)",
-                  "stroke-color": "#3399CC",
-                  "stroke-width": 2.5,
-                },
-              },
-            },
-          ],
-        }),
+    interactions: [
+      {
+        type: "draw",
+        options: {
+          active: false,
+          id: "drawInteraction",
+          type: EoxDrawTool.type,
+          modify: EoxDrawTool.allowModify,
+          stopClick: true,
+        },
+      },
+      {
+        type: "select",
+        options: {
+          id: "selectHover",
+          condition: "pointermove",
+          style: {
+            "fill-color": "rgba(51, 153, 204,0.5)",
+            "stroke-color": "#3399CC",
+            "stroke-width": 2.5,
+          },
+        },
+      },
+      {
+        type: "select",
+        options: {
+          id: "selectClick",
+          condition: "click",
+          panIn: true,
+          style: {
+            "fill-color": "rgba(51, 153, 204,0.5)",
+            "stroke-color": "#3399CC",
+            "stroke-width": 2.5,
+          },
+        },
+      },
+    ],
   });
 
   EoxDrawTool.draw = /** @type {import("ol/interaction").Draw} */ (


### PR DESCRIPTION
### Purpose of this Pull Request

- The interaction check, previously included within `init-draw-layer.js`, has been implemented inside `addOrUpdateLayer()` through PR #476. Consequently, to prevent duplicate checks, we should eliminate the corresponding check from `init-draw-layer.js`. Failing to do so will result in an error due to redundant validation.

<img width="529" alt="image" src="https://github.com/EOX-A/EOxElements/assets/10809211/f5724b47-b62e-4c2a-aa0c-39092c564e58">

