### PR TITLE
fix(test): mock map layer order

### DIFF
--- a/elements/layercontrol/test/_mockMap.js
+++ b/elements/layercontrol/test/_mockMap.js
@@ -148,7 +148,7 @@ export class MockMap extends HTMLElement {
     this.setLayers([json]);
   };
   setLayers = (layers) => {
-    this.layers = new MockCollection(layers);
+    this.layers = new MockCollection(layers.reverse());
   };
 }
 customElements.define("mock-map", MockMap);

--- a/elements/layercontrol/test/cases/general/empty-groups.js
+++ b/elements/layercontrol/test/cases/general/empty-groups.js
@@ -8,14 +8,14 @@ const emptyGroup = () => {
     mockMap.setLayers([
       {
         layers: [
-          { properties: { layerControlHide: true } },
-          { properties: { layerControlHide: true } },
+          { properties: { layerControlHide: false } },
+          { properties: { layerControlHide: false } },
         ],
       },
       {
         layers: [
-          { properties: { layerControlHide: false } },
-          { properties: { layerControlHide: false } },
+          { properties: { layerControlHide: true } },
+          { properties: { layerControlHide: true } },
         ],
       },
     ]);

--- a/elements/layercontrol/test/cases/layer-update/check-if-layer-pushed-to-group.js
+++ b/elements/layercontrol/test/cases/layer-update/check-if-layer-pushed-to-group.js
@@ -2,6 +2,7 @@ const checkLayerPushedToGroup = () => {
   // Setting up the mock map with layers and a group
   cy.get("mock-map").and(($el) => {
     $el[0].setLayers([
+      { properties: { title: "bar" } }, // Adding a standalone layer
       {
         properties: {
           title: "group",
@@ -9,7 +10,6 @@ const checkLayerPushedToGroup = () => {
         },
         layers: [{ properties: { title: "foo" } }], // Adding a layer to a group
       },
-      { properties: { title: "bar" } }, // Adding a standalone layer
     ]);
   });
 

--- a/elements/layercontrol/test/cases/layer-update/check-layer-removed-from-group.js
+++ b/elements/layercontrol/test/cases/layer-update/check-layer-removed-from-group.js
@@ -2,6 +2,7 @@ const checkLayerRemovedFromGroup = () => {
   // Set up the mock map with a group containing a layer
   cy.get("mock-map").and(($el) => {
     $el[0].setLayers([
+      { title: "bar" }, // Another separate layer outside the group
       {
         properties: {
           title: "group",
@@ -9,7 +10,6 @@ const checkLayerRemovedFromGroup = () => {
         },
         layers: [{ properties: { title: "baz" } }], // Initial layer in the group
       },
-      { title: "bar" }, // Another separate layer outside the group
     ]);
   });
 

--- a/elements/layercontrol/test/cases/layer-update/check-layer-removed-from-root.js
+++ b/elements/layercontrol/test/cases/layer-update/check-layer-removed-from-root.js
@@ -17,7 +17,7 @@ const checkLayerRemovedFromRoot = () => {
       cy.get(`[data-layer=${layerToDelete}] .tools > summary`).click();
 
       // Click on the 'remove' icon to delete the layer
-      cy.get("button.remove-icon:visible").last().click();
+      cy.get("button.remove-icon:visible").first().click();
 
       // Check if the layer UI element is removed from the layer control
       cy.get(`[data-layer=${layerToDelete}]`).should("not.exist");


### PR DESCRIPTION
## Implemented changes

This PR fixes the order of the layers rendered in the mockmap, in order to behave more similarly to the real eox-map.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
