### PR TITLE
Fix: Itemfilter StyleOverride access to selectionlist

### DIFF
--- a/elements/itemfilter/src/filters/multiselect.ts
+++ b/elements/itemfilter/src/filters/multiselect.ts
@@ -87,7 +87,7 @@ export class EOxItemFilterMultiselect extends LitElement {
           `,
           () => html`
             <eox-selectionlist
-              ?noShadow=${!this.inline}
+              .noShadow=${!this.inline}
               multiple
               .items=${this._getItems()}
               .selectedItems=${this._getSelectedItems()}

--- a/elements/itemfilter/src/filters/multiselect.ts
+++ b/elements/itemfilter/src/filters/multiselect.ts
@@ -87,6 +87,7 @@ export class EOxItemFilterMultiselect extends LitElement {
           `,
           () => html`
             <eox-selectionlist
+              ?no-shadow=${!this.inline}
               multiple
               .items=${this._getItems()}
               .selectedItems=${this._getSelectedItems()}

--- a/elements/itemfilter/src/filters/multiselect.ts
+++ b/elements/itemfilter/src/filters/multiselect.ts
@@ -87,7 +87,7 @@ export class EOxItemFilterMultiselect extends LitElement {
           `,
           () => html`
             <eox-selectionlist
-              ?no-shadow=${!this.inline}
+              ?noShadow=${!this.inline}
               multiple
               .items=${this._getItems()}
               .selectedItems=${this._getSelectedItems()}

--- a/elements/itemfilter/src/filters/select.ts
+++ b/elements/itemfilter/src/filters/select.ts
@@ -87,6 +87,7 @@ export class EOxItemFilterSelect extends LitElement {
           `,
           () => html`
             <eox-selectionlist
+              ?no-shadow=${!this.inline}
               .items=${this._getItems()}
               .selectedItems=${this._getSelectedItems()}
               .unstyled=${this.unstyled}

--- a/elements/itemfilter/src/filters/select.ts
+++ b/elements/itemfilter/src/filters/select.ts
@@ -87,7 +87,7 @@ export class EOxItemFilterSelect extends LitElement {
           `,
           () => html`
             <eox-selectionlist
-              ?no-shadow=${!this.inline}
+              ?noShadow=${!this.inline}
               .items=${this._getItems()}
               .selectedItems=${this._getSelectedItems()}
               .unstyled=${this.unstyled}

--- a/elements/itemfilter/src/filters/select.ts
+++ b/elements/itemfilter/src/filters/select.ts
@@ -87,7 +87,7 @@ export class EOxItemFilterSelect extends LitElement {
           `,
           () => html`
             <eox-selectionlist
-              ?noShadow=${!this.inline}
+              .noShadow=${!this.inline}
               .items=${this._getItems()}
               .selectedItems=${this._getSelectedItems()}
               .unstyled=${this.unstyled}

--- a/elements/itemfilter/src/selectionlist.ts
+++ b/elements/itemfilter/src/selectionlist.ts
@@ -27,7 +27,7 @@ export class EOxSelectionlist extends LitElement {
   @property({ type: Boolean })
   unstyled = false;
 
-  @property({ attribute: "no-shadow", type: Boolean })
+  @property({ type: Boolean })
   noShadow = false;
 
   @state()

--- a/elements/itemfilter/src/selectionlist.ts
+++ b/elements/itemfilter/src/selectionlist.ts
@@ -27,6 +27,9 @@ export class EOxSelectionlist extends LitElement {
   @property({ type: Boolean })
   unstyled = false;
 
+  @property({ attribute: "no-shadow", type: Boolean })
+  noShadow = false;
+
   @state()
   _currentHighlight: FilterObject = null;
 
@@ -151,6 +154,10 @@ export class EOxSelectionlist extends LitElement {
         this._currentHighlight = null;
       }
     }
+  }
+
+  protected createRenderRoot() {
+    return this.noShadow ? this : super.createRenderRoot();
   }
 
   render() {

--- a/elements/itemfilter/test/general.cy.ts
+++ b/elements/itemfilter/test/general.cy.ts
@@ -88,7 +88,6 @@ describe("Item Filter Config", () => {
       .shadow()
       .within(() => {
         cy.get("eox-selectionlist")
-          .shadow()
           .within(() => {
             cy.get('[type="checkbox"]').first().check();
             cy.get('[type="checkbox"]').eq(1).check();

--- a/elements/itemfilter/test/general.cy.ts
+++ b/elements/itemfilter/test/general.cy.ts
@@ -87,15 +87,14 @@ describe("Item Filter Config", () => {
     cy.get("eox-itemfilter")
       .shadow()
       .within(() => {
-        cy.get("eox-selectionlist")
-          .within(() => {
-            cy.get('[type="checkbox"]').first().check();
-            cy.get('[type="checkbox"]').eq(1).check();
-            cy.get('[type="checkbox"]').first().check();
-            cy.get('[type="checkbox"]').first().should("be.checked");
-            cy.get('[type="checkbox"]').eq(1).check();
-            cy.get('[type="checkbox"]').eq(1).should("be.checked");
-          });
+        cy.get("eox-selectionlist").within(() => {
+          cy.get('[type="checkbox"]').first().check();
+          cy.get('[type="checkbox"]').eq(1).check();
+          cy.get('[type="checkbox"]').first().check();
+          cy.get('[type="checkbox"]').first().should("be.checked");
+          cy.get('[type="checkbox"]').eq(1).check();
+          cy.get('[type="checkbox"]').eq(1).should("be.checked");
+        });
       });
   });
 

--- a/elements/itemfilter/test/state.cy.ts
+++ b/elements/itemfilter/test/state.cy.ts
@@ -42,10 +42,9 @@ describe("Item Filter Config", () => {
     cy.get("eox-itemfilter")
       .shadow()
       .within(() => {
-        cy.get("eox-selectionlist")
-          .within(() => {
-            cy.get('[type="checkbox"]:checked').should("have.length", 2);
-          });
+        cy.get("eox-selectionlist").within(() => {
+          cy.get('[type="checkbox"]:checked').should("have.length", 2);
+        });
       });
   });
 
@@ -85,15 +84,14 @@ describe("Item Filter Config", () => {
     cy.get("eox-itemfilter")
       .shadow()
       .within(() => {
-        cy.get("eox-itemfilter-multiselect > eox-selectionlist")
-          .within(() => {
-            Object.keys(customOrder).forEach((state) => {
-              cy.get("ul [data-identifier]")
-                .eq(customOrder[state])
-                .invoke("attr", "data-identifier")
-                .should("eq", state);
-            });
+        cy.get("eox-itemfilter-multiselect > eox-selectionlist").within(() => {
+          Object.keys(customOrder).forEach((state) => {
+            cy.get("ul [data-identifier]")
+              .eq(customOrder[state])
+              .invoke("attr", "data-identifier")
+              .should("eq", state);
           });
+        });
       });
   });
 });

--- a/elements/itemfilter/test/state.cy.ts
+++ b/elements/itemfilter/test/state.cy.ts
@@ -43,7 +43,6 @@ describe("Item Filter Config", () => {
       .shadow()
       .within(() => {
         cy.get("eox-selectionlist")
-          .shadow()
           .within(() => {
             cy.get('[type="checkbox"]:checked').should("have.length", 2);
           });
@@ -87,7 +86,6 @@ describe("Item Filter Config", () => {
       .shadow()
       .within(() => {
         cy.get("eox-itemfilter-multiselect > eox-selectionlist")
-          .shadow()
           .within(() => {
             Object.keys(customOrder).forEach((state) => {
               cy.get("ul [data-identifier]")


### PR DESCRIPTION
Introducing `noShadow` property in `eox-selectionlist` that enables it's rendering without a shadow root and giving access for `styleOverride` property of the `eox-itemfilter` to reach `eox-selectionlist` in primary (not inline) mode.