### PR TITLE
fix: check if overlay was already instantiated before creating a new one

### DIFF
--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -285,7 +285,7 @@ export const ClickSelect = {
  * ```
  * This renders a list of all feature properties of the currently selected feature.
  * Note that if multiple interactions are registered (e.g. `pointermove` and `singleclick`),
- * only the first one will trigger the tooltip.
+ * the `pointermove` interaction will have higher priority for the tooltip.
  */
 export const Tooltip = {
   args: {
@@ -312,6 +312,8 @@ export const Tooltip = {
         ],
       },
     ],
+    center: [15, 48],
+    zoom: 4,
   },
   render: (args) =>
     html`
@@ -369,6 +371,8 @@ export const TooltipWithPropertyTransform = {
         ],
       },
     ],
+    center: [15, 48],
+    zoom: 4,
   },
   render: (args) =>
     html`

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -198,13 +198,6 @@ export class EOxSelectInteraction {
       const visible = this.selectLayer.getVisible();
       this.selectStyleLayer.setVisible(visible);
       this.setActive(visible);
-      // if (overlay) {
-      //   if (visible) {
-      //     this.eoxMap.map.addOverlay(overlay);
-      //   } else {
-      //     this.eoxMap.map.removeOverlay(overlay);
-      //   }
-      // }
     });
 
     this.changeSourceListener = () => {
@@ -215,10 +208,7 @@ export class EOxSelectInteraction {
     this.selectLayer.on("change:source", this.changeSourceListener);
 
     this.removeListener = () => {
-      // this.selectStyleLayer.setMap(null);
-      // if (overlay) {
-      //   // this.eoxMap.map.removeOverlay(overlay);
-      // }
+      //
     };
     this.eoxMap.map.getLayers().on("remove", this.removeListener);
 

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -49,22 +49,31 @@ export class EOxSelectInteraction {
     this.active = options.active;
     this.panIn = options.panIn || false;
 
-    this.tooltip =
-      this.eoxMap.querySelector("eox-map-tooltip") || options.overlay?.element;
+    const existingTooltip = this.eoxMap.map.getOverlayById("eox-map-tooltip");
+
     let overlay: Overlay;
     this.selectedFids = [];
-    this.active = options?.active === false ? false : true;
 
-    if (this.tooltip) {
-      overlay = new Overlay({
-        element: this.tooltip,
-        position: undefined,
-        offset: [0, 0],
-        positioning: "top-left",
-        className: "eox-map-tooltip",
-        ...options.overlay,
-      });
-      this.eoxMap.map.addOverlay(overlay);
+    if (existingTooltip) {
+      overlay = existingTooltip;
+    } else {
+      this.tooltip =
+        this.eoxMap.querySelector("eox-map-tooltip") ||
+        options.overlay?.element;
+      this.active = options?.active === false ? false : true;
+
+      if (this.tooltip) {
+        overlay = new Overlay({
+          element: this.tooltip,
+          position: undefined,
+          offset: [0, 0],
+          positioning: "top-left",
+          className: "eox-map-tooltip",
+          id: "eox-map-tooltip",
+          ...options.overlay,
+        });
+        this.eoxMap.map.addOverlay(overlay);
+      }
 
       const pointerLeaveListener = () => {
         overlay.setPosition(undefined);

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -46,14 +46,13 @@ export class EOxSelectInteraction {
     this.eoxMap = eoxMap;
     this.selectLayer = selectLayer;
     this.options = options;
-    this.active = options.active;
+    this.active = options.active || selectLayer.getVisible();
     this.panIn = options.panIn || false;
 
     const existingTooltip = this.eoxMap.map.getOverlayById("eox-map-tooltip");
 
     let overlay: Overlay;
     this.selectedFids = [];
-    this.active = options?.active === false ? false : true;
 
     if (existingTooltip) {
       this.tooltip = existingTooltip.getElement();
@@ -198,6 +197,7 @@ export class EOxSelectInteraction {
     this.selectLayer.on("change:visible", () => {
       const visible = this.selectLayer.getVisible();
       this.selectStyleLayer.setVisible(visible);
+      this.setActive(visible);
       // if (overlay) {
       //   if (visible) {
       //     this.eoxMap.map.addOverlay(overlay);

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -53,14 +53,15 @@ export class EOxSelectInteraction {
 
     let overlay: Overlay;
     this.selectedFids = [];
+    this.active = options?.active === false ? false : true;
 
     if (existingTooltip) {
+      this.tooltip = existingTooltip.getElement();
       overlay = existingTooltip;
     } else {
       this.tooltip =
         this.eoxMap.querySelector("eox-map-tooltip") ||
         options.overlay?.element;
-      this.active = options?.active === false ? false : true;
 
       if (this.tooltip) {
         overlay = new Overlay({
@@ -74,20 +75,20 @@ export class EOxSelectInteraction {
         });
         this.eoxMap.map.addOverlay(overlay);
       }
+    }
 
-      const pointerLeaveListener = () => {
-        overlay.setPosition(undefined);
-      };
-      eoxMap.map.on("change:target", (e) => {
-        e.oldValue?.removeEventListener("pointerleave", pointerLeaveListener);
-        e.target
-          .getTargetElement()
-          ?.addEventListener("pointerleave", pointerLeaveListener);
-      });
-      eoxMap.map
+    const pointerLeaveListener = () => {
+      overlay.setPosition(undefined);
+    };
+    eoxMap.map.on("change:target", (e) => {
+      e.oldValue?.removeEventListener("pointerleave", pointerLeaveListener);
+      e.target
         .getTargetElement()
         ?.addEventListener("pointerleave", pointerLeaveListener);
-    }
+    });
+    eoxMap.map
+      .getTargetElement()
+      ?.addEventListener("pointerleave", pointerLeaveListener);
 
     // a layer that only contains the selected features, for displaying purposes only
     // unmanaged by the map
@@ -197,13 +198,13 @@ export class EOxSelectInteraction {
     this.selectLayer.on("change:visible", () => {
       const visible = this.selectLayer.getVisible();
       this.selectStyleLayer.setVisible(visible);
-      if (overlay) {
-        if (visible) {
-          this.eoxMap.map.addOverlay(overlay);
-        } else {
-          this.eoxMap.map.removeOverlay(overlay);
-        }
-      }
+      // if (overlay) {
+      //   if (visible) {
+      //     this.eoxMap.map.addOverlay(overlay);
+      //   } else {
+      //     this.eoxMap.map.removeOverlay(overlay);
+      //   }
+      // }
     });
 
     this.changeSourceListener = () => {
@@ -214,10 +215,10 @@ export class EOxSelectInteraction {
     this.selectLayer.on("change:source", this.changeSourceListener);
 
     this.removeListener = () => {
-      this.selectStyleLayer.setMap(null);
-      if (overlay) {
-        this.eoxMap.map.removeOverlay(overlay);
-      }
+      // this.selectStyleLayer.setMap(null);
+      // if (overlay) {
+      //   // this.eoxMap.map.removeOverlay(overlay);
+      // }
     };
     this.eoxMap.map.getLayers().on("remove", this.removeListener);
 

--- a/elements/map/test/tooltip.cy.ts
+++ b/elements/map/test/tooltip.cy.ts
@@ -1,0 +1,98 @@
+import { html } from "lit";
+import "../main";
+import vectorLayerStyleJson from "./hoverInteraction.json";
+import { simulateEvent } from "./utils/events";
+import { EoxLayer } from "../src/generate";
+
+describe("tooltip", () => {
+  it("displays a tooltip on hover", () => {
+    cy.intercept("https://openlayers.org/data/vector/ecoregions.json", {
+      fixture: "/ecoregions.json",
+    });
+    cy.mount(
+      html`<eox-map .layers=${vectorLayerStyleJson}>
+        <eox-map-tooltip></eox-map-tooltip>
+      </eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      eoxMap.map.on("loadend", () => {
+        simulateEvent(eoxMap.map, "pointermove", 120, -140);
+      });
+    });
+    cy.get("eox-map")
+      .shadow()
+      .within(() => {
+        cy.get("eox-map-tooltip").should("exist");
+        cy.get("eox-map-tooltip")
+          .shadow()
+          .within(() => {
+            cy.get("ul").should("exist");
+            cy.get("ul").children().should("have.length", 9);
+          });
+      });
+  });
+
+  it.only("displays a tooltip on hover when multiple layers are initialized and only one visible", () => {
+    cy.intercept("https://openlayers.org/data/vector/ecoregions.json", {
+      fixture: "/ecoregions.json",
+    });
+    const multiplelayersJson = [...vectorLayerStyleJson] as EoxLayer[];
+    const secondLayer = structuredClone(vectorLayerStyleJson[0]) as EoxLayer;
+    multiplelayersJson.unshift(secondLayer);
+    secondLayer.properties.id = "regions2";
+    secondLayer.interactions[0].options.id = "selectInteraction2";
+    // @ts-ignore
+    secondLayer.interactions[0].options.layer.properties.id = "selectLayer2";
+    secondLayer.visible = false;
+    cy.mount(
+      html`<eox-map .layers=${multiplelayersJson}>
+        <eox-map-tooltip></eox-map-tooltip>
+      </eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+
+      eoxMap.map.on("loadend", () => {
+        simulateEvent(eoxMap.map, "pointermove", 120, -140);
+      });
+    });
+
+    // first check if the tooltip on the first rendered layer works
+    cy.get("eox-map")
+      .shadow()
+      .within(() => {
+        cy.get("eox-map-tooltip").should("exist");
+        cy.get("eox-map-tooltip")
+          .shadow()
+          .within(() => {
+            cy.get("ul").should("exist");
+            cy.get("ul").children().should("have.length", 9);
+          });
+      });
+
+    // hide first rendered layer and show second layer
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.map.getLayers().getArray()[0].setVisible(false);
+      eoxMap.map.getLayers().getArray()[1].setVisible(true);
+      setTimeout(() => {
+        simulateEvent(eoxMap.map, "pointermove", 120, -141);
+      }, 1000);
+    });
+
+    // check if the tooltip on the second rendered layer works
+    cy.get("eox-map")
+      .shadow()
+      .within(() => {
+        cy.get("eox-map-tooltip").should("exist");
+        cy.get("eox-map-tooltip")
+          .shadow()
+          .within(() => {
+            cy.get("ul").should("exist");
+            cy.get("ul").children().should("have.length", 9);
+          });
+      });
+  });
+});

--- a/elements/map/test/tooltip.cy.ts
+++ b/elements/map/test/tooltip.cy.ts
@@ -34,7 +34,7 @@ describe("tooltip", () => {
       });
   });
 
-  it.only("displays a tooltip on hover when multiple layers are initialized and only one visible", () => {
+  it("displays a tooltip on hover when multiple layers are initialized and only one visible", () => {
     cy.intercept("https://openlayers.org/data/vector/ecoregions.json", {
       fixture: "/ecoregions.json",
     });


### PR DESCRIPTION
This PR goes in a different direction than https://github.com/EOX-A/EOxElements/pull/555: when the select interaction is initialized, first check if an eox-map-tooltip was already instantiated on the map, if so, reuse that overlay, if not, create a new one.
This should fix the issue with not finding the DOM element, but means only one tooltip can exist per map. 