### PR TITLE
feat: pass selection feature as second argument

### DIFF
--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -201,7 +201,7 @@ export const Controls = {
   },
 };
 
-export const Hover = {
+export const HoverSelect = {
   args: {
     layers: [
       {
@@ -236,21 +236,9 @@ export const Hover = {
       },
     ],
   },
-  render: (args) =>
-    html`
-      <eox-map
-        style="width: 100%; height: 300px;"
-        .center=${args.center}
-        .controls=${args.controls}
-        .layers=${args.layers}
-        .zoom=${args.zoom}
-      >
-        <eox-map-tooltip></eox-map-tooltip>
-      </eox-map>
-    `,
 };
 
-export const Select = {
+export const ClickSelect = {
   args: {
     layers: [
       {
@@ -286,6 +274,122 @@ export const Select = {
       },
     ],
   },
+};
+
+/**
+ * `eox-map` offers a built-in tooltip, which needs to be placed inside the default slot:
+ * ```
+ * <eox-map [...]>
+ *   <eox-map-tooltip></eox-map-tooltip>
+ * </eox-map>
+ * ```
+ * This renders a list of all feature properties of the currently selected feature.
+ * Note that if multiple interactions are registered (e.g. `pointermove` and `singleclick`),
+ * only the first one will trigger the tooltip.
+ */
+export const Tooltip = {
+  args: {
+    layers: [
+      {
+        type: "Vector",
+        source: {
+          type: "Vector",
+          url: "https://openlayers.org/data/vector/ecoregions.json",
+          format: "GeoJSON",
+        },
+        interactions: [
+          {
+            type: "select",
+            options: {
+              id: "selectInteraction",
+              condition: "pointermove",
+              style: {
+                "stroke-color": "red",
+                "stroke-width": 3,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  render: (args) =>
+    html`
+      <eox-map
+        id="tooltipTest"
+        style="width: 100%; height: 300px;"
+        .center=${args.center}
+        .controls=${args.controls}
+        .layers=${args.layers}
+        .zoom=${args.zoom}
+      >
+        <eox-map-tooltip></eox-map-tooltip>
+      </eox-map>
+    `,
+};
+
+/**
+ * The rendering of feature properties inside the tooltip can be transformed
+ * by passing a `propertyTransform` function to the tooltip element which applies to each property in the rendering loop:
+ * ```
+ * <eox-map [...]>
+ *   <eox-map-tooltip
+ *     .propertyTransform=${({key, value}, feature) => key.includes("COLOR") ? { key: key.toLowerCase(), value }}
+ *   ></eox-map-tooltip>
+ * </eox-map>
+ * ```
+ *
+ * The first argument are `key` and `value` of the current feature property; this object needs to be
+ * returned in order to render the property in the list.
+ * Additionally, the entire feature is passed as a second argument, for cases of more advanced property
+ * transformation in which needs access to the entire feature.
+ */
+export const TooltipWithPropertyTransform = {
+  args: {
+    layers: [
+      {
+        type: "Vector",
+        source: {
+          type: "Vector",
+          url: "https://openlayers.org/data/vector/ecoregions.json",
+          format: "GeoJSON",
+        },
+        interactions: [
+          {
+            type: "select",
+            options: {
+              id: "selectInteraction",
+              condition: "pointermove",
+              style: {
+                "stroke-color": "red",
+                "stroke-width": 3,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  render: (args) =>
+    html`
+      <eox-map
+        id="tooltipTest"
+        style="width: 100%; height: 300px;"
+        .center=${args.center}
+        .controls=${args.controls}
+        .layers=${args.layers}
+        .zoom=${args.zoom}
+      >
+        <eox-map-tooltip
+          .propertyTransform=${({ key, value }, hoverFeature) => {
+            console.log(hoverFeature);
+            if (key.includes("COLOR")) {
+              return { key: key.toLowerCase(), value };
+            }
+          }}
+        ></eox-map-tooltip>
+      </eox-map>
+    `,
 };
 
 export const MapSync = {

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -164,9 +164,7 @@ export class EOxSelectInteraction {
             overlay.setPositioning(`${yPosition}-${xPosition}`);
             overlay.setPosition(feature ? event.coordinate : null);
             if (feature && (<EOxMapTooltip>this.tooltip).renderContent) {
-              (<EOxMapTooltip>this.tooltip).renderContent(
-                feature.getProperties()
-              );
+              (<EOxMapTooltip>this.tooltip).renderContent(feature);
             }
           }
 

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -1,6 +1,7 @@
 import { html, render } from "lit";
 import { property } from "lit/decorators.js";
 import Feature from "ol/Feature";
+import RenderFeature from "ol/render/Feature";
 import { TemplateElement } from "../../../utils/templateElement";
 
 export class EOxMapTooltip extends TemplateElement {
@@ -15,10 +16,11 @@ export class EOxMapTooltip extends TemplateElement {
   @property()
   propertyTransform = (
     property: { key: string; value: unknown },
-    _feature: Feature
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _feature: Feature | RenderFeature
   ) => property;
 
-  renderContent(feature: Feature) {
+  renderContent(feature: Feature | RenderFeature) {
     render(
       this.hasTemplate("properties")
         ? html`${this.renderTemplate(

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -1,21 +1,29 @@
 import { html, render } from "lit";
 import { property } from "lit/decorators.js";
+import Feature from "ol/Feature";
 import { TemplateElement } from "../../../utils/templateElement";
 
 export class EOxMapTooltip extends TemplateElement {
   /**
    * Transform the default rendering of each feature property key/value.
    * Useful for e.g. translating keys or introducing a whitelist.
+   * Passes the current property key and value as first argument,
+   * and the hovered feature as second argument.
+   * @example
+   * .propertyTransform=${({key, value}, feature) => myWhitelist.includes(key)}
    */
   @property()
-  propertyTransform = (property: [key: string, value: unknown]) => property;
+  propertyTransform = (
+    property: { key: string; value: unknown },
+    _feature: Feature
+  ) => property;
 
-  renderContent(content: object) {
+  renderContent(feature: Feature) {
     render(
       this.hasTemplate("properties")
         ? html`${this.renderTemplate(
             "properties",
-            content,
+            feature.getProperties(),
             // `tooltip-${this.content.id}`
             "tooltip-1"
           )}`
@@ -34,11 +42,14 @@ export class EOxMapTooltip extends TemplateElement {
               }
             </style>
             <ul>
-              ${Object.entries(content)
-                .map(([key, value]) => this.propertyTransform([key, value]))
+              ${Object.entries(feature.getProperties())
+                .map(([key, value]) =>
+                  this.propertyTransform({ key, value }, feature)
+                )
                 .filter((v) => v)
                 .map(
-                  ([key, value]) => html`<li><span>${key}</span>: ${value}</li>`
+                  ({ key, value }) =>
+                    html`<li><span>${key}</span>: ${value}</li>`
                 )}
             </ul>`,
       this.shadowRoot


### PR DESCRIPTION
This PR adds the currently selected `Feature` as a second argument to the `propertyTransform` function in order to cover more complex transformation use cases.
Alongside this, more stories and documentation have been added to showcase usage of the tooltip.

Closes https://github.com/EOX-A/EOxElements/issues/541