### PR TITLE
fix: refresh source of VectorLayer after projection change

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -40,6 +40,7 @@ import {
   get as getProjection,
 } from "ol/proj";
 import { Coordinate } from "ol/coordinate";
+import { Layer } from "ol/layer";
 
 type ConfigObject = {
   controls: controlDictionary;
@@ -308,6 +309,9 @@ export class EOxMap extends LitElement {
         }
       });
       this.map.setView(newView);
+      this.getFlatLayersArray(this.map.getLayers().getArray() as Array<Layer>)
+        .filter((l) => l instanceof VectorLayer)
+        .forEach((l) => l.getSource().refresh());
       this._projection = projection;
       this.center = newCenter;
     }

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -496,6 +496,14 @@ export const Projection = {
   args: {
     layers: [
       {
+        type: "Vector",
+        source: {
+          type: "Vector",
+          url: "https://openlayers.org/data/vector/ecoregions.json",
+          format: "GeoJSON",
+        },
+      },
+      {
         type: "Tile",
         properties: {
           id: "osm",


### PR DESCRIPTION
## Implemented changes
This PR fixes an oversight that VectorLayers need a `refresh` on their source after changing the projection of the `view`.

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
