### PR TITLE
fix: support layers inside groups

### DIFF
--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -2,6 +2,7 @@ import { LitElement, html, svg, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { Map } from "ol";
 import Layer from "ol/layer/Layer";
+import Group from "ol/layer/Group";
 import UrlTile from "ol/source/UrlTile";
 import "toolcool-range-slider";
 import { style } from "./style";
@@ -151,6 +152,36 @@ export class EOxTimeControl extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * TEMP / TO-DO, this is a copy of the function defined in the eox-map:
+   * https://github.com/EOX-A/EOxElements/blob/main/elements/map/src/layer.ts#L25
+   * Consider a way to properly export that function and use it here
+   * @param layers layers Array
+   */
+  getFlatLayersArray(layers: Array<Layer>) {
+    const flatLayers = [];
+    flatLayers.push(...layers);
+
+    let groupLayers = flatLayers.filter(
+      (l) => l instanceof Group
+    ) as unknown as Array<Group>;
+
+    while (groupLayers.length) {
+      const newGroupLayers = [];
+      for (let i = 0, ii = groupLayers.length; i < ii; i++) {
+        const layersInsideGroup = groupLayers[i].getLayers().getArray();
+        flatLayers.push(...layersInsideGroup);
+        newGroupLayers.push(
+          ...(layersInsideGroup.filter(
+            (l) => l instanceof Group
+          ) as Array<Group>)
+        );
+      }
+      groupLayers = newGroupLayers;
+    }
+    return flatLayers as Array<Layer>;
+  }
+
   render() {
     const mapQuery = document.querySelector(this.for as string);
     // @ts-ignore
@@ -158,10 +189,13 @@ export class EOxTimeControl extends LitElement {
 
     olMap.once("loadend", () => {
       if (!this._originalParams) {
-        const animationLayer = olMap
-          .getLayers()
-          .getArray()
-          .find((l) => l.get("id") === this.layer) as Layer;
+        // @ts-ignore
+        const flatLayers = this.getFlatLayersArray(
+          olMap.getLayers().getArray()
+        );
+        const animationLayer = flatLayers.find(
+          (l: Layer) => l.get("id") === this.layer
+        ) as Layer;
         this._animationSource = animationLayer.getSource() as UrlTile;
 
         this._originalParams =

--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -189,8 +189,8 @@ export class EOxTimeControl extends LitElement {
 
     olMap.once("loadend", () => {
       if (!this._originalParams) {
-        // @ts-ignore
         const flatLayers = this.getFlatLayersArray(
+          // @ts-ignore
           olMap.getLayers().getArray()
         );
         const animationLayer = flatLayers.find(


### PR DESCRIPTION
## Implemented changes

This fix allows also using tiemcontrol with layers inside layer groups. It uses a copy of the `getFlatLayersArray` function from https://github.com/EOX-A/EOxElements/blob/main/elements/map/src/layer.ts#L25 as temporary solution, for a permanent solution see: https://github.com/EOX-A/EOxElements/issues/636

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
