### PR TITLE
feat: add a `currentTime` property to get and set time programmatically

### DIFF
--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -113,6 +113,9 @@ export class EOxTimeControl extends LitElement {
     this._updateStep(0);
   }
 
+  /**
+   * Gets or sets the current selected time as a string.
+   */
   get currentTime() {
     return this.animationValues[this._newTimeIndex];
   }

--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -113,14 +113,16 @@ export class EOxTimeControl extends LitElement {
     this._updateStep(0);
   }
 
-  get currentTime() { return this.animationValues[this._newTimeIndex] }
+  get currentTime() {
+    return this.animationValues[this._newTimeIndex];
+  }
 
   set currentTime(time: string) {
     const idx = this.animationValues.findIndex((v) => v === time);
     if (idx > -1) {
       this._newTimeIndex = idx;
     } else {
-      console.error(`Unable to find time "${time}" in available times!`)
+      console.error(`Unable to find time "${time}" in available times!`);
     }
   }
 

--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -113,7 +113,9 @@ export class EOxTimeControl extends LitElement {
     this._updateStep(0);
   }
 
-  setTime(time: string) {
+  get currentTime() { return this.animationValues[this._newTimeIndex] }
+
+  set currentTime(time: string) {
     const idx = this.animationValues.findIndex((v) => v === time);
     if (idx > -1) {
       this._newTimeIndex = idx;

--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -114,12 +114,14 @@ export class EOxTimeControl extends LitElement {
   }
 
   /**
-   * Gets or sets the current selected time as a string.
+   * The currently selected time
+   * @type string
    */
   get currentTime() {
     return this.animationValues[this._newTimeIndex];
   }
 
+  @property({ attribute: "current-time" })
   set currentTime(time: string) {
     const idx = this.animationValues.findIndex((v) => v === time);
     if (idx > -1) {

--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -113,6 +113,15 @@ export class EOxTimeControl extends LitElement {
     this._updateStep(0);
   }
 
+  setTime(time: string) {
+    const idx = this.animationValues.findIndex((v) => v === time);
+    if (idx > -1) {
+      this._newTimeIndex = idx;
+    } else {
+      console.error(`Unable to find time "${time}" in available times!`)
+    }
+  }
+
   @state()
   private _animationInterval: ReturnType<typeof setInterval>;
 

--- a/elements/timecontrol/timecontrol.stories.js
+++ b/elements/timecontrol/timecontrol.stories.js
@@ -99,3 +99,36 @@ export const Slider = {
     ></eox-timecontrol>
   `,
 };
+
+export const ProgrammaticTimeSelection = {
+  args: {
+    ...Primary.args,
+    for: "eox-map#programmatic-time-selection",
+    slider: true,
+  },
+  render: (args) => html`
+    <eox-map
+      id="programmatic-time-selection"
+      style="width: 400px; height: 300px;"
+      .zoom=${args.zoom}
+      .center=${args.center}
+      .layers=${args.layers}
+    ></eox-map>
+    <div>
+      <input type="text" id="time" value="2022-12-26" />
+      <button @click="${() => {
+        const time = document.getElementById("time").value;
+        const timeControl = document.getElementById("programmatic");
+        timeControl.currentTime = time;
+      }}">Go</button>
+    </div>
+    <eox-timecontrol
+      id="programmatic"
+      .for=${args.for}
+      .layer=${args.layer}
+      .animationProperty=${args.animationProperty}
+      .animationValues=${args.animationValues}
+      .slider=${args.slider}
+    ></eox-timecontrol>
+  `,
+};

--- a/elements/timecontrol/timecontrol.stories.js
+++ b/elements/timecontrol/timecontrol.stories.js
@@ -50,6 +50,9 @@ export const Primary = {
       },
       {
         type: "Tile",
+        properties: {
+          id: "OSM"
+        },
         source: {
           type: "OSM",
         },

--- a/elements/timecontrol/timecontrol.stories.js
+++ b/elements/timecontrol/timecontrol.stories.js
@@ -116,11 +116,15 @@ export const ProgrammaticTimeSelection = {
     ></eox-map>
     <div>
       <input type="text" id="time" value="2022-12-26" />
-      <button @click="${() => {
-        const time = document.getElementById("time").value;
-        const timeControl = document.getElementById("programmatic");
-        timeControl.currentTime = time;
-      }}">Go</button>
+      <button
+        @click="${() => {
+          const time = document.getElementById("time").value;
+          const timeControl = document.getElementById("programmatic");
+          timeControl.currentTime = time;
+        }}"
+      >
+        Go
+      </button>
     </div>
     <eox-timecontrol
       id="programmatic"

--- a/elements/timecontrol/timecontrol.stories.js
+++ b/elements/timecontrol/timecontrol.stories.js
@@ -51,7 +51,7 @@ export const Primary = {
       {
         type: "Tile",
         properties: {
-          id: "OSM"
+          id: "OSM",
         },
         source: {
           type: "OSM",


### PR DESCRIPTION
## Implemented changes

This pull request introduces a new `currentTime` property within the time control, which gets the currently selected time string of an `eox-timecontrol` element, for example like this:

```javascript
// Set the current time
timeControl.currentTime = '2022-12-26'

// '2022-12-26'
console.log(timeControl.currentTime)
```

Closes #608 

## Screenshots/Videos

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
