### PR TITLE
feat: hide styled details marker if no children are in group

### DIFF
--- a/elements/layercontrol/src/components/layer-group.js
+++ b/elements/layercontrol/src/components/layer-group.js
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
 import { when } from "lit/directives/when.js";
+import { hideLayersBasedOnProperties } from "../helpers";
 import "./layer";
 import "./layer-list";
 
@@ -99,6 +100,9 @@ export class EOxLayerControlLayerGroup extends LitElement {
   render() {
     // Check if the group should be open based on a specific control property
     const groupOpen = Boolean(this.group?.get("layerControlExpand"));
+    const numberOfChildLayers = hideLayersBasedOnProperties(
+      this.group.getLayers()
+    )?.length;
 
     return html`
       <style>
@@ -109,7 +113,10 @@ export class EOxLayerControlLayerGroup extends LitElement {
         this.group,
         () => html`
           <!-- Render the details element with the layer control -->
-          <details open=${groupOpen}>
+          <details
+            open=${groupOpen}
+            data-children-length=${numberOfChildLayers}
+          >
             <summary>
               <!-- Render the layer control within the summary -->
               <eox-layercontrol-layer
@@ -163,6 +170,9 @@ export class EOxLayerControlLayerGroup extends LitElement {
     }
     details[open] > summary:before {
       transform: rotate(90deg);
+    }
+    details[data-children-length="0"] summary::before {
+      display: none;
     }
   `;
 }

--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit";
 import { when } from "lit/directives/when.js";
 import { repeat } from "lit/directives/repeat.js";
-import { getLayerType } from "../helpers";
+import { getLayerType, hideLayersBasedOnProperties } from "../helpers";
 import "./layer";
 import "./layer-group";
 import { firstUpdatedMethod, updateMethod } from "../methods/layer-list";
@@ -113,12 +113,7 @@ export class EOxLayerControlLayerList extends LitElement {
    */
   render() {
     // Filter and reverse layers based on control properties
-    const layers = this.layers
-      ?.getArray()
-      ?.filter(
-        (l) => !l.get("layerControlHide") && !l.get("layerControlOptional")
-      )
-      .reverse();
+    const layers = hideLayersBasedOnProperties(this.layers).reverse();
 
     return html`
       <style>

--- a/elements/layercontrol/src/helpers/hide-layers-based-on-property.js
+++ b/elements/layercontrol/src/helpers/hide-layers-based-on-property.js
@@ -1,0 +1,11 @@
+/**
+ * Run the layer collection through a set of property filters before rendering
+ *
+ * @param {import("ol").Collection<import("ol/layer").Layer | import("ol/layer").Group>} collection - The collection of layers to be checked.
+ */
+export const hideLayersBasedOnProperties = (collection) => {
+  const propertyFilters = ["layerControlHide", "layerControlOptional"];
+  return collection
+    ?.getArray()
+    ?.filter((l) => propertyFilters.every((p) => !l.get(p)));
+};

--- a/elements/layercontrol/src/helpers/index.js
+++ b/elements/layercontrol/src/helpers/index.js
@@ -18,3 +18,4 @@ export {
   removeButton,
   sortButton,
 } from "./layer-tools";
+export { hideLayersBasedOnProperties } from "./hide-layers-based-on-property";

--- a/elements/layercontrol/test/_mockMap.js
+++ b/elements/layercontrol/test/_mockMap.js
@@ -148,7 +148,7 @@ export class MockMap extends HTMLElement {
     this.setLayers([json]);
   };
   setLayers = (layers) => {
-    this.layers = new MockCollection(layers.reverse());
+    this.layers = new MockCollection(layers);
   };
 }
 customElements.define("mock-map", MockMap);

--- a/elements/layercontrol/test/_mockMap.js
+++ b/elements/layercontrol/test/_mockMap.js
@@ -148,7 +148,7 @@ export class MockMap extends HTMLElement {
     this.setLayers([json]);
   };
   setLayers = (layers) => {
-    this.layers = new MockCollection(layers);
+    this.layers = new MockCollection(layers.reverse());
   };
 }
 customElements.define("mock-map", MockMap);

