### PR TITLE
fix(docs): improve args/props rendering

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -37,21 +37,51 @@ const preview = {
       page: DocumentationTemplate,
       source: {
         transform: (code, storyContext) => {
+          /**
+           * Check which props belong to which tag
+           * and create object
+           */
           const undecorated = storyContext.undecoratedStoryFn(storyContext);
-          return code.replace(
-            `<${storyContext.component}`,
-            `<${storyContext.component} ${Object.entries(storyContext.args)
-              .filter(([key]) =>
-                undecorated.strings.find((s) => s.includes(`.${key}=`))
-              )
-              .map(
-                ([key, value], index, row) =>
-                  `\n .${key}='\${${JSON.stringify(value)}}'${
-                    index + 1 === row.length ? "\n" : ""
-                  }`
-              )
-              .join("")}`
-          );
+          let currentTag = undefined;
+          const tags = {};
+          undecorated.strings
+            .map((string, index) => {
+              const startOfTag = string.match(/(?<=<eox-).*?((?=>| )|$)/gim);
+              if (startOfTag) {
+                currentTag = `eox-${startOfTag}`;
+              }
+              const property = string
+                .match(/(?<=\.).*?(?==)/gim)?.[0]
+                ?.replaceAll(" ", "");
+              const value = undecorated.values[index];
+              if (property && value) {
+                if (!tags[currentTag]) {
+                  tags[currentTag] = {};
+                }
+                tags[currentTag][property] = value;
+              }
+            })
+            .filter((l) => l);
+
+          /**
+           * Inject prop for each tag in the rendered code
+           */
+          Object.keys(tags).forEach((tag) => {
+            code = code.replace(
+              `<${tag}`,
+              `<${tag}\n  ${Object.keys(tags[tag])
+                .map(
+                  (key, index) =>
+                    `.${key}='\$\{${
+                      typeof tags[tag][key] === "string"
+                        ? tags[tag][key]
+                        : JSON.stringify(tags[tag][key])
+                    }\}'`
+                )
+                .join("\n  ")}\n  `
+            );
+          });
+          return code;
         },
       },
     },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -37,10 +37,13 @@ const preview = {
       page: DocumentationTemplate,
       source: {
         transform: (code, storyContext) => {
+          const undecorated = storyContext.undecoratedStoryFn(storyContext);
           return code.replace(
             `<${storyContext.component}`,
             `<${storyContext.component} ${Object.entries(storyContext.args)
-              .filter(([key]) => key !== "onLoadend")
+              .filter(([key]) =>
+                undecorated.strings.find((s) => s.includes(`.${key}=`))
+              )
               .map(
                 ([key, value], index, row) =>
                   `\n .${key}='\${${JSON.stringify(value)}}'${


### PR DESCRIPTION
## Implemented changes

When generating the autodocs code, Storybook scraps properties added via the lit `.<property>` syntax. The previous solution worked for some cases, but it
- wrongly applied args to the elements (the story element would get all args) and it
- applied args that weren't even used

The new approach goes through the raw lines line by line and tries to figure out which arg belongs to which element.

## Screenshots/Videos
### Before
![image](https://github.com/EOX-A/EOxElements/assets/26576876/ab6cf466-b1ea-464f-8a88-1a15d1e24557)

### After
![image](https://github.com/EOX-A/EOxElements/assets/26576876/0ba6d963-12fb-46a5-b77f-86e6dc3e6d98)

### Before
![image](https://github.com/EOX-A/EOxElements/assets/26576876/158974ad-7e1e-4c91-bb69-cf2514f3f881)

### After
![image](https://github.com/EOX-A/EOxElements/assets/26576876/5802b6a6-6a74-4363-8818-881363e39f58)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
