### PR TITLE
Feat: Render attributes via comment tags 

### DIFF
--- a/elements/storytelling/src/enums/index.js
+++ b/elements/storytelling/src/enums/index.js
@@ -1,1 +1,2 @@
 export { TEST_SELECTORS } from "./test";
+export { TAGS_EXPR, TAGS_OPENING, TAGS_SELF_CLOSING } from "./plugin";

--- a/elements/storytelling/src/enums/plugin.js
+++ b/elements/storytelling/src/enums/plugin.js
@@ -1,0 +1,26 @@
+// Regular expression to match the custom tag expressions
+export const TAGS_EXPR =
+  /^<!-- ?\{(?:([a-z0-9]+)(\^[0-9]*)?: ?)?(.*)} ?-->\n?$/;
+
+// Mapping of tag to token type. This helps in identifying the opening tags and their corresponding Markdown-it token types.
+export const TAGS_OPENING = {
+  li: ["list_item"],
+  ul: ["bullet_list"],
+  p: ["paragraph"],
+  ol: ["ordered_list"],
+  blockquote: ["blockquote"],
+  h1: ["heading"],
+  h2: ["heading"],
+  h3: ["heading"],
+  h4: ["heading"],
+  h5: ["heading"],
+  h6: ["heading"],
+  a: ["link"],
+  code: ["code_inline", "code_block", "fence"],
+};
+
+// Self-closing tags
+export const TAGS_SELF_CLOSING = {
+  hr: true,
+  image: true,
+};

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -5,7 +5,10 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { loadMarkdownURL } from "./helpers/index";
 import mainStyle from "../../../utils/styles/dist/main.style";
 import DOMPurify from "isomorphic-dompurify";
+import { markdownItDecorateImproved } from "./markdown-it-plugin";
 const md = markdownit({ html: true });
