### PR TITLE
feat: initial layout element setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Please find [descriptions, API docs and interactive examples here](https://eox-a
     <td>🟡</td>
   </tr>
     <tr>
-    <td><a href="./elements/layercontrol/">eox-layercontrol</a></td>
+    <td><a href="./elements/layout/">eox-layout</a></td>
     <td>Easily create a UI layout</td>
-    <td><a href="https://eox-a.github.io/EOxElements/index.html?path=/docs/elements-eox-layercontrol--docs">Docs & Examples</a></td>
-    <td><a href="elements/layercontrol/CHANGELOG.md"><img src="https://img.shields.io/npm/v/@eox/layout.svg?label=%20" /></a></td>
+    <td><a href="https://eox-a.github.io/EOxElements/index.html?path=/docs/elements-eox-layout--docs">Docs & Examples</a></td>
+    <td><a href="elements/layout/CHANGELOG.md"><img src="https://img.shields.io/npm/v/@eox/layout.svg?label=%20" /></a></td>
     <td>🟡</td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Please find [descriptions, API docs and interactive examples here](https://eox-a
     <td><a href="elements/layercontrol/CHANGELOG.md"><img src="https://img.shields.io/npm/v/@eox/layercontrol.svg?label=%20" /></a></td>
     <td>🟡</td>
   </tr>
+    <tr>
+    <td><a href="./elements/layercontrol/">eox-layercontrol</a></td>
+    <td>Easily create a UI layout</td>
+    <td><a href="https://eox-a.github.io/EOxElements/index.html?path=/docs/elements-eox-layercontrol--docs">Docs & Examples</a></td>
+    <td><a href="elements/layercontrol/CHANGELOG.md"><img src="https://img.shields.io/npm/v/@eox/layout.svg?label=%20" /></a></td>
+    <td>🟡</td>
+  </tr>
   <tr>
     <td><a href="./elements/map/">eox-map</a></td>
     <td>Map with powerful tools & helpers</td>

--- a/elements/layout/README.md
+++ b/elements/layout/README.md
@@ -1,0 +1,33 @@
+# Layout
+
+## Usage
+
+```
+npm install @eox/layout
+```
+
+```
+import "@eox/layout"
+
+<eox-layout>
+  <eox-layout-item></eox-layout-item>
+</eox-layout>
+```
+
+// TODO: add documentation
+
+## Contribute
+
+```
+npm watch
+(on root) npm run cypress
+(on root) npm run format
+
+npm version <new version>
+npm run build
+npm publish (requires OTP)
+```
+
+## Changelog
+
+Created automatically [here](./CHANGELOG.md)

--- a/elements/layout/package.json
+++ b/elements/layout/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@eox/layout",
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": {
+    "@eox/eslint-config": "^1.0.0",
+    "vite": "^5.0.2"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/eox-layout.js",
+  "scripts": {
+    "build": "vite build",
+    "watch": "vite build --watch",
+    "format": "prettier --write .",
+    "lint": "eslint --ext .js,.ts .",
+    "lint:fix": "eslint --ext .js,.ts . --fix"
+  }
+}

--- a/elements/layout/src/enums/index.js
+++ b/elements/layout/src/enums/index.js
@@ -1,1 +1,3 @@
 export { STORIES_LAYOUT_STYLE } from "./stories";
+
+export { TEST_SELECTORS } from "./test";

--- a/elements/layout/src/enums/index.js
+++ b/elements/layout/src/enums/index.js
@@ -1,0 +1,1 @@
+export { STORIES_LAYOUT_STYLE } from "./stories";

--- a/elements/layout/src/enums/stories.js
+++ b/elements/layout/src/enums/stories.js
@@ -1,0 +1,1 @@
+export const STORIES_LAYOUT_STYLE = "width: 100%; height: 400px;";

--- a/elements/layout/src/enums/test.js
+++ b/elements/layout/src/enums/test.js
@@ -1,0 +1,4 @@
+export const TEST_SELECTORS = {
+  layoutElement: "eox-layout",
+  layoutItemElement: "eox-layout-item",
+};

--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -1,0 +1,73 @@
+const observer = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    if (mutation.type === "attributes") {
+      mutation.target.render();
+    }
+  });
+});
+
+customElements.define(
+  "eox-layout",
+  class extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: "open" });
+      this.render();
+      observer.observe(this, {
+        attributes: true,
+      });
+    }
+    render() {
+      this.shadowRoot.innerHTML = `
+      <style>
+          :host {
+              display: grid;
+              padding: ${this.getAttribute("gap") || 0}px;
+              height: 100%;
+              box-sizing: border-box;
+              gap: ${this.getAttribute("gap") || "0"}px;
+              grid-template-columns: repeat(12, 1fr);
+              grid-template-rows: repeat(12, 1fr);
+          }
+      </style>
+      <slot></slot>
+    `;
+    }
+  }
+);
+
+customElements.define(
+  "eox-layout-item",
+  class extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: "open" });
+      this.render();
+      observer.observe(this, {
+        attributes: true,
+      });
+    }
+    render() {
+      this.shadowRoot.innerHTML = `
+        <style>
+            :host {
+                background: lightgrey;
+                border: 1px solid darkgrey;
+                border-radius: 4px;
+                padding: 4px 8px;
+                overflow: hidden;
+
+
+                grid-column: ${
+                  parseInt(this.getAttribute("x")) + 1
+                } / span ${this.getAttribute("w")};
+                grid-row: ${
+                  parseInt(this.getAttribute("y")) + 1
+                } / span ${this.getAttribute("h")};
+            }
+        </style>
+        <slot></slot>
+      `;
+    }
+  }
+);

