### PR TITLE
chore: initialize noShadow as false by default

### DIFF
--- a/elements/layercontrol/src/components/addLayers.js
+++ b/elements/layercontrol/src/components/addLayers.js
@@ -70,7 +70,7 @@ export class EOxLayerControlAddLayers extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
   }
 
   /**

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -68,7 +68,7 @@ export class EOxLayerControlLayer extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
   }
 
   /**

--- a/elements/layercontrol/src/components/layerConfig.js
+++ b/elements/layercontrol/src/components/layerConfig.js
@@ -51,7 +51,7 @@ export class EOxLayerControlLayerConfig extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
 
     /**
      * Layer config for eox-jsonform

--- a/elements/layercontrol/src/components/layerGroup.js
+++ b/elements/layercontrol/src/components/layerGroup.js
@@ -65,7 +65,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
   }
 
   createRenderRoot() {

--- a/elements/layercontrol/src/components/layerList.js
+++ b/elements/layercontrol/src/components/layerList.js
@@ -67,7 +67,7 @@ export class EOxLayerControlLayerList extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
   }
 
   #handleLayersChangeLength = () => {

--- a/elements/layercontrol/src/components/layerTools.js
+++ b/elements/layercontrol/src/components/layerTools.js
@@ -46,7 +46,7 @@ export class EOxLayerControlLayerTools extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
   }
 
   /**

--- a/elements/layercontrol/src/components/optionalList.js
+++ b/elements/layercontrol/src/components/optionalList.js
@@ -38,7 +38,7 @@ export class EOxLayerControlOptionalList extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
   }
 
   createRenderRoot() {

--- a/elements/layercontrol/src/components/tabs.js
+++ b/elements/layercontrol/src/components/tabs.js
@@ -36,7 +36,7 @@ export class EOxLayerControlTabs extends LitElement {
     /**
      * Renders the element without a shadow root
      */
-    this.noShadow = true;
+    this.noShadow = false;
   }
 
   createRenderRoot() {


### PR DESCRIPTION
This PR sets all `noShadow` property setups to use `false` as default value. The reasoning is as follows: By default, the sub-components shall have a shadow root, so they can be easily used as standalone components in other circumstances. Just in the case of being integrated into the layercontrol, we want to override this and set `noShadow`  to true, skipping the shadow root creation. This enables an easier way to access deeply nested DOM elements for easier styling etc.