### PR TITLE
feat: support non-tiled sources

### DIFF
--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -47,13 +47,13 @@ export class EOxTimeControl extends LitElement {
   slider: boolean;
 
   /**
-   * Original params (in case of a image source).
+   * Original params of layer source
    */
   @property()
   private _originalParams: object;
 
   /**
-   * Hides the play button if set.
+   * Hides the play button if set
    */
   @property({ attribute: "disable-play", type: Boolean })
   disablePlay: boolean;


### PR DESCRIPTION
## Implemented changes
Edit: after some discussion, we opted to just support param updates instead of maintaingin both tile-specific cases and other cases. This also removes the usage of OL-internal API (which we should do anyway). This setup is now much simpler, and for special/complicated cases we would use a STAC-based approach (e.g. each "time" entry is a separate STAC item with a self-contained visualization url).

~This adds support for non-tiled sources by checking if a `tileUrlFunction` exists. If not, it is assumed to be a non-tiled source, and the params are used instead. The reason behind this is that ImageWMS sources don't have a url loader function and generally use urls + params instead.~

~We could use url + params also for tiled sources, but with the current setup, we would allow deeper level control of url manipulation in tiled source urls. Although I am open to replace all by the param updating via `updateParams`.~

~More details: Both ImageWMS and TileWMS have a [updateParams](https://openlayers.org/en/latest/apidoc/module-ol_source_TileWMS-TileWMS.html#updateParams) function, which allows setting new params like TIME, LAYER etc. This can be used to switch between dates that an endpoint provides. But, additionally, a TileWMS source also offers a [setTileUrlFunction](https://openlayers.org/en/latest/apidoc/module-ol_source_TileWMS-TileWMS.html#setTileUrlFunction) function, which (if I understand correctly), allows a deeper level of url manipulation, not limited to params. If we have use cases where this is needed we can keep both. If we say we only need to upgrade params, then both tiled and non-tiled sources could use `updateParams()`. I am not an expert on this, so I am unsure.~

Fixes #629

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
