### PR TITLE
feat: switch projections & allow advanced projections

### DIFF
--- a/elements/map/helpers.ts
+++ b/elements/map/helpers.ts
@@ -11,6 +11,8 @@ import { getUid } from "ol";
 import { DrawEvent } from "ol/interaction/Draw";
 import { DragAndDropEvent } from "ol/interaction/DragAndDrop";
 import Feature from "ol/Feature";
+import proj4 from "proj4";
+import { register } from "ol/proj/proj4";
 
 /**
  * Specifies the options for reading features with defined source and target projections.
@@ -212,4 +214,12 @@ export function isTopoJSON(text: string): boolean {
   } catch (e) {
     return false;
   }
+}
+
+export function registerProjection(
+  name: string,
+  projection: string | proj4.ProjectionDefinition
+) {
+  proj4.defs(name, projection);
+  register(proj4);
 }

--- a/elements/map/helpers.ts
+++ b/elements/map/helpers.ts
@@ -12,7 +12,7 @@ import { DrawEvent } from "ol/interaction/Draw";
 import { DragAndDropEvent } from "ol/interaction/DragAndDrop";
 import Feature from "ol/Feature";
 import proj4 from "proj4";
-import { register } from "ol/proj/proj4";
+import { fromEPSGCode, register } from "ol/proj/proj4";
 
 /**
  * Specifies the options for reading features with defined source and target projections.
@@ -216,6 +216,22 @@ export function isTopoJSON(text: string): boolean {
   }
 }
 
+/**
+ * given a projection code, this fetches the definition from epsg.io
+ * and registers the projection using proj4
+ * @param code The EPSG code (e.g. 4326 or 'EPSG:4326').
+ *
+ */
+export async function registerProjectionFromCode(code: string | number) {
+  register(proj4);
+  return await fromEPSGCode(code);
+}
+
+/**
+ * registers a projection under a given name, defined via a proj4 definition
+ * @param name name of the projection (e.g. "EPSG:4326")
+ * @param projection proj4 projection definition string
+ */
 export function registerProjection(
   name: string,
   projection: string | proj4.ProjectionDefinition

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -23,7 +23,12 @@ import {
   removeDefaultScrollInteractions,
 } from "./src/utils";
 import GeoJSON from "ol/format/GeoJSON";
-import { parseText, READ_FEATURES_OPTIONS } from "./helpers";
+import {
+  parseText,
+  registerProjection,
+  registerProjectionFromCode,
+  READ_FEATURES_OPTIONS,
+} from "./helpers";
 import Feature from "ol/Feature";
 import { Geometry } from "ol/geom";
 import VectorLayer from "ol/layer/Vector.js";
@@ -445,6 +450,10 @@ export class EOxMap extends LitElement {
   ) => {
     parseText(text, vectorLayer, this, replaceFeatures);
   };
+
+  registerProjectionFromCode = registerProjectionFromCode;
+
+  registerProjection = registerProjection;
 
   /**
    * Gets all map layers (including groups and nested layers)

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -89,7 +89,7 @@ export class EOxMap extends LitElement {
   private _center: Coordinate = [0, 0];
 
   set center(center: Coordinate) {
-    const centerIsSame = coordinatesRoughlyEquals(
+    const centerIsSame = center?.length && coordinatesRoughlyEquals(
       center,
       this.map.getView().getCenter()
     );

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -224,7 +224,7 @@ export class EOxMap extends LitElement {
   /**
    * projection of the map view as SRS-identifier (e.g. EPSG:4326)
    */
-  @property({ attribute: "prevent-scroll", type: Boolean })
+  @property({ attribute: "projection", type: String })
   set projection(projection: ProjectionLike) {
     const oldView = this.map.getView();
     if (projection && projection !== oldView.getProjection().getCode()) {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -89,10 +89,9 @@ export class EOxMap extends LitElement {
   private _center: Coordinate = [0, 0];
 
   set center(center: Coordinate) {
-    const centerIsSame = center?.length && coordinatesRoughlyEquals(
-      center,
-      this.map.getView().getCenter()
-    );
+    const centerIsSame =
+      center?.length &&
+      coordinatesRoughlyEquals(center, this.map.getView().getCenter());
     if (center && !centerIsSame) {
       if (!this.projection || this.projection === "EPSG:3857") {
         // we allow lat-lon center when map is in web mercator

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -486,6 +486,12 @@ export const ConfigObject = {
     `,
 };
 
+/**
+ * The projection of the view can be changed via the `projection`-attribute.
+ * Out-of-the-box the projections EPSG:3857 (default) and EPSG:4326 (geographic coordinates)
+ * are included, additional projections can be used by registering them via the `registerProjection` or 
+ * `registerProjectionFromCode` helper functions beforehand. 
+ */
 export const Projection = {
   args: {
     layers: [

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -486,6 +486,48 @@ export const ConfigObject = {
     `,
 };
 
+export const Projection = {
+  args: {
+    layers: [
+      {
+        type: "Tile",
+        properties: {
+          id: "osm",
+          title: "Background",
+        },
+        source: { type: "OSM" },
+      },
+    ],
+    center: [16.8, 48.2],
+    zoom: 7,
+  },
+  render: (args) =>
+    html`
+      <eox-map
+        id="projectionMap"
+        style="width: 100%; height: 300px;"
+        .center=${args.center}
+        .controls=${args.controls}
+        .layers=${args.layers}
+        .zoom=${args.zoom}
+      >
+      </eox-map>
+      <button
+        @click=${() => {
+          const eoxMap = document.querySelector("#projectionMap");
+          eoxMap.setAttribute(
+            "projection",
+            eoxMap.map.getView().getProjection().getCode() === "EPSG:4326"
+              ? "EPSG:3857"
+              : "EPSG:4326"
+          );
+        }}
+      >
+        change projection
+      </button>
+    `,
+};
+
 /**
  * By setting the `prevent-scroll` attribute or by setting `preventScroll` property to `true` (either on the element or within the config object),
  * the map doesnt mouse-scroll (on desktop) or drag-touch (on tab/mobile). Pressing the platform modifier key (ctrl/cmd) will enable scrolling.

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -489,8 +489,8 @@ export const ConfigObject = {
 /**
  * The projection of the view can be changed via the `projection`-attribute.
  * Out-of-the-box the projections EPSG:3857 (default) and EPSG:4326 (geographic coordinates)
- * are included, additional projections can be used by registering them via the `registerProjection` or 
- * `registerProjectionFromCode` helper functions beforehand. 
+ * are included, additional projections can be used by registering them via the `registerProjection` or
+ * `registerProjectionFromCode` helper functions beforehand.
  */
 export const Projection = {
   args: {

--- a/elements/map/src/utils.ts
+++ b/elements/map/src/utils.ts
@@ -14,10 +14,6 @@ export function coordinatesRoughlyEquals(
   coordinate2: import("ol/coordinate").Coordinate,
   epsilon = 0.001
 ): boolean {
-  /*if (!!coordinate1 !== !!coordinate2) { // if exactly one coordinate is not defined, the coordinates are not equal
-    return false;
-  }*/
-  return false;
   let equals = true;
   for (let i = coordinate1.length - 1; i >= 0; --i) {
     if (!numbersRoughlyEquals(coordinate1[i], coordinate2[i], epsilon)) {

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -18,7 +18,7 @@ describe("config property", () => {
             },
           ],
           view: {
-            center: [10, 20],
+            center: [16, 48],
             zoom: 9,
             projection: "EPSG:4326",
           },
@@ -27,7 +27,6 @@ describe("config property", () => {
     ).as("eox-map");
     cy.get("eox-map").and(async ($el) => {
       const eoxMap = <EOxMap>$el[0];
-
       expect(eoxMap.map.getControls().getLength()).to.be.equal(1);
 
       expect(eoxMap.map.getLayers().getArray().length).to.be.equal(1);
@@ -37,9 +36,8 @@ describe("config property", () => {
       expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
         "EPSG:4326"
       );
-      expect(eoxMap.map.getView().getCenter()[0]).to.be.closeTo(10, 0.0001);
-      expect(eoxMap.map.getView().getCenter()[1]).to.be.closeTo(20, 0.0001);
-
+      expect(eoxMap.map.getView().getCenter()[0]).to.be.closeTo(16, 0.0001);
+      expect(eoxMap.map.getView().getCenter()[1]).to.be.closeTo(48, 0.0001);
       expect(eoxMap.map.getView().getZoom()).to.be.equal(9);
     });
     cy.get("eox-map").and(async ($el) => {
@@ -56,7 +54,7 @@ describe("config property", () => {
           },
         ],
         view: {
-          center: [1113194, 2273030],
+          center: [1113194, 2273030], // [10, 20]
           zoom: 10,
           projection: "EPSG:3857",
         },

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -18,8 +18,9 @@ describe("config property", () => {
             },
           ],
           view: {
-            center: [1113194, 2273030],
+            center: [10, 20],
             zoom: 9,
+            projection: "EPSG:4326",
           },
         }}
       ></eox-map>`
@@ -33,9 +34,11 @@ describe("config property", () => {
 
       expect(eoxMap.map.getLayers().getArray()[0].get("id")).to.be.equal("osm");
 
-      expect(eoxMap.map.getView().getCenter()).to.deep.equal([
-        1113194, 2273030,
-      ]);
+      expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+        "EPSG:4326"
+      );
+      expect(eoxMap.map.getView().getCenter()[0]).to.be.closeTo(10, 0.0001);
+      expect(eoxMap.map.getView().getCenter()[1]).to.be.closeTo(20, 0.0001);
 
       expect(eoxMap.map.getView().getZoom()).to.be.equal(9);
     });
@@ -55,6 +58,7 @@ describe("config property", () => {
         view: {
           center: [1113194, 2273030],
           zoom: 10,
+          projection: "EPSG:3857",
         },
       };
 
@@ -64,6 +68,12 @@ describe("config property", () => {
       expect(eoxMap.map.getLayers().getArray()[0].get("title")).to.be.equal(
         "bar"
       );
+
+      expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+        "EPSG:3857"
+      );
+      expect(eoxMap.map.getView().getCenter()[0]).to.be.closeTo(1113194, 0.01);
+      expect(eoxMap.map.getView().getCenter()[1]).to.be.closeTo(2273030, 0.01);
     });
   });
 });

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -1,6 +1,5 @@
 import { html } from "lit";
 import "../main";
-import { registerProjection, registerProjectionFromCode } from "../helpers";
 import vectorLayerStyleJson from "./vectorLayer.json";
 
 describe("view projections", () => {
@@ -95,26 +94,22 @@ describe("view projections", () => {
     cy.intercept("https://openlayers.org/data/vector/ecoregions.json", {
       fixture: "/ecoregions.json",
     });
-    registerProjection(
-      "ESRI:53009",
-      "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
-        "+b=6371000 +units=m +no_defs"
-    );
     // not using osm because of performance issues while testing
-    cy.mount(
-      html`<eox-map
-        .layers=${vectorLayerStyleJson}
-        .projection=${"ESRI:53009"}
-      ></eox-map>`
-    ).as("eox-map");
+    cy.mount(html`<eox-map .layers=${vectorLayerStyleJson}></eox-map>`).as(
+      "eox-map"
+    );
 
     cy.get("eox-map").and(($el) => {
       const eoxMap = <EOxMap>$el[0];
-      setTimeout(() => {
-        expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
-          "ESRI:53009"
-        );
-      }, 1000);
+      eoxMap.registerProjection(
+        "ESRI:53009",
+        "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
+          "+b=6371000 +units=m +no_defs"
+      );
+      eoxMap.setAttribute("projection", "ESRI:53009");
+      expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+        "ESRI:53009"
+      );
     });
   });
 
@@ -157,14 +152,12 @@ describe("view projections", () => {
     ).as("eox-map");
 
     cy.get("eox-map").and(($el) => {
-      registerProjectionFromCode("EPSG:32633").then(() => {
-        const eoxMap = <EOxMap>$el[0];
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.registerProjectionFromCode("EPSG:32633").then(() => {
         eoxMap.setAttribute("projection", "EPSG:32633");
-        setTimeout(() => {
-          expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
-            "EPSG:32633"
-          );
-        }, 1000);
+        expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+          "EPSG:32633"
+        );
       });
     });
   });

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -1,0 +1,91 @@
+import { html } from "lit";
+import "../main";
+
+describe("view projections", () => {
+  it("can set the initial projection of the view", () => {
+    cy.intercept(/^.*openstreetmap.*$/, { fixture: "/tiles/osm/0/0/0.png" });
+    cy.mount(
+      html`<eox-map
+        .layers=${[
+          {
+            type: "Tile",
+            properties: {
+              id: "customId",
+            },
+            source: {
+              type: "OSM",
+            },
+          },
+        ]}
+        .projection=${"EPSG:4326"}
+      ></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+        "EPSG:4326"
+      );
+    });
+  });
+
+  it("can change the projection of the view", () => {
+    cy.intercept(/^.*openstreetmap.*$/, { fixture: "/tiles/osm/0/0/0.png" });
+
+    cy.mount(
+      html`<eox-map
+        .layers=${[
+          {
+            type: "Tile",
+            properties: {
+              id: "customId",
+            },
+            source: {
+              type: "OSM",
+            },
+          },
+        ]}
+      ></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.map
+        .getView()
+        .on("change:resolution", (e) =>
+          e.target.set("keepResolutionListener", true)
+        );
+      eoxMap.map
+        .getView()
+        .on("change:rotation", (e) =>
+          e.target.set("keepRotationListener", true)
+        );
+      eoxMap.map
+        .getView()
+        .on("change:center", (e) => e.target.set("keepCenterListener", true));
+      setTimeout(() => {
+        eoxMap.projection = "EPSG:4326";
+        expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+          "EPSG:4326"
+        );
+        const newView = eoxMap.map.getView();
+        newView.setZoom(newView.getZoom() + 1);
+        newView.setRotation(1);
+        newView.setCenter([1, 1]);
+
+        setTimeout(() => {
+          expect(
+            eoxMap.map.getView().get("keepResolutionListener"),
+            "keeps resolution listener"
+          ).to.be.true;
+          expect(
+            eoxMap.map.getView().get("keepRotationListener"),
+            "keeps rotation listener"
+          ).to.be.true;
+          expect(
+            eoxMap.map.getView().get("keepCenterListener"),
+            "keeps center listener"
+          ).to.be.true;
+        }, 100);
+      }, 1000);
+    });
+  });
+});

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -1,5 +1,7 @@
 import { html } from "lit";
 import "../main";
+import { registerProjection } from "../helpers";
+import vectorLayerStyleJson from "./vectorLayer.json";
 
 describe("view projections", () => {
   it("can set the initial projection of the view", () => {
@@ -85,6 +87,33 @@ describe("view projections", () => {
             "keeps center listener"
           ).to.be.true;
         }, 100);
+      }, 1000);
+    });
+  });
+
+  it("use special projection", () => {
+    cy.intercept("https://openlayers.org/data/vector/ecoregions.json", {
+      fixture: "/ecoregions.json",
+    });
+    registerProjection(
+      "ESRI:53009",
+      "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
+        "+b=6371000 +units=m +no_defs"
+    );
+    // not using osm because of performance issues while testing
+    cy.mount(
+      html`<eox-map
+        .layers=${vectorLayerStyleJson}
+        .projection=${"ESRI:53009"}
+      ></eox-map>`
+    ).as("eox-map");
+
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      setTimeout(() => {
+        expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+          "ESRI:53009"
+        );
       }, 1000);
     });
   });


### PR DESCRIPTION
This PR brings the usage of projections, as described in #702.

Out-of-the-box, `EPSG:4326` is supported in addition to the standard `EPSG:3857`. Other projections can be used by calling the helper-function `registerProjection` first, including a name and proj4 definition string. These can be obtained by via services like [epsg.io](epsg.io), this must be handled by the parent application.

Switching the projection is possible by setting the `projection`-attribute. A new `view` is created when doing so, listener functions are moved over to the new view. It is important that set listeners retrieve the view via `evt.target`, instead of `this`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
