### PR TITLE
fix: only use layerConfig element when layerConfig property is used

### DIFF
--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -106,7 +106,6 @@ export class EOxLayerControlLayerTools extends LitElement {
     // Determine the number of actions and tools for conditional rendering
     const actionsLen = actions?.length;
     const toolsLen = tools?.length;
-
     // Render the HTML template based on the conditions
     return html`
       <style>
@@ -158,14 +157,19 @@ export class EOxLayerControlLayerTools extends LitElement {
                   </div>
                   <div slot="config-content">
                     <!-- Layer configuration -->
-                    <eox-layercontrol-layerconfig
-                      slot="config-content"
-                      .layer=${this.layer}
-                      .noShadow=${true}
-                      .layerConfig=${this.layer.get("layerConfig")}
-                      .unstyled=${this.unstyled}
-                      @changed=${() => this.requestUpdate()}
-                    ></eox-layercontrol-layerconfig>
+                    ${when(
+                      this.layer.get("layerConfig"),
+                      () => html`
+                        <eox-layercontrol-layerconfig
+                          slot="config-content"
+                          .layer=${this.layer}
+                          .noShadow=${true}
+                          .layerConfig=${this.layer.get("layerConfig")}
+                          .unstyled=${this.unstyled}
+                          @changed=${() => this.requestUpdate()}
+                        ></eox-layercontrol-layerconfig>
+                      `
+                    )}
                   </div>
                   <div slot="remove-icon">${this._removeButton()}</div>
                   <div slot="sort-icon">${this._sortButton()}</div>


### PR DESCRIPTION
## Implemented changes
Check if `layerConfig` prop is used before using the `<eox-layercontrol-layerconfig>` component
Fixes #734 
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
