### PR TITLE
Feat: Render markdown from default slot

### DIFF
--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -68,16 +68,23 @@ export class EOxStoryTelling extends LitElement {
     }
   }
 
+  /**
+   * Handles changes to the slot's content, updating the component's internal state.
+   */
   handleSlotChange() {
+    // Query the shadow DOM for the slot element
     const slot = this.shadowRoot.querySelector("slot");
+
     if (slot) {
+      // Retrieve all nodes assigned to the slot, flattening any nested nodes
       const slottedContent = slot.assignedNodes({ flatten: true });
+
+      // Map each node to its text content, filtering out any non-text nodes, and join into a single string
       this.markdown = slottedContent
-        .map((node) => {
-          return node.textContent ? node.textContent : "";
-        })
+        .map((node) => (node.textContent ? node.textContent : ""))
         .join("");
 
+      // Request an update to re-render the component with the new content
       this.requestUpdate();
     }
   }
@@ -86,9 +93,10 @@ export class EOxStoryTelling extends LitElement {
     return html`
       <style>
         :host { display: block; }
+        .slot-hide { display: none; }
         ${!this.unstyled && mainStyle}
       </style>
-      <slot style="display: none;" @slotchange=${this.handleSlotChange}></slot>
+      <slot class="slot-hide" @slotchange=${this.handleSlotChange}></slot>
       ${when(this.#html, () => html`${unsafeHTML(this.#html)}`)}
     `;
   }

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -68,12 +68,27 @@ export class EOxStoryTelling extends LitElement {
     }
   }
 
+  handleSlotChange() {
+    const slot = this.shadowRoot.querySelector("slot");
+    if (slot) {
+      const slottedContent = slot.assignedNodes({ flatten: true });
+      this.markdown = slottedContent
+        .map((node) => {
+          return node.textContent ? node.textContent : "";
+        })
+        .join("");
+
+      this.requestUpdate();
+    }
+  }
+
   render() {
     return html`
       <style>
         :host { display: block; }
         ${!this.unstyled && mainStyle}
       </style>
+      <slot style="display: none;" @slotchange=${this.handleSlotChange}></slot>
       ${when(this.#html, () => html`${unsafeHTML(this.#html)}`)}
     `;
   }

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -1,2 +1,3 @@
 export { default as PrimaryStory } from "./primary"; // StoryTelling with markdown string
 export { default as MarkdownAsURLStory } from "./markdown-url"; // StoryTelling with markdown URL
+export { default as MarkdownSlotStory } from "./markdown-slot"; // StoryTelling with markdown from the slot

--- a/elements/storytelling/stories/markdown-slot.js
+++ b/elements/storytelling/stories/markdown-slot.js
@@ -1,0 +1,18 @@
+/**
+ * Markdown from the slot component demonstrating the configuration options for eox-storytelling
+ * It renders storytelling markdown based on the content from the slot.
+ */
+import { html } from "lit";
+import "../src/main.js";
+
+export const MarkdownSlot = {
+  args: {
+    markdown: "## Hello World, Markdown Inside Slot.",
+  },
+  render: (args) => html`
+    <!-- Render eox-storytelling from markdown inside the slot. -->
+    <eox-storytelling id="markdown-slot">${args.markdown}</eox-storytelling>
+  `,
+};
+
+export default MarkdownSlot;

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -2,7 +2,7 @@
  * Stories for eox-storytelling component showcasing various configurations.
  * These stories provide visual representations and usage examples for different scenarios.
  */
-import { PrimaryStory, MarkdownAsURLStory } from "./index";
+import { PrimaryStory, MarkdownAsURLStory, MarkdownSlotStory } from "./index";
 
 export default {
   title: "Elements/eox-storytelling",
@@ -21,3 +21,8 @@ export const Primary = PrimaryStory;
  * StoryTelling using markdown URL.
  */
 export const MarkdownAsURL = MarkdownAsURLStory;
+
+/**
+ * StoryTelling using markdown from the slot.
+ */
+export const MarkdownInsideSlot = MarkdownSlotStory;

--- a/elements/storytelling/test/cases/index.js
+++ b/elements/storytelling/test/cases/index.js
@@ -2,3 +2,4 @@
 
 export { default as loadMarkdownTest } from "./load-markdown";
 export { default as loadMarkdownUrlTest } from "./load-markdown-url";
+export { default as loadMarkdownSlot } from "./load-markdown-slot";

--- a/elements/storytelling/test/cases/load-markdown-slot.js
+++ b/elements/storytelling/test/cases/load-markdown-slot.js
@@ -1,0 +1,23 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { storyTelling } = TEST_SELECTORS;
+
+/**
+ * Loads markdown passed as slot.
+ */
+const loadMarkdownSlot = () => {
+  const testText = "Hello World!";
+
+  cy.mount(`<eox-storytelling># ${testText}</eox-storytelling>`).as(
+    storyTelling
+  );
+
+  cy.get(storyTelling)
+    .shadow()
+    .within(() => {
+      cy.get("h1").should("have.text", testText);
+    });
+};
+
+export default loadMarkdownSlot;

--- a/elements/storytelling/test/general.cy.js
+++ b/elements/storytelling/test/general.cy.js
@@ -1,7 +1,11 @@
 // Importing necessary modules, test cases, and enums
 import "../src/main";
 
-import { loadMarkdownTest, loadMarkdownUrlTest } from "./cases";
+import {
+  loadMarkdownTest,
+  loadMarkdownUrlTest,
+  loadMarkdownSlot,
+} from "./cases";
 
 // Test suite for Storytelling
 describe("Storytelling", () => {
@@ -10,4 +14,7 @@ describe("Storytelling", () => {
 
   // Test case to ensure the storytelling component loads a markdown file from a url
   it("loads markdown from a url", () => loadMarkdownUrlTest());
+
+  // Test case to ensure the storytelling component loads successfully and renders passed markdown from the slot
+  it("loads markdown from slot", () => loadMarkdownSlot());
 });


### PR DESCRIPTION
## Implemented changes
- Allow users to pass markdown as an `inner-child` using slot and then generate html out of it.
```html
<eox-storytelling>
# Hello world!
This is some [markdown](https://en.wikipedia.org/wiki/Markdown).
</eox-storytelling>
```
- By default `<slot>` will be hidden using `css` but able to access markdown using 
```javascript
this.shadowRoot.querySelector("slot")
```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
<img width="821" alt="image" src="https://github.com/EOX-A/EOxElements/assets/10809211/ae2e57c9-67a3-4afc-bd8c-93d7e96f060a">


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
