### PR TITLE
fix!: remove @eox/jsonform import from layercontrol

### DIFF
--- a/elements/layercontrol/src/components/layer-config.js
+++ b/elements/layercontrol/src/components/layer-config.js
@@ -1,6 +1,4 @@
 import { LitElement, html } from "lit";
-// import "../../../jsonform/src/main";
-// import "@eox/jsonform";
 import { getStartVals } from "../helpers";
 import { dataChangeMethod } from "../methods/layer-config";
 import { when } from "lit/directives/when.js";

--- a/elements/layercontrol/src/components/layer-config.js
+++ b/elements/layercontrol/src/components/layer-config.js
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
-import "../../../jsonform/src/main";
+// import "../../../jsonform/src/main";
+// import "@eox/jsonform";
 import { getStartVals } from "../helpers";
 import { dataChangeMethod } from "../methods/layer-config";
 import { when } from "lit/directives/when.js";
@@ -111,7 +112,9 @@ export class EOxLayerControlLayerConfig extends LitElement {
   render() {
     // Fetch initial values for the layer and its configuration
     this.#startVals = getStartVals(this.layer, this.layerConfig);
-
+    if (!customElements.get("eox-jsonform")) {
+      console.error("Please import @eox/jsonform in order to use layerconfig");
+    }
     // Options for the JSON form rendering
     const options = {
       disable_edit_json: true,
@@ -133,7 +136,9 @@ export class EOxLayerControlLayerConfig extends LitElement {
             .startVals=${this.#startVals}
             .options=${options}
             @change=${this.debouncedDataChange}
-          ></eox-jsonform>
+            >Please import @eox/jsonform in order to use
+            layerconfig</eox-jsonform
+          >
         `
       )}
     `;

--- a/elements/layercontrol/src/components/layer-config.js
+++ b/elements/layercontrol/src/components/layer-config.js
@@ -134,9 +134,7 @@ export class EOxLayerControlLayerConfig extends LitElement {
             .startVals=${this.#startVals}
             .options=${options}
             @change=${this.debouncedDataChange}
-            >Please import @eox/jsonform in order to use
-            layerconfig</eox-jsonform
-          >
+          ></eox-jsonform>
         `
       )}
     `;

--- a/elements/layercontrol/stories/layercontrol.stories.js
+++ b/elements/layercontrol/stories/layercontrol.stories.js
@@ -1,5 +1,6 @@
 import "@eox/map/src/plugins/advancedLayersAndSources";
 import "@eox/map/main";
+import "@eox/jsonform";
 import "../src/main";
 import {
   ExclusiveLayersStory,
@@ -59,6 +60,7 @@ export const Tools = ToolsStory;
  * The "config" tool reads settings passed via the "layerConfig" property,
  * e.g. rendering a from from a provided JSON schema that allows updating the
  * source url parameters.
+ * Needs import of `@eox/jsonform` in order to work.
  */
 export const LayerConfig = LayerConfigStory;
 


### PR DESCRIPTION
## Implemented changes
Remove import of @eox/jsonform from layercontrol
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
Bundle size before removal of `@eox/jsonform` package
```
dist/eox-layercontrol.js  547.90 kB │ gzip: 119.85 kB
dist/eox-layercontrol.umd.cjs  421.72 kB │ gzip: 102.76 kB
```
Bundle size after removal of `@eox/jsonform` package
<img width="901" alt="Screenshot 2024-03-05 at 17 15 42" src="https://github.com/EOX-A/EOxElements/assets/17007165/1b76d281-ae2b-455e-b098-ec0a47d1aefa">


Fixes #585 
<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
