### PR TITLE
Fix: Build fail due to async call

### DIFF
--- a/elements/layercontrol/test/layersUpdate.cy.js
+++ b/elements/layercontrol/test/layersUpdate.cy.js
@@ -272,7 +272,10 @@ describe("LayerControl", () => {
           cy.get(".add-icon").click();
           cy.get(".eox-add").should("have.class", "open");
           cy.get(".add-url").type("https://ows.mundialis.de/services/service");
-          cy.get(".search-icon").click();
+
+          cy.get(".search-icon").as("apibtn").click();
+          cy.get("@apibtn").should("not.be.disabled");
+
           cy.get(".add-layer-icon").first().click();
           cy.get(".search-list")
             .first()

--- a/elements/layercontrol/test/layersUpdate.cy.js
+++ b/elements/layercontrol/test/layersUpdate.cy.js
@@ -272,10 +272,8 @@ describe("LayerControl", () => {
           cy.get(".add-icon").click();
           cy.get(".eox-add").should("have.class", "open");
           cy.get(".add-url").type("https://ows.mundialis.de/services/service");
-
           cy.get(".search-icon").as("apibtn").click();
           cy.get("@apibtn").should("not.be.disabled");
-
           cy.get(".add-layer-icon").first().click();
           cy.get(".search-list")
             .first()


### PR DESCRIPTION
## What does this PR Fix 

```bash
Add new external WMS/XYZ and JSON Layer - addExternalLayers:

CypressError: Timed out retrying after 4000ms: `cy.find()` failed because the page updated as a result of this command, but you tried to continue the command chain. The subject is no longer attached to the DOM, and Cypress cannot requery the page after commands such as `cy.find()`.
```

### Common situations why this happens:
  - Your JS framework re-rendered asynchronously
  - Your app code reacted to an event firing and removed the element

### Solved this by breaking up a chain -

```js
cy.get(".search-icon").click();
cy.get(".add-layer-icon").first().click();
```

to (by adding ref - `@apibtn` to the async API button)

```js
cy.get(".search-icon").as("apibtn").click();
cy.get("@apibtn").should("not.be.disabled");
cy.get(".add-layer-icon").first().click();
```

#### Solution from Github Action Log - 
<img width="671" alt="image" src="https://github.com/EOX-A/EOxElements/assets/10809211/56f2a361-4b0b-4515-9ba9-634b0b93da61">
