### PR TITLE
fix: check for tooltip element in shadowroot

### DIFF
--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -300,6 +300,7 @@ export const Tooltip = {
         interactions: [
           {
             type: "select",
+            showTooltip: true,
             options: {
               id: "selectInteraction",
               condition: "pointermove",
@@ -360,6 +361,7 @@ export const TooltipWithPropertyTransform = {
             options: {
               id: "selectInteraction",
               condition: "pointermove",
+              tooltipId: 'hoverTooltip',
               style: {
                 "stroke-color": "red",
                 "stroke-width": 3,
@@ -380,8 +382,9 @@ export const TooltipWithPropertyTransform = {
         .layers=${args.layers}
         .zoom=${args.zoom}
       >
-        <eox-map-tooltip
-          .propertyTransform=${({ key, value }, hoverFeature) => {
+        <eox-map-tooltip 
+          id="hoverTooltip"
+          .propertyTransform${({ key, value }, hoverFeature) => {
             console.log(hoverFeature);
             if (key.includes("COLOR")) {
               return { key: key.toLowerCase(), value };

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -51,7 +51,7 @@ export class EOxSelectInteraction {
 
     this.tooltip =
       this.eoxMap.querySelector("eox-map-tooltip") ||
-      this.eoxMap.shadowRoot.querySelector("eox-map-tooltip") ||
+      this.eoxMap.shadowRoot?.querySelector("eox-map-tooltip") ||
       options.overlay?.element;
     let overlay: Overlay;
     this.selectedFids = [];

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -51,7 +51,8 @@ export class EOxSelectInteraction {
 
     this.tooltip =
       this.eoxMap.querySelector("eox-map-tooltip") ||
-      this.eoxMap.shadowRoot.querySelector("eox-map-tooltip");
+      this.eoxMap.shadowRoot.querySelector("eox-map-tooltip") ||
+      options.overlay?.element;
     let overlay: Overlay;
     this.selectedFids = [];
     this.active = options?.active === false ? false : true;

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -50,9 +50,18 @@ export class EOxSelectInteraction {
     this.panIn = options.panIn || false;
 
     this.tooltip =
-      this.eoxMap.querySelector("eox-map-tooltip") ||
-      this.eoxMap.shadowRoot?.querySelector("eox-map-tooltip") ||
+      (this.eoxMap
+        .querySelector("eox-map-tooltip")
+        ?.cloneNode(true) as HTMLElement) ||
+      (this.eoxMap.shadowRoot
+        ?.querySelector("eox-map-tooltip")
+        ?.cloneNode(true) as HTMLElement) ||
       options.overlay?.element;
+
+    if (this.tooltip && !this.tooltip.id) {
+      this.tooltip.setAttribute("id", `_eoxTooltip_${options.id}`);
+    }
+
     let overlay: Overlay;
     this.selectedFids = [];
     this.active = options?.active === false ? false : true;

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -22,6 +22,7 @@ export type SelectOptions = Omit<
   layer?: EoxLayer;
   style?: import("ol/style/flat.js").FlatStyleLike;
   overlay?: import("ol/Overlay").Options;
+  tooltipId?: string;
   active?: boolean;
   panIn?: boolean;
 };
@@ -31,6 +32,7 @@ export class EOxSelectInteraction {
   options: SelectOptions;
   active: boolean;
   panIn: boolean;
+  tooltipId: string;
   tooltip: HTMLElement;
   selectedFids: Array<string | number>;
   selectLayer: SelectLayer;
@@ -48,18 +50,23 @@ export class EOxSelectInteraction {
     this.options = options;
     this.active = options.active;
     this.panIn = options.panIn || false;
+    this.tooltipId = options.tooltipId || '';
 
-    this.tooltip =
-      (this.eoxMap
-        .querySelector("eox-map-tooltip")
-        ?.cloneNode(true) as HTMLElement) ||
-      (this.eoxMap.shadowRoot
-        ?.querySelector("eox-map-tooltip")
-        ?.cloneNode(true) as HTMLElement) ||
-      options.overlay?.element;
-
-    if (this.tooltip && !this.tooltip.id) {
-      this.tooltip.setAttribute("id", `_eoxTooltip_${options.id}`);
+    console.log(this.tooltipId)
+    if (this.options.tooltipId) {
+      const originalNode = this.eoxMap.querySelector(
+        `#${this.tooltipId}`
+      ) as EOxMapTooltip || this.eoxMap.shadowRoot?.querySelector(
+        `#${this.tooltipId}`
+      ) as EOxMapTooltip;
+      if (originalNode) {
+        const propertyTransformFunction = originalNode.propertyTransform;
+        const clonedNode = originalNode?.cloneNode(true) as EOxMapTooltip;
+        //clonedNode.propertyTransform = originalNode.propertyTransform;
+        clonedNode.propertyTransform = propertyTransformFunction;
+        clonedNode.setAttribute("id", `_eoxTooltip_${options.id}`);
+        this.tooltip = clonedNode;
+      }
     }
 
     let overlay: Overlay;

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -50,7 +50,8 @@ export class EOxSelectInteraction {
     this.panIn = options.panIn || false;
 
     this.tooltip =
-      this.eoxMap.querySelector("eox-map-tooltip") || options.overlay?.element;
+      this.eoxMap.querySelector("eox-map-tooltip") ||
+      this.eoxMap.shadowRoot.querySelector("eox-map-tooltip");
     let overlay: Overlay;
     this.selectedFids = [];
     this.active = options?.active === false ? false : true;

--- a/elements/map/src/tooltip.ts
+++ b/elements/map/src/tooltip.ts
@@ -45,9 +45,11 @@ export class EOxMapTooltip extends TemplateElement {
             </style>
             <ul>
               ${Object.entries(feature.getProperties())
-                .map(([key, value]) =>
-                  this.propertyTransform({ key, value }, feature)
-                )
+                .map(([key, value]) =>{
+                  const transformedValue = this.propertyTransform({ key, value }, feature);
+                  console.log(transformedValue);
+                  return this.propertyTransform({ key, value }, feature)
+                })
                 .filter((v) => v)
                 .map(
                   ({ key, value }) =>

--- a/elements/map/test/hoverInteraction.json
+++ b/elements/map/test/hoverInteraction.json
@@ -15,6 +15,7 @@
         "options": {
           "id": "selectInteraction",
           "condition": "pointermove",
+          "showTooltip": true,
           "layer": {
             "type": "Vector",
             "properties": {

--- a/elements/map/test/tooltip.cy.ts
+++ b/elements/map/test/tooltip.cy.ts
@@ -69,7 +69,7 @@ describe("tooltip", () => {
       .shadow()
       .within(() => {
         cy.get("eox-map-tooltip").should("exist");
-        cy.get("eox-map-tooltip")
+        cy.get("#_eoxTooltip_selectInteraction")
           .shadow()
           .within(() => {
             cy.get("ul").should("exist");
@@ -82,14 +82,18 @@ describe("tooltip", () => {
       const eoxMap = <EOxMap>$el[0];
       eoxMap.map.getLayers().getArray()[0].setVisible(false);
       eoxMap.map.getLayers().getArray()[1].setVisible(true);
+      setTimeout(() => {
+        simulateEvent(eoxMap.map, "pointermove", 120, -141);
+      }, 1000)
     });
+
 
     // check if the tooltip on the second rendered layer works
     cy.get("eox-map")
       .shadow()
       .within(() => {
         cy.get("eox-map-tooltip").should("exist");
-        cy.get("eox-map-tooltip")
+        cy.get("#_eoxTooltip_selectInteraction2")
           .shadow()
           .within(() => {
             cy.get("ul").should("exist");

--- a/elements/map/test/tooltip.cy.ts
+++ b/elements/map/test/tooltip.cy.ts
@@ -84,9 +84,8 @@ describe("tooltip", () => {
       eoxMap.map.getLayers().getArray()[1].setVisible(true);
       setTimeout(() => {
         simulateEvent(eoxMap.map, "pointermove", 120, -141);
-      }, 1000)
+      }, 1000);
     });
-
 
     // check if the tooltip on the second rendered layer works
     cy.get("eox-map")

--- a/elements/map/test/tooltip.cy.ts
+++ b/elements/map/test/tooltip.cy.ts
@@ -1,0 +1,39 @@
+import { html } from "lit";
+import "../main";
+import vectorLayerStyleJson from "./hoverInteraction.json";
+import { simulateEvent } from "./utils/events";
+
+describe("tooltip", () => {
+  it("displays a tooltip on hover", () => {
+    cy.intercept("https://openlayers.org/data/vector/ecoregions.json", {
+      fixture: "/ecoregions.json",
+    });
+    cy.mount(
+      html`<eox-map .layers=${vectorLayerStyleJson}>
+        <eox-map-tooltip></eox-map-tooltip>
+      </eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      eoxMap.map.on("loadend", () => {
+        simulateEvent(eoxMap.map, "pointermove", 120, -140);
+      });
+    });
+    cy.get("eox-map")
+      .shadow()
+      .within(() => {
+        console.log("here");
+        cy.get("eox-map-tooltip").should("exist");
+        cy.get("eox-map-tooltip").and(($el) => {
+          console.log($el[0]);
+        });
+        cy.get("eox-map-tooltip")
+          .shadow()
+          .within(() => {
+            cy.get("ul").should("exist");
+            cy.get("ul").children().should("have.length", 9);
+          });
+      });
+  });
+});

--- a/elements/map/test/tooltip.cy.ts
+++ b/elements/map/test/tooltip.cy.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import "../main";
 import vectorLayerStyleJson from "./hoverInteraction.json";
 import { simulateEvent } from "./utils/events";
+import { EoxLayer } from "../src/generate";
 
 describe("tooltip", () => {
   it("displays a tooltip on hover", () => {
@@ -28,6 +29,66 @@ describe("tooltip", () => {
         cy.get("eox-map-tooltip").and(($el) => {
           console.log($el[0]);
         });
+        cy.get("eox-map-tooltip")
+          .shadow()
+          .within(() => {
+            cy.get("ul").should("exist");
+            cy.get("ul").children().should("have.length", 9);
+          });
+      });
+  });
+
+  it.only("displays a tooltip on hover when multiple layers are initialized and only one visible", () => {
+    cy.intercept("https://openlayers.org/data/vector/ecoregions.json", {
+      fixture: "/ecoregions.json",
+    });
+    const multiplelayersJson = [...vectorLayerStyleJson] as EoxLayer[];
+    const secondLayer = structuredClone(vectorLayerStyleJson[0]) as EoxLayer;
+    multiplelayersJson.unshift(secondLayer);
+    secondLayer.properties.id = "regions2";
+    secondLayer.interactions[0].options.id = "selectInteraction2";
+    // @ts-ignore
+    secondLayer.interactions[0].options.layer.properties.id = "selectLayer2";
+    secondLayer.visible = false;
+    console.log(multiplelayersJson);
+    cy.mount(
+      html`<eox-map .layers=${multiplelayersJson}>
+        <eox-map-tooltip></eox-map-tooltip>
+      </eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      eoxMap.map.on("loadend", () => {
+        simulateEvent(eoxMap.map, "pointermove", 120, -140);
+      });
+    });
+
+    // first check if the tooltip on the first rendered layer works
+    cy.get("eox-map")
+      .shadow()
+      .within(() => {
+        cy.get("eox-map-tooltip").should("exist");
+        cy.get("eox-map-tooltip")
+          .shadow()
+          .within(() => {
+            cy.get("ul").should("exist");
+            cy.get("ul").children().should("have.length", 9);
+          });
+      });
+
+    // hide first rendered layer and show second layer
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.map.getLayers().getArray()[0].setVisible(false);
+      eoxMap.map.getLayers().getArray()[1].setVisible(true);
+    });
+
+    // check if the tooltip on the second rendered layer works
+    cy.get("eox-map")
+      .shadow()
+      .within(() => {
+        cy.get("eox-map-tooltip").should("exist");
         cy.get("eox-map-tooltip")
           .shadow()
           .within(() => {


### PR DESCRIPTION
This PR adds an additional check to find the tooltip element inside the map shadow root and fixes #549. The reason for this is that OpenLayers "hijacks" the DOM element and pulls it into its DOM, changing the location from the slot (outside the shadow root) into its own div (inside the shadow root).
This fix does not consider the overlay element option, as this is tracked in a separate issue (#548).