### PR TITLE
feat: allow sorting layers by dragging them

### DIFF
--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -157,10 +157,8 @@ export class EOxLayerControlLayer extends LitElement {
         this.layer,
         () => html`
           <!-- Render the layer -->
-          <div
-            class="layer drag-handle ${visibilityClass} ${layerZoomStateClass}"
-          >
-            <label class="${disableClass}">
+          <div class="layer ${visibilityClass} ${layerZoomStateClass}">
+            <label class="drag-handle ${disableClass}">
               <!-- Input element for layer visibility -->
               <input
                 type=${inputType}

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -157,7 +157,9 @@ export class EOxLayerControlLayer extends LitElement {
         this.layer,
         () => html`
           <!-- Render the layer -->
-          <div class="layer ${visibilityClass} ${layerZoomStateClass}">
+          <div
+            class="layer drag-handle ${visibilityClass} ${layerZoomStateClass}"
+          >
             <label class="${disableClass}">
               <!-- Input element for layer visibility -->
               <input

--- a/elements/layercontrol/test/cases/general/disable-drag.js
+++ b/elements/layercontrol/test/cases/general/disable-drag.js
@@ -19,7 +19,7 @@ const disableDrag = () => {
       cy.get(".tools summary").click({ multiple: true });
 
       // Verifying the visibility of the drag handle
-      cy.get(".drag-handle:visible").should("have.length", 1);
+      cy.get(".drag-handle.disabled").should("have.length", 1);
     });
 };
 


### PR DESCRIPTION
This PR adds an additional way to sort layers by dragging them (dragging the sorting "tool" icon still works).