--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -1,73 +1,79 @@
-const observer = new MutationObserver((mutations) => {
-  mutations.forEach((mutation) => {
-    if (mutation.type === "attributes") {
-      mutation.target.render();
+/**
+ * This element allows to quickly set up an app layout using a 12x12 grid. It consists of two elements:
+ * - `eox-layout`: the container holding all the items
+ * - `eox-layout-item`: the individual items placed on the grid, with a defined x/y coordinate, and a w(idth) and h(eight)
+ */
+export class EOxLayout extends HTMLElement {
+  static get observedAttributes() {
+    return ["gap"];
+  }
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.render();
+  }
+  render() {
+    this.shadowRoot.innerHTML = `
+    <style>
+      :host {
+        display: grid;
+        padding: ${this.getAttribute("gap") || 0}px;
+        height: 100%;
+        box-sizing: border-box;
+        gap: ${this.getAttribute("gap") || "0"}px;
+        grid-template-columns: repeat(12, 1fr);
+        grid-template-rows: repeat(12, 1fr);
+      }
+    </style>
+    <slot></slot>
+  `;
+  }
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue !== newValue) {
+      this[name] = newValue;
     }
-  });
-});
+    this.render();
+  }
+}
 
-customElements.define(
-  "eox-layout",
-  class extends HTMLElement {
-    constructor() {
-      super();
-      this.attachShadow({ mode: "open" });
-      this.render();
-      observer.observe(this, {
-        attributes: true,
-      });
-    }
-    render() {
-      this.shadowRoot.innerHTML = `
+export class EOxLayoutItem extends HTMLElement {
+  static get observedAttributes() {
+    return ["x", "y", "w", "h"];
+  }
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.render();
+  }
+  render() {
+    this.shadowRoot.innerHTML = `
       <style>
-          :host {
-              display: grid;
-              padding: ${this.getAttribute("gap") || 0}px;
-              height: 100%;
-              box-sizing: border-box;
-              gap: ${this.getAttribute("gap") || "0"}px;
-              grid-template-columns: repeat(12, 1fr);
-              grid-template-rows: repeat(12, 1fr);
-          }
+        :host {
+          background: lightgrey;
+          border: 1px solid darkgrey;
+          border-radius: 4px;
+          padding: 4px 8px;
+          overflow: hidden;
+
+
+          grid-column: ${
+            parseInt(this.getAttribute("x")) + 1
+          } / span ${this.getAttribute("w")};
+          grid-row: ${
+            parseInt(this.getAttribute("y")) + 1
+          } / span ${this.getAttribute("h")};
+        }
       </style>
       <slot></slot>
     `;
-    }
   }
-);
-
-customElements.define(
-  "eox-layout-item",
-  class extends HTMLElement {
-    constructor() {
-      super();
-      this.attachShadow({ mode: "open" });
-      this.render();
-      observer.observe(this, {
-        attributes: true,
-      });
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue !== newValue) {
+      this[name] = newValue;
     }
-    render() {
-      this.shadowRoot.innerHTML = `
-        <style>
-            :host {
-                background: lightgrey;
-                border: 1px solid darkgrey;
-                border-radius: 4px;
-                padding: 4px 8px;
-                overflow: hidden;
-
-
-                grid-column: ${
-                  parseInt(this.getAttribute("x")) + 1
-                } / span ${this.getAttribute("w")};
-                grid-row: ${
-                  parseInt(this.getAttribute("y")) + 1
-                } / span ${this.getAttribute("h")};
-            }
-        </style>
-        <slot></slot>
-      `;
-    }
+    this.render();
   }
-);
+}
+
+customElements.define("eox-layout", EOxLayout);
+customElements.define("eox-layout-item", EOxLayoutItem);

--- a/elements/layout/stories/gap.js
+++ b/elements/layout/stories/gap.js
@@ -1,0 +1,21 @@
+import { html } from "lit";
+import "../src/main";
+import { STORIES_LAYOUT_STYLE } from "../src/enums";
+
+export const GapStory = {
+  args: {},
+  render: () => html`
+    <!-- Render eox-layout component -->
+    <eox-layout
+      gap="8"
+      style="${STORIES_LAYOUT_STYLE}; border: 1px solid darkgrey"
+    >
+      <eox-layout-item x="0" y="0" w="3" h="2"></eox-layout-item>
+      <eox-layout-item x="0" y="2" w="2" h="10"></eox-layout-item>
+      <eox-layout-item x="10" y="0" w="2" h="12"></eox-layout-item>
+      <eox-layout-item x="4" y="10" w="4" h="2"></eox-layout-item>
+    </eox-layout>
+  `,
+};
+
+export default GapStory;

--- a/elements/layout/stories/grid.js
+++ b/elements/layout/stories/grid.js
@@ -2,6 +2,7 @@ import { html } from "lit";
 import "../src/main";
 import { STORIES_LAYOUT_STYLE } from "../src/enums";
 
+// Generate one [x,y] array for each slot in a 12x12 grid
 const renderItems = () => {
   let items = [];
   for (let x = 0; x < 12; x++) {

--- a/elements/layout/stories/grid.js
+++ b/elements/layout/stories/grid.js
@@ -1,0 +1,30 @@
+import { html } from "lit";
+import "../src/main";
+import { STORIES_LAYOUT_STYLE } from "../src/enums";
+
+const renderItems = () => {
+  let items = [];
+  for (let x = 0; x < 12; x++) {
+    for (let y = 0; y < 12; y++) {
+      items.push([x, y]);
+    }
+  }
+  return items;
+};
+
+export const Grid = {
+  args: {},
+  render: () => html`
+    <!-- Render eox-layout component -->
+    <eox-layout style="${STORIES_LAYOUT_STYLE}">
+      ${renderItems().map(
+        ([x, y]) =>
+          html`<eox-layout-item x="${x}" y="${y}" w="1" h="1"
+            >${x}/${y}</eox-layout-item
+          >`
+      )}
+    </eox-layout>
+  `,
+};
+
+export default Grid;

--- a/elements/layout/stories/index.js
+++ b/elements/layout/stories/index.js
@@ -1,0 +1,5 @@
+// Export different stories
+
+export { default as PrimaryStory } from "./primary";
+export { default as GridStory } from "./grid";
+export { default as GapStory } from "./gap";

--- a/elements/layout/stories/layout.stories.js
+++ b/elements/layout/stories/layout.stories.js
@@ -1,0 +1,29 @@
+/**
+ * Stories for eox-layout component showcasing various configurations.
+ * These stories provide visual representations and usage examples for different scenarios.
+ */
+import { PrimaryStory, GridStory, GapStory } from "./index";
+
+export default {
+  title: "Elements/eox-layout",
+  tags: ["autodocs"],
+  component: "eox-layout",
+};
+
+// Exporting each individual story for the eox-layout component.
+
+/**
+ * Primary story showcasing basic usage.
+ */
+export const Primary = PrimaryStory;
+
+/**
+ * The layout grid consists of 12x12 slots, where `x` and `y` coordinates are zero-indexed.
+ */
+export const Grid = GridStory;
+
+/**
+ * When using the `gap` attribute on `eox-layout`, a padding as well as gaps are
+ * created between the individual items. A 1px border was added to demonstrate the padding.
+ */
+export const Gap = GapStory;

--- a/elements/layout/stories/primary.js
+++ b/elements/layout/stories/primary.js
@@ -1,0 +1,26 @@
+import { html } from "lit";
+import "../src/main";
+import { STORIES_LAYOUT_STYLE } from "../src/enums";
+
+export const Primary = {
+  args: {},
+  render: () => html`
+    <!-- Render eox-layout component -->
+    <eox-layout style="${STORIES_LAYOUT_STYLE}">
+      <eox-layout-item x="0" y="0" w="3" h="2">
+        x="0" y="0" w="3" h="2"
+      </eox-layout-item>
+      <eox-layout-item x="0" y="2" w="2" h="10">
+        x="0" y="2" w="2" h="10"
+      </eox-layout-item>
+      <eox-layout-item x="10" y="0" w="2" h="12">
+        x="10" y="0" w="2" h="12"
+      </eox-layout-item>
+      <eox-layout-item x="4" y="10" w="4" h="2">
+        x="4" y="10" w="4" h="2"
+      </eox-layout-item>
+    </eox-layout>
+  `,
+};
+
+export default Primary;

--- a/elements/layout/test/cases/index.js
+++ b/elements/layout/test/cases/index.js
@@ -1,0 +1,6 @@
+// Exported test methods
+
+export { default as loadLayoutTest } from "./load-layout";
+export { default as renderItemsTest } from "./render-items";
+export { default as renderItemsWidthTest } from "./render-items-width";
+export { default as renderGapTest } from "./render-gap";

--- a/elements/layout/test/cases/load-layout.js
+++ b/elements/layout/test/cases/load-layout.js
@@ -1,0 +1,19 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { layoutElement } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the layout component loads successfully.
+ */
+const loadLayoutTest = () => {
+  // Mounting eox-layout element
+  cy.mount(`<eox-layout></eox-layout>`).as(layoutElement);
+
+  it("loads the layout", () => {
+    // Find the layout element and access its shadow DOM
+    cy.get(layoutElement).shadow();
+  });
+};
+
+export default loadLayoutTest;

--- a/elements/layout/test/cases/render-gap.js
+++ b/elements/layout/test/cases/render-gap.js
@@ -1,0 +1,27 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { layoutElement } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the layout-items component render correctly.
+ */
+const renderGap = () => {
+  const testGap = 8;
+  cy.mount(
+    `   
+    <eox-layout gap="${testGap}"> 
+      <eox-layout-item x="0" y="0" w="1" h="1"></eox-layout-item>
+      <eox-layout-item x="0" y="1" w="1" h="1"></eox-layout-item>
+      <eox-layout-item x="0" y="2" w="1" h="1"></eox-layout-item>
+    </eox-layout>
+  `
+  ).as(layoutElement);
+
+  cy.get(layoutElement).and(($el) => {
+    expect(getComputedStyle($el[0]).padding).to.eq(`${testGap}px`);
+    expect(getComputedStyle($el[0]).gap).to.eq(`${testGap}px`);
+  });
+};
+
+export default renderGap;

--- a/elements/layout/test/cases/render-items-width.js
+++ b/elements/layout/test/cases/render-items-width.js
@@ -1,0 +1,38 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { layoutElement } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the layout-items component render correctly.
+ */
+const renderItemsWidthTest = () => {
+  cy.mount(
+    `   
+    <eox-layout> 
+      <eox-layout-item x="0" y="0" w="1" h="1"></eox-layout-item>
+      <eox-layout-item x="0" y="1" w="2" h="1"></eox-layout-item>
+      <eox-layout-item x="0" y="2" w="3" h="1"></eox-layout-item>
+    </eox-layout>
+  `
+  ).as(layoutElement);
+
+  cy.get(layoutElement)
+    .shadow()
+    .within(() => {
+      cy.get("slot").and(($el) => {
+        const items = $el[0].assignedElements();
+        expect(
+          getComputedStyle(items[0]).gridColumn.includes("/ span 1")
+        ).to.eq(true);
+        expect(
+          getComputedStyle(items[1]).gridColumn.includes("/ span 2")
+        ).to.eq(true);
+        expect(
+          getComputedStyle(items[2]).gridColumn.includes("/ span 3")
+        ).to.eq(true);
+      });
+    });
+};
+
+export default renderItemsWidthTest;

--- a/elements/layout/test/cases/render-items.js
+++ b/elements/layout/test/cases/render-items.js
@@ -1,0 +1,31 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { layoutElement, layoutItemElement } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the number of layout-items component render correctly.
+ */
+const renderItemsTest = () => {
+  cy.mount(
+    `   
+    <eox-layout> 
+      <eox-layout-item></eox-layout-item>
+      <eox-layout-item></eox-layout-item>
+      <eox-layout-item></eox-layout-item>
+    </eox-layout>
+  `
+  ).as(layoutElement);
+
+  cy.get(layoutItemElement).should("have.length", 3);
+  // Find the layout element and access its shadow DOM
+  cy.get(layoutElement)
+    .shadow()
+    .within(() => {
+      cy.get("slot").and(($el) => {
+        expect($el[0].assignedElements().length).to.eq(3);
+      });
+    });
+};
+
+export default renderItemsTest;

--- a/elements/layout/test/general.cy.js
+++ b/elements/layout/test/general.cy.js
@@ -1,0 +1,15 @@
+// Importing necessary modules, test cases, and enums
+import "../src/main";
+import {
+  loadLayoutTest,
+  renderItemsTest,
+  renderItemsWidthTest,
+  renderGapTest,
+} from "./cases";
+
+describe("Layout", () => {
+  it("loads the drawtools", () => loadLayoutTest());
+  it("renders the correct number of layout items", () => renderItemsTest());
+  it("renders the correct width of layout items", () => renderItemsWidthTest());
+  it("renders the correct gap", () => renderGapTest());
+});

--- a/elements/layout/tsconfig.json
+++ b/elements/layout/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "strictNullChecks": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "allowJs": true,
+    "checkJs": true,
+    "types": ["cypress"]
+  },
+  "include": ["src/*.js"]
+}

--- a/elements/layout/vite.config.js
+++ b/elements/layout/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "./src/main.js",
+      name: "eox-jsonform",
+      // the proper extensions will be added
+      fileName: "eox-layout",
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,7 @@
       }
     },
     "elements/layout": {
+      "name": "@eox/layout",
       "version": "0.0.0",
       "devDependencies": {
         "@eox/eslint-config": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,13 @@
         "npm": ">=8.0.0"
       }
     },
+    "elements/layout": {
+      "version": "0.0.0",
+      "devDependencies": {
+        "@eox/eslint-config": "^1.0.0",
+        "vite": "^5.0.2"
+      }
+    },
     "elements/map": {
       "name": "@eox/map",
       "version": "1.2.0",
@@ -194,7 +201,7 @@
     },
     "elements/timecontrol": {
       "name": "@eox/timecontrol",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "dayjs": "^1.11.9",
         "lit": "^3.0.2",
@@ -2495,6 +2502,10 @@
     },
     "node_modules/@eox/layercontrol": {
       "resolved": "elements/layercontrol",
+      "link": true
+    },
+    "node_modules/@eox/layout": {
+      "resolved": "elements/layout",
       "link": true
     },
     "node_modules/@eox/map": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
     "elements/itemfilter": {},
     "elements/jsonform": {},
     "elements/layercontrol": {},
+    "elements/layout": {},
     "elements/map": {},
     "elements/stacinfo": {},
     "elements/timecontrol": {}


### PR DESCRIPTION
## Implemented changes

This is the initial release of the new `eox-layout` element. It should facilitate the creation of user interface layouts based on a 12/12 grid. Initial features:
- `eox-layout` and `eox-layout-item` elements
- `gap` attribute for `eox-layout`
- configurable for `eox-layout-item`: **x** (coordinate), **y** (coordinate), **w**(idth) and **h**(eight)
- it has basic reactivity, meaning once attributes change, the layout re-renders

Future evolution might include features such as creating a layout from JSON, responsive layouts etc.

## Screenshots

![screencapture-localhost-6006-2024-02-08-12_15_08](https://github.com/EOX-A/EOxElements/assets/26576876/2c4642a4-0ae7-45de-a200-67d509ac9314)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
