### PR TITLE
chore: move definition of available formats, layers and sources into function

### DIFF
--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -90,21 +90,6 @@ const basicOlSources = {
   XYZ,
 };
 
-const availableFormats = {
-  ...basicOlFormats,
-  ...window.eoxMapAdvancedOlFormats,
-};
-
-const availableLayers = {
-  ...basicOlLayers,
-  ...window.eoxMapAdvancedOlLayers,
-};
-
-const availableSources = {
-  ...basicOlSources,
-  ...window.eoxMapAdvancedOlSources,
-};
-
 export type EOxInteraction = {
   type: "draw" | "select";
   options: DrawOptions | SelectOptions;
@@ -141,6 +126,21 @@ export function createLayer(
   createInteractions: boolean = true
 ): Layer {
   layer = JSON.parse(JSON.stringify(layer));
+
+  const availableFormats = {
+    ...basicOlFormats,
+    ...window.eoxMapAdvancedOlFormats,
+  };
+
+  const availableLayers = {
+    ...basicOlLayers,
+    ...window.eoxMapAdvancedOlLayers,
+  };
+
+  const availableSources = {
+    ...basicOlSources,
+    ...window.eoxMapAdvancedOlSources,
+  };
 
   const newLayer = availableLayers[layer.type];
   const newSource = availableSources[layer.source?.type];


### PR DESCRIPTION
This moves the definitions into the `createLayer` function, in order to avoid race conditions where `window.eoxMapAdvancedOlLayers` etc. are undefined at execution.