### PR TITLE
fix: don't expand layer if `layerControlExpand` is falsy

### DIFF
--- a/elements/layercontrol/src/components/layer-group.js
+++ b/elements/layercontrol/src/components/layer-group.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from "lit";
+import { LitElement, html, nothing } from "lit";
 import { when } from "lit/directives/when.js";
 import { hideLayersBasedOnProperties } from "../helpers";
 import "./layer";
@@ -114,7 +114,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
         () => html`
           <!-- Render the details element with the layer control -->
           <details
-            open=${groupOpen}
+            open=${groupOpen || nothing}
             data-children-length=${numberOfChildLayers}
           >
             <summary>

--- a/elements/layercontrol/test/cases/general/check-pre-open-section.js
+++ b/elements/layercontrol/test/cases/general/check-pre-open-section.js
@@ -6,7 +6,10 @@ const checkPreOpenSection = () => {
 
     // Setting layers: one visible and another with layerControlExpand: true
     mockMap.setLayers([
-      { visible: true },
+      {
+        properties: { layerControlExpand: undefined },
+        layers: [{ visible: true }],
+      },
       {
         properties: { layerControlExpand: true },
         layers: [{ visible: true }],
@@ -19,7 +22,7 @@ const checkPreOpenSection = () => {
     .shadow()
     .within(() => {
       // Checking if a details tag (any open section) exists
-      cy.get("details[open]").should("exist");
+      cy.get("details[open]").should("have.length", 1);
     });
 };
 


### PR DESCRIPTION
## Implemented changes

This PR fixes a bug introduced by [the layercontrol refactor](https://github.com/EOX-A/EOxElements/pull/527/files#diff-0c0c4261c188b4fd751b2dbe16180cfaf498f1d0e312ce9915a952acd91a07fcR101), as the `layerControlExpand` boolean property [was always creating a "truthy" `open` attribute on the details](https://github.com/EOX-A/EOxElements/pull/527/files#diff-0c0c4261c188b4fd751b2dbe16180cfaf498f1d0e312ce9915a952acd91a07fcR112). In HTML, an attribute like e.g. `<details open="false"></details>` is still interpreted as "truthy" (as it is just a string). By using the `nothing` helper provided by lit, this can be mitigated (`nothing` removes the attribute completely).

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/26576876/537bd909-5df8-4816-a29d-23a47f4475e9)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
