### PR TITLE
feat: dispatch layerchange event

### DIFF
--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -154,14 +154,11 @@ export class EOxLayerControl extends LitElement {
    */
   #handleLayerControlLayerListChange(evt) {
     layerListChangeMethod(evt, this);
-  }
-
-  _emitLayerChangeEvent(detail) {
     /**
      * A generic layer change event; could be a layer visibility, group length updates and others.
      * Passes the changed layer in the `detail`.
      */
-    this.dispatchEvent(new CustomEvent("layerchange", { detail }));
+    this.dispatchEvent(new CustomEvent("layerchange", { detail: evt.detail }));
   }
 
   render() {

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -156,6 +156,14 @@ export class EOxLayerControl extends LitElement {
     layerListChangeMethod(evt, this);
   }
 
+  _emitLayerChangeEvent(detail) {
+    /**
+     * A generic layer change event; could be a layer visibility, group length updates and others.
+     * Passes the changed layer in the `detail`.
+     */
+    this.dispatchEvent(new CustomEvent("layerchange", { detail }));
+  }
+
   render() {
     // Checks if there are any layers with the 'layerControlOptional' property set to true
     // @ts-ignore

--- a/elements/layercontrol/src/methods/layer/input-click.js
+++ b/elements/layercontrol/src/methods/layer/input-click.js
@@ -34,7 +34,7 @@ const inputClickMethod = (evt, EOxLayerControlLayer) => {
 
   // Dispatch a 'changed' event to signal a change in the layer's state.
   EOxLayerControlLayer.dispatchEvent(
-    new CustomEvent("changed", { bubbles: true })
+    new CustomEvent("changed", { bubbles: true, detail: layer })
   );
 
   // Request an update for the layer control to reflect the changes.

--- a/elements/layercontrol/src/methods/layercontrol/layer-list-change.js
+++ b/elements/layercontrol/src/methods/layercontrol/layer-list-change.js
@@ -5,6 +5,7 @@
  * @param {import("../../main").EOxLayerControl} EOxLayerControl - The EOxLayerControl element.
  */
 const layerListChangeMethod = (evt, EOxLayerControl) => {
+  EOxLayerControl._emitLayerChangeEvent(evt.detail);
   // Request an update for the EOxLayerControl
   EOxLayerControl.requestUpdate();
 

--- a/elements/layercontrol/src/methods/layercontrol/layer-list-change.js
+++ b/elements/layercontrol/src/methods/layercontrol/layer-list-change.js
@@ -5,7 +5,6 @@
  * @param {import("../../main").EOxLayerControl} EOxLayerControl - The EOxLayerControl element.
  */
 const layerListChangeMethod = (evt, EOxLayerControl) => {
-  EOxLayerControl._emitLayerChangeEvent(evt.detail);
   // Request an update for the EOxLayerControl
   EOxLayerControl.requestUpdate();
 

--- a/elements/layercontrol/test/cases/layer-update/check-layer-changed-event.js
+++ b/elements/layercontrol/test/cases/layer-update/check-layer-changed-event.js
@@ -1,0 +1,29 @@
+const checkLayerChangedEvent = () => {
+  let mockLayer;
+
+  // Set up the mock map with an initial layer
+  cy.get("mock-map").and(($el) => {
+    const mockMap = $el[0];
+    mockMap.setLayers([{ properties: { title: "foo" } }]);
+    mockLayer = mockMap.map.getLayers().getArray()[0];
+  });
+
+  // Set up event listener
+  cy.get("eox-layercontrol").and(($el) => {
+    $el[0].addEventListener("layerchange", (evt) => {
+      if (evt.detail) {
+        // Verify if the `layerchange` event triggers with layer as `detail`
+        expect(evt.detail).to.eq(mockLayer);
+      }
+    });
+  });
+
+  // Change visibility of the layer by clicking the checkbox
+  cy.get("eox-layercontrol")
+    .shadow()
+    .within(() => {
+      cy.get(".layer").find("input").click();
+    });
+};
+
+export default checkLayerChangedEvent;

--- a/elements/layercontrol/test/cases/layer-update/index.js
+++ b/elements/layercontrol/test/cases/layer-update/index.js
@@ -6,3 +6,4 @@ export { default as checkLayerRemovedFromGroup } from "./check-layer-removed-fro
 export { default as addLayerFromOptional } from "./add-layer-from-optional";
 export { default as checkLayerZoomState } from "./check-layer-zoom-state";
 export { default as addExternalLayers } from "./add-external-layer";
+export { default as checkLayerChangedEvent } from "./check-layer-changed-event";

--- a/elements/layercontrol/test/layersUpdate.cy.js
+++ b/elements/layercontrol/test/layersUpdate.cy.js
@@ -9,6 +9,7 @@ import {
   checkLayerRemovedFromRoot,
   checkLayerSizeAfterMultipleCalls,
   checkLayerZoomState,
+  checkLayerChangedEvent,
 } from "./cases/layer-update";
 
 describe("LayerControl", () => {
@@ -64,4 +65,8 @@ describe("LayerControl", () => {
   // Test case: Add new external layers (WMS/XYZ and JSON)
   it("Add new external WMS/XYZ and JSON Layer - addExternalLayers", () =>
     addExternalLayers());
+
+  // Test case: `layerchange` event
+  it("Checks if a `layerchange` event is dispatched", () =>
+    checkLayerChangedEvent());
 });


### PR DESCRIPTION
## Implemented changes

This PR adds a generic `layerchange` event to `eox-layercontrol`. Currently it triggers when a layer's visibility is changed or the length of layers inside a group is changed; more events could be added in the future.

Usage:
```js
eoxLayerControl.addEventListener("layerchange", (e) => {
  console.log(e.detail.get("id))  
  console.log(e.detail.getVisible())
})
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] I have added documentation
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
