### PR TITLE
fix: consider active inside listener

### DIFF
--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -144,6 +144,9 @@ export class EOxSelectInteraction {
     };
 
     const listener = (event: MapBrowserEvent<UIEvent>) => {
+      if (!this.active) {
+        return;
+      }
       const currentZoom = this.eoxMap.map.getView().getZoom();
       if (
         event.dragging ||


### PR DESCRIPTION
This PR fixes a bug where the interaction was still firing events, even when it is not active.