### PR TITLE
Fix: Redundant cypress `it()` from drawtools test case

### DIFF
--- a/elements/drawtools/test/cases/click-discard-btn.js
+++ b/elements/drawtools/test/cases/click-discard-btn.js
@@ -7,27 +7,25 @@ const { drawTools, controller, drawBtn, discardBtn } = TEST_SELECTORS;
  * Clicks the discard button and verifies if drawn features are cleared.
  */
 const clickDiscardBtnTest = () => {
-  it("clicks the discard button and clears drawn features", () => {
-    cy.get(drawTools)
-      .shadow()
-      .within(() => {
-        cy.get(controller)
-          .shadow()
-          .within(() => {
-            // Click the draw button and verify if it is in the 'drawing' state
-            cy.get(drawBtn).click();
-            cy.get(drawBtn).contains("drawing");
+  cy.get(drawTools)
+    .shadow()
+    .within(() => {
+      cy.get(controller)
+        .shadow()
+        .within(() => {
+          // Click the draw button and verify if it is in the 'drawing' state
+          cy.get(drawBtn).click();
+          cy.get(drawBtn).contains("drawing");
 
-            // Click the discard button and verify if the 'drawing' state is removed
-            cy.get(discardBtn).click();
-            cy.get(drawBtn).should("not.contain", "drawing");
-          });
-      });
-
-    // Verify if drawn features array is empty after discarding
-    cy.get(drawTools).should(($el) => {
-      expect($el[0].drawnFeatures).to.have.length(0);
+          // Click the discard button and verify if the 'drawing' state is removed
+          cy.get(discardBtn).click();
+          cy.get(drawBtn).should("not.contain", "drawing");
+        });
     });
+
+  // Verify if drawn features array is empty after discarding
+  cy.get(drawTools).should(($el) => {
+    expect($el[0].drawnFeatures).to.have.length(0);
   });
 };
 

--- a/elements/drawtools/test/cases/click-draw-btn.js
+++ b/elements/drawtools/test/cases/click-draw-btn.js
@@ -7,25 +7,23 @@ const { drawTools, controller, drawBtn } = TEST_SELECTORS;
  * Clicks the draw button and verifies the 'drawing' state.
  */
 const clickDrawBtnTest = () => {
-  it("clicks the draw button", () => {
-    cy.get(drawTools)
-      .shadow()
-      .within(() => {
-        cy.get(controller)
-          .shadow()
-          .within(() => {
-            // Verify the initial state of the draw button
-            cy.get(drawBtn).contains("draw");
-            cy.get(drawBtn).should("not.contain", "drawing");
+  cy.get(drawTools)
+    .shadow()
+    .within(() => {
+      cy.get(controller)
+        .shadow()
+        .within(() => {
+          // Verify the initial state of the draw button
+          cy.get(drawBtn).contains("draw");
+          cy.get(drawBtn).should("not.contain", "drawing");
 
-            // Click the draw button and verify the 'drawing' state
-            cy.get(drawBtn).click();
-            cy.get(drawBtn).contains("drawing");
-          });
-      });
+          // Click the draw button and verify the 'drawing' state
+          cy.get(drawBtn).click();
+          cy.get(drawBtn).contains("drawing");
+        });
+    });
 
-    // TODO: Simulate drawing and add drawn features (not implemented in the current test)
-  });
+  // TODO: Simulate drawing and add drawn features (not implemented in the current test)
 };
 
 export default clickDrawBtnTest;

--- a/elements/drawtools/test/cases/load-drawtool.js
+++ b/elements/drawtools/test/cases/load-drawtool.js
@@ -7,10 +7,8 @@ const { drawTools } = TEST_SELECTORS;
  * Test to verify if the drawtools component loads successfully.
  */
 const loadDrawToolsTest = () => {
-  it("loads the drawtools", () => {
-    // Find the drawTools element and access its shadow DOM
-    cy.get(drawTools).shadow();
-  });
+  // Find the drawTools element and access its shadow DOM
+  cy.get(drawTools).shadow();
 };
 
 export default loadDrawToolsTest;


### PR DESCRIPTION
## Implemented changes
Fixed redundant Cypress `it()` from the `drawtools` test. No matter what was placed inside, Cypress used to pass every single `drawtools` test. It was fixed by removing the `it()` inside the test methods.

#### Issue due to this PR 
- #460

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

### Tests passed even after putting a `nonExistingFunction()` - 
<img src="https://github.com/EOX-A/EOxElements/assets/10809211/4dd6ac59-e9de-4ec8-b666-9e4dabe7ea28" width="49%" /> <img src="https://github.com/EOX-A/EOxElements/assets/10809211/a8b575c1-f6b9-4bf6-b861-f396087e8974" width="49%" />


<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