+
+md.use(markdownItDecorateImproved);
 
 export class EOxStoryTelling extends LitElement {
   // Define properties with defaults and types

--- a/elements/storytelling/src/markdown-it-plugin/index.js
+++ b/elements/storytelling/src/markdown-it-plugin/index.js
@@ -1,0 +1,1 @@
+export { default as markdownItDecorateImproved } from "./markdown-it-decorate-improved";

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -1,7 +1,9 @@
 import { TAGS_EXPR, TAGS_OPENING, TAGS_SELF_CLOSING } from "../enums";
 
 /**
- * Plugin registration with Markdown-it
+ * Plugin registration with Markdown-it - Annotate Markdown documents with HTML attributes, IDs and classes.
+ * This plugin is improved ES6 version of `markdown-it-decorate`
+ * Ref - https://github.com/rstacruz/markdown-it-decorate
  *
  * @param {import("markdown-it").default} md - Markdown-It instances
  */

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -1,0 +1,222 @@
+import { TAGS_EXPR, TAGS_OPENING, TAGS_SELF_CLOSING } from "../enums";
+
+/**
+ * Plugin registration with Markdown-it
+ *
+ * @param {import("markdown-it").default} md - Markdown-It instances
+ */
+export default function attributes(md) {
+  md.core.ruler.push("curly_attributes", curlyAttrs);
+}
+
+/**
+ * Main function to process tokens and apply attributes
+ *
+ * @param {{tokens: Array<Object>}} state - Token state
+ */
+function curlyAttrs(state) {
+  const tokens = state.tokens;
+  const omissions = [];
+  let parent;
+  const stack = { len: 0, contents: [], types: {} };
+
+  tokens.forEach((token, i) => {
+    if (isOpener(token.type) || TAGS_SELF_CLOSING[token.type]) {
+      sPush(stack, token);
+    }
+
+    if (token.type === "html_block") {
+      const m = token.content.match(TAGS_EXPR);
+      if (!m) return;
+
+      parent = findParent(stack, m[1], m[2]);
+      if (parent && applyToToken(parent, m[3])) {
+        omissions.unshift(i);
+      }
+    }
+
+    if (token.type === "inline") {
+      curlyInline(token.children, stack);
+    }
+  });
+
+  omissions.forEach((idx) => tokens.splice(idx, 1));
+}
+
+// Utility functions below this line handle specific tasks within the plugin logic
+
+/**
+ * Check if a token type is a block opener
+ *
+ * @param {String} type - Token type
+ */
+function isOpener(type) {
+  return (
+    type.match(/_(open|start)$/) || type === "fence" || type === "code_block"
+  );
+}
+
+/**
+ * Process inline tokens for attributes
+ *
+ * @param {Array<Object>} children - Inline children
+ * @param {Object} stack
+ */
+function curlyInline(children, stack) {
+  let lastText;
+  const omissions = [];
+
+  children.forEach((child, i) => {
+    if (
+      isOpener(child.type) ||
+      TAGS_SELF_CLOSING[child.type] ||
+      child.type === "code_inline"
+    ) {
+      sPush(stack, child);
+    }
+
+    const m = child.content.match(TAGS_EXPR);
+    if (m) {
+      const parent = findParent(stack, m[1], m[2]);
+      if (parent && applyToToken(parent, m[3])) {
+        omissions.unshift(i);
+        if (lastText) trimRight(lastText, "content");
+      }
+    }
+
+    if (child.type === "text") lastText = child;
+  });
+
+  omissions.forEach((idx) => children.splice(idx, 1));
+}
+
+/**
+ * Find parent token for applying attributes
+ *
+ * @param {Object} stack
+ * @param {String} tag
+ * @param {Number | String} depth
+ */
+function findParent(stack, tag, depth) {
+  if (!tag) return stack.last;
+
+  if (depth === "^") {
+    depth = 1;
+  } else if (typeof depth === "string") {
+    depth = +depth.slice(1);
+  } else {
+    depth = 0;
+  }
+
+  const targets = TAGS_OPENING[tag.toLowerCase()] || [tag.toLowerCase()];
+  const target = targets.find((t) => stack.types[t]);
+  const list = stack.types[target];
+  if (!list) return;
+
+  return list[list.length - 1 - depth];
+}
+
+/**
+ * Apply attributes to a token, correctly handling id and classes
+ *
+ * @param {Object} token
+ * @param {String} attrs
+ */
+function applyToToken(token, attrs) {
+  let m;
+
+  // Iterate over the attributes string to find all matches for id, class, or other attributes
+  while (attrs.length > 0) {
+    // Match class names, prefixed with a dot (.)
+    if ((m = attrs.match(/^\s*\.([a-zA-Z0-9\-_]+)/))) {
+      addAttr(token, "class", m[1], { append: true });
+      attrs = attrs.slice(m[0].length);
+    }
+    // Match IDs, prefixed with a hash (#)
+    else if ((m = attrs.match(/^\s*#([a-zA-Z0-9\-_]+)/))) {
+      addAttr(token, "id", m[1]);
+      attrs = attrs.slice(m[0].length);
+    }
+    // Match other attributes in the format attr="value"
+    else if ((m = attrs.match(/^\s*([a-zA-Z0-9\-_]+)="([^"]*)"/))) {
+      addAttr(token, m[1], m[2]);
+      attrs = attrs.slice(m[0].length);
+    }
+    // Match other attributes in the format attr='value'
+    else if ((m = attrs.match(/^\s*([a-zA-Z0-9\-_]+)='([^']*)'/))) {
+      addAttr(token, m[1], m[2]);
+      attrs = attrs.slice(m[0].length);
+    }
+    // Match other attributes without quotes
+    else if ((m = attrs.match(/^\s*([a-zA-Z0-9\-_]+)=([^ ]*)/))) {
+      addAttr(token, m[1], m[2]);
+      attrs = attrs.slice(m[0].length);
+    }
+    // Match boolean attributes
+    else if ((m = attrs.match(/^\s*([a-zA-Z0-9\-_]+)/))) {
+      addAttr(token, m[1], "");
+      attrs = attrs.slice(m[0].length);
+    }
+    // Skip whitespace
+    else if ((m = attrs.match(/^\s+/))) {
+      attrs = attrs.slice(m[0].length);
+    }
+    // If no matches are found, break the loop to avoid an infinite loop
+    else {
+      break;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Function to add or append an attribute to a token
+ *
+ * @param {Object} token
+ * @param {String} attr
+ * @param {String} value
+ * @param {Object} options
+ */
+function addAttr(token, attr, value, options = {}) {
+  const idx = token.attrIndex(attr);
+
+  // If the attribute is 'class' and append is true, add the value to the existing class list
+  if (attr === "class" && options.append && idx !== -1) {
+    // Ensure not to duplicate the class name
+    if (!token.attrs[idx][1].includes(value)) {
+      token.attrs[idx][1] += ` ${value}`;
+    }
+  } else if (idx === -1) {
+    // If the attribute does not exist, add it
+    token.attrPush([attr, value]);
+  } else if (options.append) {
+    token.attrs[idx][1] += ` ${value}`;
+  } else {
+    // If the attribute exists and it's not class append, replace its value
+    token.attrs[idx][1] = value;
+  }
+}
+
+/**
+ * Push a token to the stack
+ *
+ * @param {Object} stack
+ * @param {Object} token
+ */
+function sPush(stack, token) {
+  const type = token.type.replace(/_(open|start)$/, "");
+  if (!stack.types[type]) stack.types[type] = [];
+  stack.types[type].push(token);
+  stack.last = token;
+}
+
+/**
+ * Trim whitespace from the right of a string
+ *
+ * @param {Object} obj
+ * @param {String} attr
+ */
+function trimRight(obj, attr) {
+  obj[attr] = obj[attr].replace(/\s*$/, "");
+}

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -1,3 +1,4 @@
 export { default as PrimaryStory } from "./primary"; // StoryTelling with markdown string
 export { default as MarkdownAsURLStory } from "./markdown-url"; // StoryTelling with markdown URL
 export { default as MarkdownSlotStory } from "./markdown-slot"; // StoryTelling with markdown from the slot
+export { default as MarkdownAttrCommentStory } from "./markdown-attr-comment"; // StoryTelling using attribute as comments in markdown

--- a/elements/storytelling/stories/markdown-attr-comment.js
+++ b/elements/storytelling/stories/markdown-attr-comment.js
@@ -1,0 +1,25 @@
+/**
+ * Renders storytelling using attribute as a comment in markdown.
+ */
+import { html } from "lit";
+import "../src/main.js";
+
+export const MarkdownAttrComment = {
+  args: {
+    markdown: `
+  ## Hero World section <!--{.some-comment}-->
+  Some text with red color <!--{#red-color style="color:red;"}-->
+  
+  ![Image](https://www.gstatic.com/prettyearth/assets/full/14617.jpg)<!-- {width=300} -->
+`,
+  },
+  render: (args) => html`
+    <!-- Render eox-storytelling with attribute as comment markdown. -->
+    <eox-storytelling
+      id="markdown-str"
+      markdown=${args.markdown}
+    ></eox-storytelling>
+  `,
+};
+
+export default MarkdownAttrComment;

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -2,7 +2,12 @@
  * Stories for eox-storytelling component showcasing various configurations.
  * These stories provide visual representations and usage examples for different scenarios.
  */
-import { PrimaryStory, MarkdownAsURLStory, MarkdownSlotStory } from "./index";
+import {
+  PrimaryStory,
+  MarkdownAsURLStory,
+  MarkdownSlotStory,
+  MarkdownAttrCommentStory,
+} from "./index";
 
 export default {
   title: "Elements/eox-storytelling",
@@ -26,3 +31,8 @@ export const MarkdownAsURL = MarkdownAsURLStory;
  * StoryTelling using markdown from the slot.
  */
 export const MarkdownInsideSlot = MarkdownSlotStory;
+
+/**
+ * Renders storytelling using attribute as a comment in markdown.
+ */
+export const MarkdownWithAttributeAsComment = MarkdownAttrCommentStory;

--- a/elements/storytelling/test/cases/index.js
+++ b/elements/storytelling/test/cases/index.js
@@ -3,3 +3,4 @@
 export { default as loadMarkdownTest } from "./load-markdown";
 export { default as loadMarkdownUrlTest } from "./load-markdown-url";
 export { default as loadMarkdownSlot } from "./load-markdown-slot";
+export { default as loadMarkdownAttrComment } from "./load-markdown-attribute-comment";

--- a/elements/storytelling/test/cases/load-markdown-attribute-comment.js
+++ b/elements/storytelling/test/cases/load-markdown-attribute-comment.js
@@ -1,0 +1,29 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { storyTelling } = TEST_SELECTORS;
+
+/**
+ * Load markdown with attributes from comment
+ */
+const loadMarkdownAttrComment = () => {
+  const testText = "Hello World!";
+  const testId = "red-color";
+  const testClass = "red";
+  const testColor = "rgb(255, 0, 0)";
+
+  cy.mount(
+    `<eox-storytelling markdown="# ${testText} <!--{#${testId} .${testClass} style='color:${testColor};'}-->"></eox-storytelling>`
+  ).as(storyTelling);
+
+  cy.get(storyTelling)
+    .shadow()
+    .within(() => {
+      cy.get("h1").should("have.text", testText);
+      cy.get("h1").should("have.id", testId);
+      cy.get("h1").should("have.class", testClass);
+      cy.get("h1").should("have.css", "color", testColor);
+    });
+};
+
+export default loadMarkdownAttrComment;

--- a/elements/storytelling/test/general.cy.js
+++ b/elements/storytelling/test/general.cy.js
@@ -5,6 +5,7 @@ import {
   loadMarkdownTest,
   loadMarkdownUrlTest,
   loadMarkdownSlot,
+  loadMarkdownAttrComment,
 } from "./cases";
 
 // Test suite for Storytelling
@@ -17,4 +18,7 @@ describe("Storytelling", () => {
 
   // Test case to ensure the storytelling component loads successfully and renders passed markdown from the slot
   it("loads markdown from slot", () => loadMarkdownSlot());
+
+  // Test case to ensure the storytelling component loads with attribute from comments
+  it("load markdown as attribute as comments", () => loadMarkdownAttrComment());
 });


### PR DESCRIPTION
## Implemented changes
- Added improved [markdown-it-decorate](https://github.com/rstacruz/markdown-it-decorate)
  - Converted to ES6 
  - Added comments 
  - We can expand it in the future based on adding new features to it.
- Example markdown 

```markdown
## Hero World section <!--{.some-comment}-->
Some text with red color <!--{#red-color style="color:red;"}-->
  
![Image](https://www.gstatic.com/prettyearth/assets/full/14617.jpg)<!-- {width=300} -->
```

## Screenshots/Videos

<img width="589" alt="image" src="https://github.com/EOX-A/EOxElements/assets/10809211/c6ca0d76-33aa-4153-9c51-949aaaf20819">


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
