### PR TITLE
fix(style): restrict `iframe`, `img`, `video` max width by default

### DIFF
--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -97,6 +97,11 @@ export class EOxStoryTelling extends LitElement {
       <style>
         :host { display: block; }
         .slot-hide { display: none; }
+        iframe,
+        img,
+        video {
+          max-width: 100%;
+        }
         ${!this.unstyled && mainStyle}
       </style>
       <slot class="slot-hide" @slotchange=${this.handleSlotChange}></slot>


### PR DESCRIPTION
## Implemented changes
This PR introduces a default general restriction for the width of `iframe`, `img` and `video` elements. These elements shouldn't break out of the page by default, and setting them to `max-width: 100%` helps contain them.

In case someone wants to explicitly override this default and set them larger, it will be possible using #700.

## Screenshots/Videos

### Before
![image](https://github.com/EOX-A/EOxElements/assets/26576876/e9f2d1c6-8963-4814-adc1-28e1489b3213)

### After
![image](https://github.com/EOX-A/EOxElements/assets/26576876/a1410864-16fc-4746-968b-e50d45128e29)

### Explicit override with comment attrs
E.g. `<!-- {style=max-width:150%} -->`
![image](https://github.com/EOX-A/EOxElements/assets/26576876/c8100285-2a64-46be-a50f-b800375ee7af)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
