### PR TITLE
feat: introduce reactive `items` property

### DIFF
--- a/elements/itemfilter/itemfilter.stories.js
+++ b/elements/itemfilter/itemfilter.stories.js
@@ -1,5 +1,4 @@
 import { html } from "lit";
-import { EOxItemFilter } from "./src/main";
 import "./src/main";
 import "./src/autocomplete";
 import "./src/selectionlist";

--- a/elements/itemfilter/itemfilter.stories.js
+++ b/elements/itemfilter/itemfilter.stories.js
@@ -1,3 +1,4 @@
+import { html } from "lit";
 import { EOxItemFilter } from "./src/main";
 import "./src/main";
 import "./src/autocomplete";
@@ -10,168 +11,179 @@ export default {
   title: "Elements/eox-itemfilter",
   tags: ["autodocs"],
   component: "eox-itemfilter",
-  render: (args) => {
-    const eoxItemFilter = new EOxItemFilter();
-    eoxItemFilter.config = args;
-    eoxItemFilter.apply(items);
-    return eoxItemFilter;
-  },
+  render: (args) =>
+    html`<eox-itemfilter
+      .config=${args.config}
+      .items=${args.items}
+    ></eox-itemfilter>`,
 };
 
 export const Primary = {
   args: {
-    titleProperty: "title",
-    filterProperties: [
-      {
-        keys: ["title", "themes"],
-        title: "Search",
-        type: "text",
-        expanded: true,
-        // state: {
-        //   title: "no2",
-        //   themes: "no2",
-        // },
+    config: {
+      titleProperty: "title",
+      filterProperties: [
+        {
+          keys: ["title", "themes"],
+          title: "Search",
+          type: "text",
+          expanded: true,
+          // state: {
+          //   title: "no2",
+          //   themes: "no2",
+          // },
+        },
+        {
+          key: "themes",
+          title: "Theme",
+          type: "multiselect",
+          // state: {
+          //   air: true,
+          //   agriculture: true,
+          // },
+        },
+        {
+          key: "timestamp",
+          type: "range",
+          format: "date",
+          // state: {
+          //   min: 1685232950,
+          //   max: 1686454646,
+          // },
+        },
+        {
+          key: "geometry",
+          type: "spatial",
+          // state: {
+          //   mode: "within",
+          //   geometry: {
+          //     type: "Polygon",
+          //     coordinates: [
+          //       [
+          //         [-97.71428571428572, 38.00407795331557],
+          //         [-102.00000000000001, -40.329636215359066],
+          //         [81.85714285714282, -47.42214099287611],
+          //         [50.57142857142855, 51.0574434128921],
+          //         [-97.71428571428572, 38.00407795331557],
+          //       ],
+          //     ],
+          //   },
+          // },
+        },
+      ],
+      aggregateResults: "themes",
+      enableHighlighting: true,
+      onSelect: (item) => {
+        console.log(item);
       },
-      {
-        key: "themes",
-        title: "Theme",
-        type: "multiselect",
-        // state: {
-        //   air: true,
-        //   agriculture: true,
-        // },
-      },
-      {
-        key: "timestamp",
-        type: "range",
-        format: "date",
-        // state: {
-        //   min: 1685232950,
-        //   max: 1686454646,
-        // },
-      },
-      {
-        key: "geometry",
-        type: "spatial",
-        // state: {
-        //   mode: "within",
-        //   geometry: {
-        //     type: "Polygon",
-        //     coordinates: [
-        //       [
-        //         [-97.71428571428572, 38.00407795331557],
-        //         [-102.00000000000001, -40.329636215359066],
-        //         [81.85714285714282, -47.42214099287611],
-        //         [50.57142857142855, 51.0574434128921],
-        //         [-97.71428571428572, 38.00407795331557],
-        //       ],
-        //     ],
-        //   },
-        // },
-      },
-    ],
-    aggregateResults: "themes",
-    enableHighlighting: true,
-    onSelect: (item) => {
-      console.log(item);
     },
+    items,
   },
 };
 
 export const MultiSelect = {
   args: {
-    titleProperty: "title",
-    filterProperties: [
-      {
-        key: "themes",
-        title: "Theme",
-        type: "multiselect",
-        expanded: true,
-        state: {
-          air: true,
-          agriculture: true,
+    config: {
+      titleProperty: "title",
+      filterProperties: [
+        {
+          key: "themes",
+          title: "Theme",
+          type: "multiselect",
+          expanded: true,
+          state: {
+            air: true,
+            agriculture: true,
+          },
         },
-      },
-    ],
+      ],
+    },
+    items,
   },
 };
 
 export const SortedMultiSelect = {
   args: {
-    titleProperty: "title",
-    filterProperties: [
-      {
-        key: "themes",
-        title: "Theme",
-        type: "multiselect",
-        expanded: true,
-        sort: (a, b) => b.localeCompare(a),
-        state: {
-          air: true,
-          agriculture: true,
+    config: {
+      titleProperty: "title",
+      filterProperties: [
+        {
+          key: "themes",
+          title: "Theme",
+          type: "multiselect",
+          expanded: true,
+          sort: (a, b) => b.localeCompare(a),
+          state: {
+            air: true,
+            agriculture: true,
+          },
         },
-      },
-    ],
+      ],
+    },
+    items,
   },
 };
 
 export const InlineMode = {
   args: {
-    inlineMode: true,
-    titleProperty: "title",
-    filterProperties: [
-      {
-        key: "themes",
-        id: "themes",
-        title: "Theme",
-        type: "multiselect",
-        state: {
-          air: null,
-          agriculture: null,
+    config: {
+      inlineMode: true,
+      titleProperty: "title",
+      filterProperties: [
+        {
+          key: "themes",
+          id: "themes",
+          title: "Theme",
+          type: "multiselect",
+          state: {
+            air: null,
+            agriculture: null,
+          },
         },
-      },
-      {
-        key: "timestamp",
-        id: "date",
-        title: "Date",
-        type: "range",
-        format: "date",
-        state: {
-          min: 1685232950,
-          max: 1686454646,
+        {
+          key: "timestamp",
+          id: "date",
+          title: "Date",
+          type: "range",
+          format: "date",
+          state: {
+            min: 1685232950,
+            max: 1686454646,
+          },
         },
-      },
-      {
-        key: "geometry",
-        id: "spatial",
-        type: "spatial",
-        title: "Spatial",
-        state: {
-          mode: "intersects",
+        {
+          key: "geometry",
+          id: "spatial",
+          type: "spatial",
+          title: "Spatial",
+          state: {
+            mode: "intersects",
+          },
         },
-      },
-      {
-        key: "code",
-        id: "code",
-        title: "Code",
-        type: "multiselect",
-        // state: {
-        //   air: true,
-        //   agriculture: true,
-        // },
-      },
-      {
-        keys: ["title", "themes"],
-        title: "Search",
-        id: "search",
-        type: "text",
-        expanded: true,
-        state: {
-          title: "no2",
-          themes: "no2",
+        {
+          key: "code",
+          id: "code",
+          title: "Code",
+          type: "multiselect",
+          // state: {
+          //   air: true,
+          //   agriculture: true,
+          // },
         },
-      },
-    ],
-    onFilter: (items) => console.log(items),
+        {
+          keys: ["title", "themes"],
+          title: "Search",
+          id: "search",
+          type: "text",
+          expanded: true,
+          state: {
+            title: "no2",
+            themes: "no2",
+          },
+        },
+      ],
+      onFilter: (items) => console.log(items),
+    },
+    items,
   },
 };

--- a/elements/itemfilter/test/general.cy.ts
+++ b/elements/itemfilter/test/general.cy.ts
@@ -13,21 +13,23 @@ describe("Item Filter Config", () => {
       .as("eox-itemfilter")
       .then(($el) => {
         const eoxItemFilter = <EOxItemFilter>$el[0];
-        eoxItemFilter.config = {
-          titleProperty: "title",
-          filterProperties: [
-            {
-              keys: ["title", "themes"],
-              title: "Search",
-              type: "text",
-              expanded: true,
-            },
-            { key: "themes", expanded: true },
-          ],
-          aggregateResults: "themes",
-          enableHighlighting: true,
-        };
-        eoxItemFilter.apply(testItems);
+        Object.assign(eoxItemFilter, {
+          config: {
+            titleProperty: "title",
+            filterProperties: [
+              {
+                keys: ["title", "themes"],
+                title: "Search",
+                type: "text",
+                expanded: true,
+              },
+              { key: "themes", expanded: true },
+            ],
+            aggregateResults: "themes",
+            enableHighlighting: true,
+          },
+          items: testItems,
+        });
       });
   });
 
@@ -195,17 +197,19 @@ describe("Item Filter Config", () => {
   it("should show the map when spatial filter is enabled", () => {
     cy.get("eox-itemfilter").and(($el) => {
       const eoxItemFilter = <EOxItemFilter>$el[0];
-      eoxItemFilter.config = {
-        titleProperty: "title",
-        filterProperties: [
-          {
-            key: "geometry",
-            type: "spatial",
-            expanded: true,
-          },
-        ],
-      };
-      eoxItemFilter.apply(testItems);
+      Object.assign(eoxItemFilter, {
+        config: {
+          titleProperty: "title",
+          filterProperties: [
+            {
+              key: "geometry",
+              type: "spatial",
+              expanded: true,
+            },
+          ],
+        },
+        items: testItems,
+      });
     });
     cy.get("eox-itemfilter")
       .shadow()

--- a/elements/itemfilter/test/state.cy.ts
+++ b/elements/itemfilter/test/state.cy.ts
@@ -19,22 +19,24 @@ describe("Item Filter Config", () => {
       .as("eox-itemfilter")
       .then(($el) => {
         const eoxItemFilter = <EOxItemFilter>$el[0];
-        eoxItemFilter.config = {
-          titleProperty: "title",
-          filterProperties: [
-            {
-              key: "themes",
-              type: "multiselect",
-              expanded: true,
-              sort: (a, b) => customOrder[a] - customOrder[b],
-              // @ts-ignore
-              state,
-            },
-          ],
-          aggregateResults: "themes",
-        };
-        eoxItemFilter.apply(testItems);
-        eoxItemFilter.selectedResult = testItems[selectedResultIndex];
+        Object.assign(eoxItemFilter, {
+          config: {
+            titleProperty: "title",
+            filterProperties: [
+              {
+                key: "themes",
+                type: "multiselect",
+                expanded: true,
+                sort: (a, b) => customOrder[a] - customOrder[b],
+                // @ts-ignore
+                state,
+              },
+            ],
+            aggregateResults: "themes",
+          },
+          items: testItems,
+          selectedResult: testItems[selectedResultIndex],
+        });
       });
   });
 

--- a/elements/itemfilter/test/state.cy.ts
+++ b/elements/itemfilter/test/state.cy.ts
@@ -27,6 +27,7 @@ describe("Item Filter Config", () => {
                 key: "themes",
                 type: "multiselect",
                 expanded: true,
+                // @ts-ignore
                 sort: (a, b) => customOrder[a] - customOrder[b],
                 // @ts-ignore
                 state,


### PR DESCRIPTION
## Implemented changes
This PR introduces a reactive `items` property for setting items. Up until now, `eoxItemFilter.items` was only used to retrieve the current state, now it can also be set:

```
eoxItemFilter.items = [{...}]
```

Under the hood, this does the same as the `apply()` function; it's just more web component-like and easier to render in the storybook.

Implements https://github.com/EOX-A/EOxElements/issues/718.

Stories and tests have been updated accordingly.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have adapted tests related to this feature/fix
- [x] I have adapted stories showcasing this feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
