### PR TITLE
chore!: rename event from onTimeChange to timeChange in `timecontrol`

### DIFF
--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -156,7 +156,7 @@ export class EOxTimeControl extends LitElement {
      * `event.detail.currentTime` returns the new *currentTime* value.
      */
     this.dispatchEvent(
-      new CustomEvent("onTimeChange", {
+      new CustomEvent("timeChange", {
         detail: {
           currentTime: this.currentTime,
         },

--- a/elements/timecontrol/src/main.ts
+++ b/elements/timecontrol/src/main.ts
@@ -156,7 +156,7 @@ export class EOxTimeControl extends LitElement {
      * `event.detail.currentTime` returns the new *currentTime* value.
      */
     this.dispatchEvent(
-      new CustomEvent("timeChange", {
+      new CustomEvent("timechange", {
         detail: {
           currentTime: this.currentTime,
         },

--- a/elements/timecontrol/test/cases/change-time.js
+++ b/elements/timecontrol/test/cases/change-time.js
@@ -22,7 +22,7 @@ const changeTimeTest = () => {
       layer="TEST_ID"
       .animationProperty=${testParam}
       .animationValues=${testTimes}
-      @timeChange="${(e) => {
+      @timechange="${(e) => {
         timeChangeEventValue = e.detail.currentTime;
       }}"
     ></eox-timecontrol>`

--- a/elements/timecontrol/test/cases/change-time.js
+++ b/elements/timecontrol/test/cases/change-time.js
@@ -22,7 +22,7 @@ const changeTimeTest = () => {
       layer="TEST_ID"
       .animationProperty=${testParam}
       .animationValues=${testTimes}
-      @onTimeChange="${(e) => {
+      @timeChange="${(e) => {
         timeChangeEventValue = e.detail.currentTime;
       }}"
     ></eox-timecontrol>`


### PR DESCRIPTION
## Implemented changes

<!-- description of implemented changes -->
Suggested by @StefanBrand , `onTimeChange` sounded more like an event callback, hence the change. **This is a breaking change**.
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
