### PR TITLE
fix: keep tooltip visible if not emitted by pointermove

### DIFF
--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -77,7 +77,9 @@ export class EOxSelectInteraction {
     }
 
     const pointerLeaveListener = () => {
-      overlay.setPosition(undefined);
+      if (options.condition === "pointermove") {
+        overlay.setPosition(undefined);
+      }
     };
     eoxMap.map.on("change:target", (e) => {
       e.oldValue?.removeEventListener("pointerleave", pointerLeaveListener);


### PR DESCRIPTION
[Screencast from 2024-01-16 09:04:23.webm](https://github.com/EOX-A/EOxElements/assets/26576876/f54a5730-c523-4a1c-a3db-8df8382a9a84)

This PR introduces a check before setting the overlay position to `null`. This helps keeping the tooltipü visible if a user clicks on a featuer and then leaves the map with the mouse.

With this PR, only `pointermove` events will disable the tooltip when leaving the map - I am wondering if also other conditions should be checked? :thinking: See https://openlayers.org/en/latest/apidoc/module-ol_events_condition.html#~Condition