### PR TITLE
Fix: Markdown url pattern breaking on prod

### DIFF
--- a/elements/storytelling/stories/markdown-url.js
+++ b/elements/storytelling/stories/markdown-url.js
@@ -6,7 +6,9 @@ import { html } from "lit";
 import "../src/main.js";
 
 export const MarkdownAsURL = {
-  args: { markdownURL: `${window.location.origin}/sample.md` },
+  args: {
+    markdownURL: `${window.location.href.split("iframe.html")[0]}/sample.md`,
+  },
   render: (args) => html`
     <!-- Render eox-storytelling with basic markdown url. -->
     <eox-storytelling


### PR DESCRIPTION
## Implemented changes
Hotfix for `markdownURL` issue in production because the github pages has a subfolder `/EOxElements`. And we were using `window.location.origin`, now it is replaced to `window.location.href.split("iframe.html")[0]`. It will work on both local and prod.
 
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
