### PR TITLE
chore: decrease bundle size of jsonform

### DIFF
--- a/elements/jsonform/src/custom-inputs/index.js
+++ b/elements/jsonform/src/custom-inputs/index.js
@@ -1,4 +1,4 @@
-import { JSONEditor } from "@json-editor/json-editor/dist/jsoneditor.js";
+import { JSONEditor } from "@json-editor/json-editor/src/core.js";
 import { MinMaxEditor } from "./minmax";
 const inputs = [
   {

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -1,4 +1,4 @@
-import { JSONEditor } from "@json-editor/json-editor/dist/jsoneditor.js";
+import { JSONEditor } from "@json-editor/json-editor/src/core.js";
 import { LitElement, html } from "lit";
 import { style } from "./style";
 import { styleEOX } from "./style.eox";


### PR DESCRIPTION
Instead of importing the bundle, import the module, which allows tree-shaking.

Ref. https://github.com/json-editor/json-editor/issues/1470


## Before

```
dist/eox-jsonform.js  828.19 kB │ gzip: 144.86 kB
dist/eox-jsonform.umd.cjs  596.59 kB │ gzip: 127.46 kB
```

## After

```
dist/eox-jsonform.js  421.60 kB │ gzip: 86.46 kB
dist/eox-jsonform.umd.cjs  328.16 kB │ gzip: 74.71 kB
```