### PR TITLE
fix: replace empty button to fix firefox sorting

### DIFF
--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -182,7 +182,7 @@ export class EOxLayerControlLayerTools extends LitElement {
     ${radio}
     ${checkbox}
     ${slider}
-    button.icon.drag-handle {
+    .drag-handle {
       cursor: n-resize;
     }
     .single-action-container,
@@ -239,11 +239,13 @@ export class EOxLayerControlLayerTools extends LitElement {
       height: 16px;
       width: 16px;
     }
-    eox-layercontrol-tabs button.icon {
+    eox-layercontrol-tabs button.icon,
+    eox-layercontrol-tabs .button.icon {
       display: flex;
       justify-content: center;
     }
-    eox-layercontrol-tabs .icon::before {
+    eox-layercontrol-tabs button.icon::before,
+    eox-layercontrol-tabs .button.icon::before {
       width: 16px;
       height: 16px;
     }
@@ -264,7 +266,7 @@ export class EOxLayerControlLayerTools extends LitElement {
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ff0000' viewBox='0 0 24 24'%3E%3Ctitle%3Edelete-outline%3C/title%3E%3Cpath d='M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19M8,9H16V19H8V9M15.5,4L14.5,3H9.5L8.5,4H5V6H19V4H15.5Z' /%3E%3C/svg%3E");
     }
     .single-action .sort-icon::before,
-    [slot=sort-icon] button.icon::before {
+    [slot=sort-icon] .button.icon::before {
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23004170' viewBox='0 0 24 24'%3E%3Ctitle%3Edrag-horizontal-variant%3C/title%3E%3Cpath d='M21 11H3V9H21V11M21 13H3V15H21V13Z' /%3E%3C/svg%3E");
     }
     [slot=info-content],

--- a/elements/layercontrol/src/helpers/layer-tools.js
+++ b/elements/layercontrol/src/helpers/layer-tools.js
@@ -76,6 +76,6 @@ export const removeButton = (EOxLayerControlLayerTools) => html`
  */
 export const sortButton = (unstyled) => html`
   <span class="button sort-icon icon drag-handle">
-    ${unstyled ? "sort" : nothing}
+    ${unstyled ? "═" : nothing}
   </span>
 `;

--- a/elements/layercontrol/src/helpers/layer-tools.js
+++ b/elements/layercontrol/src/helpers/layer-tools.js
@@ -75,7 +75,7 @@ export const removeButton = (EOxLayerControlLayerTools) => html`
  * @returns {import("lit").HTMLTemplateResult} - Sort button element.
  */
 export const sortButton = (unstyled) => html`
-  <button class="sort-icon icon drag-handle">
+  <span class="button sort-icon icon drag-handle">
     ${unstyled ? "sort" : nothing}
-  </button>
+  </span>
 `;

--- a/utils/styles/button.ts
+++ b/utils/styles/button.ts
@@ -1,5 +1,6 @@
 export const button = `
-button {
+button,
+.button {
   /* TODO: why does this only work here and not from :root? */
   --primary-color: #004170;
   --primary-color-hover: #004170CC;
@@ -26,31 +27,37 @@ button {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-button:hover:not([disabled]):not(.icon) {
+button:hover:not([disabled]):not(.icon),
+.button:hover:not([disabled]):not(.icon) {
   box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
   background: var(--primary-color-hover);
 }
 
-button, button:active {
+button, button:active,
+.button, .button:active {
   background: var(--primary-color);
 }
 
-button[disabled] {
+button[disabled],
+.button[disabled] {
   opacity: 0.5;
 }
 
-button.outline {
+button.outline,
+.button.outline {
   background: transparent;
   box-shadow: none;
   color: var(--primary-color);
   outline: 1px solid var(--primary-color);
 }
 
-button.outline:hover {
+button.outline:hover,
+.button.outline:hover {
   background: transparent;
 }
 
-button.icon {
+button.icon,
+.button.icon {
   background: transparent;
   border: none;
   box-shadow: none;
@@ -61,28 +68,33 @@ button.icon {
   text-indent: -9999px;
 }
 
-button.icon-text {
+button.icon-text,
+.button.icon-text {
   text-indent: 26px;
 }
 
-button.icon:before, button.icon-text:before {
+button.icon:before, button.icon-text:before,
+.button.icon:before, .button.icon-text:before {
   position: absolute;
   text-indent: 0;
   line-height: initial;
 }
 
-button.icon:before {
+button.icon:before,
+.button.icon:before {
   width: 24px;
   height: 24px;
   margin-right: 0;
 }
 
-button.icon-text:before {
+button.icon-text:before,
+.button.icon-text:before {
   width: 18px;
   height: 18px;
 }
 
-button.small {
+button.small,
+.button.small {
   height: 28px;
   padding: 12.4px;
   font-size: .75rem;


### PR DESCRIPTION
This PR replaces empty buttons (used for sorting the layer) with spans in order to fix [a bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=568313).

Fixes #580