### PR TITLE
fix: make sure a fallback layer id is rendered in time in order to support sorting

### DIFF
--- a/elements/layercontrol/src/helpers/check-properties.js
+++ b/elements/layercontrol/src/helpers/check-properties.js
@@ -5,20 +5,37 @@
  * @param {import("ol").Collection<import("ol/layer").Layer | import("ol/layer").Group>} collection - The collection of layers to be checked.
  * @param {string} idProperty - The property used as the ID.
  * @param {string} titleProperty - The property used as the title.
+ * @param {import("lit").LitElement} that - The LitElement instance.
  */
 //
-export default function checkProperties(collection, idProperty, titleProperty) {
+export default function checkProperties(
+  collection,
+  idProperty,
+  titleProperty,
+  that
+) {
   const layerArray = collection.getArray(); // Get an array of layers from the collection.
 
+  let requestUpdateNecessary = false;
   // Loop through each layer in the array to check and assign properties if missing.
   layerArray.forEach((layer) => {
     //@ts-ignore
     const olUID = layer.ol_uid;
 
     // Check and assign an ID property if it's missing.
-    if (!layer.get(idProperty)) layer.set(idProperty, olUID);
+    if (!layer.get(idProperty)) {
+      layer.set(idProperty, olUID);
+      requestUpdateNecessary = true;
+    }
 
     // Check and assign a title property if it's missing.
-    if (!layer.get(titleProperty)) layer.set(titleProperty, `layer ${olUID}`);
+    if (!layer.get(titleProperty)) {
+      layer.set(titleProperty, `layer ${olUID}`);
+      requestUpdateNecessary = true;
+    }
+
+    if (requestUpdateNecessary) {
+      that.requestUpdate();
+    }
   });
 }

--- a/elements/layercontrol/src/methods/layer-list/first-updated.js
+++ b/elements/layercontrol/src/methods/layer-list/first-updated.js
@@ -17,7 +17,12 @@ const firstUpdatedMethod = (EOxLayerControlLayerList) => {
     const element = renderRoot.querySelector("ul");
 
     // Checking properties of the layers
-    checkProperties(layers, idProperty, titleProperty);
+    checkProperties(
+      layers,
+      idProperty,
+      titleProperty,
+      EOxLayerControlLayerList
+    );
 
     // Creating a sortable list using helper function createSortable
     createSortable(element, layers, idProperty, EOxLayerControlLayerList);


### PR DESCRIPTION
This PR adds an additional `requestUpdate()` after the initial `propertyCheck()`, to force the DOM to re-render. The reason for this is that SortableJS needs the layer `id` present in order to work correctly.

The `requestUpdate()` is only called in case it is needed, e.g. if the `id` or `title` were changed by the `propertyCheck()`.

Fixes #584.