### PR TITLE
Feature: Disable interactions on map 

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -164,7 +164,7 @@ export class EOxMap extends LitElement {
     this.zoom = config?.view.zoom;
     this.layers = config?.layers;
     this.controls = config?.controls;
-    this.disableInteractions = config?.disableInteractions;
+    this.disableInteractions = config?.disableInteractions || [];
   }
 
   /**

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -17,6 +17,10 @@ import {
 } from "./src/controls";
 import { buffer } from "ol/extent";
 import "./src/compare";
+import {
+  DisableInteractionsType,
+  setInteractionInactive,
+} from "./src/interaction";
 
 type ConfigObject = {
   controls: controlDictionary;
@@ -25,6 +29,7 @@ type ConfigObject = {
     center: Array<number>;
     zoom: number;
   };
+  disableInteractions: DisableInteractionsType;
 };
 
 /**
@@ -159,6 +164,7 @@ export class EOxMap extends LitElement {
     this.zoom = config?.view.zoom;
     this.layers = config?.layers;
     this.controls = config?.controls;
+    this.disableInteractions = config?.disableInteractions;
   }
 
   /**
@@ -175,6 +181,12 @@ export class EOxMap extends LitElement {
    */
   @property({ attribute: false, type: Number })
   zoom: number = 0;
+
+  /**
+   * List of interactions to be disabled
+   */
+  @property({ attribute: false, type: Array })
+  disableInteractions: DisableInteractionsType = [];
 
   /**
    * Sync map with another map view by providing its query selector
@@ -330,6 +342,9 @@ export class EOxMap extends LitElement {
     }
 
     this.map.setTarget(this.renderRoot.querySelector("div"));
+
+    if (this.disableInteractions.length)
+      setInteractionInactive(this.disableInteractions, this.map);
 
     this.map.on("loadend", () => {
       /**

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -481,3 +481,27 @@ export const ConfigObject = {
       ></eox-map>
     `,
 };
+
+export const DisableInteractions = {
+  args: {
+    config: {
+      controls: {
+        Zoom: {},
+      },
+      layers: [{ type: "Tile", source: { type: "OSM" } }],
+      view: {
+        center: [16.8, 48.2],
+        zoom: 9,
+      },
+      disableInteractions: ["MouseWheelZoom", "DoubleClickZoom"],
+    },
+  },
+  render: (args) =>
+    html`
+      <h3>Try to double click or mouse scroll to zoom</h3>
+      <eox-map
+        style="width: 100%; height: 300px;"
+        .config=${args.config}
+      ></eox-map>
+    `,
+};

--- a/elements/map/src/interaction.ts
+++ b/elements/map/src/interaction.ts
@@ -1,0 +1,36 @@
+import * as interactions from "ol/interaction";
+import Map from "ol/Map.js";
+
+export type DisableInteractionsType =
+  | [
+      "DragRotate",
+      "DoubleClickZoom",
+      "DragPan",
+      "PinchRotate",
+      "PinchZoom",
+      "KeyboardPan",
+      "KeyboardZoom",
+      "MouseWheelZoom",
+      "DragZoom"
+    ]
+  | [];
+
+/**
+ * Loop through interactions available on map
+ * and setActive to `false
+ * `
+ * @param {DisableInteractionsType} disableInteractions
+ * @param {Map} olMap
+ */
+export function setInteractionInactive(
+  disableInteractions: DisableInteractionsType,
+  olMap: Map
+) {
+  olMap.getInteractions().forEach(function (interaction) {
+    disableInteractions.forEach(
+      (type) =>
+        interaction instanceof interactions[type] &&
+        interaction.setActive(false)
+    );
+  });
+}


### PR DESCRIPTION
### Context -
- Feature to disable different interactions available on OpenLayers

#### We can disable following interactions using these keys - 
```json
[
    "DragRotate",
    "DoubleClickZoom",
    "DragPan",
    "PinchRotate",
    "PinchZoom",
    "KeyboardPan",
    "KeyboardZoom",
    "MouseWheelZoom",
    "DragZoom"
]
```

Pass following property to disable interactions - 
```html
<eox-map
  .disableInteractions=${["MouseWheelZoom", "DoubleClickZoom"]}
></eox-map>
```