--- a/elements/layercontrol/test/cases/general/empty-groups.js
+++ b/elements/layercontrol/test/cases/general/empty-groups.js
@@ -1,0 +1,41 @@
+// Function to simulate "empty" groups within the LayerControl
+const emptyGroup = () => {
+  // Set up the layers in the mock map
+  cy.get("mock-map").then(($el) => {
+    const mockMap = $el[0]; // Accessing the mock map element
+
+    // Setting layer groups: one with visible layers and another one with hidden layers
+    mockMap.setLayers([
+      {
+        layers: [
+          { properties: { layerControlHide: false } },
+          { properties: { layerControlHide: false } },
+        ],
+      },
+      {
+        layers: [
+          { properties: { layerControlHide: true } },
+          { properties: { layerControlHide: true } },
+        ],
+      },
+    ]);
+  });
+
+  // Verify the effect on the LayerControl
+  cy.get("eox-layercontrol")
+    .shadow()
+    .within(() => {
+      cy.get("summary").then(($els) => {
+        const control = $els[0];
+        const test = $els[6];
+        const checkDisplay = (el) =>
+          el.ownerDocument.defaultView
+            .getComputedStyle(el, "before")
+            .getPropertyValue("display");
+        expect(checkDisplay(control)).to.eq("block");
+        expect(checkDisplay(test)).to.eq("none");
+      });
+    });
+};
+
+export default emptyGroup;

--- a/elements/layercontrol/test/cases/general/empty-groups.js
+++ b/elements/layercontrol/test/cases/general/empty-groups.js
@@ -8,14 +8,14 @@ const emptyGroup = () => {
     mockMap.setLayers([
       {
         layers: [
-          { properties: { layerControlHide: false } },
-          { properties: { layerControlHide: false } },
+          { properties: { layerControlHide: true } },
+          { properties: { layerControlHide: true } },
         ],
       },
       {
         layers: [
-          { properties: { layerControlHide: true } },
-          { properties: { layerControlHide: true } },
+          { properties: { layerControlHide: false } },
+          { properties: { layerControlHide: false } },
         ],
       },
     ]);

--- a/elements/layercontrol/test/cases/general/index.js
+++ b/elements/layercontrol/test/cases/general/index.js
@@ -3,5 +3,6 @@ export { default as checkPreOpenLayerTools } from "./check-pre-open-layer-tools"
 export { default as checkPreOpenSection } from "./check-pre-open-section";
 export { default as disableDrag } from "./disable-drag";
 export { default as hideLayers } from "./hide-layers";
+export { default as emptyGroup } from "./empty-groups";
 export { default as renderOptionalLayer } from "./render-optional-layer";
 export { default as showCorrectLayerTitle } from "./show-layer-title";

--- a/elements/layercontrol/test/general.cy.js
+++ b/elements/layercontrol/test/general.cy.js
@@ -7,6 +7,7 @@ import {
   checkPreOpenSection,
   disableDrag,
   hideLayers,
+  emptyGroup,
   renderOptionalLayer,
   showCorrectLayerTitle,
 } from "./cases/general";
@@ -29,6 +30,9 @@ describe("LayerControl", () => {
 
   // Test to validate the hiding of layers
   it("hides layers correctly", () => hideLayers());
+
+  // Test if groups with no layers are shown as not expandable
+  it.only("shows groups with no layers as not expandable", () => emptyGroup());
 
   // Test to verify the rendering of optional layer selection
   it("renders the optional layer selection", () => renderOptionalLayer());

--- a/elements/layercontrol/test/general.cy.js
+++ b/elements/layercontrol/test/general.cy.js
@@ -32,7 +32,7 @@ describe("LayerControl", () => {
   it("hides layers correctly", () => hideLayers());
 
   // Test if groups with no layers are shown as not expandable
-  it.only("shows groups with no layers as not expandable", () => emptyGroup());
+  it("shows groups with no layers as not expandable", () => emptyGroup());
 
   // Test to verify the rendering of optional layer selection
   it("renders the optional layer selection", () => renderOptionalLayer());


### PR DESCRIPTION
## Implemented changes

This PR supersedes https://github.com/EOX-A/EOxElements/pull/604. It hides the details marker for layer groups with no child layers. As this is a styling "opinion" it only applies to the "EOX styled" version (not to the unstyled one).

To trigger this, all child layers need to have the `layerControlHide` property set to `true`; it automatically hides the expand/contract icon on the parent group, this way it looks like a layer (but with a "group" icon).

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/26576876/7a91e6ef-2d9d-4c81-bb8f-212ac7d76062)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
