### PR TITLE
Feat: Replace `h2` tags via `as` attr

### DIFF
--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -1,2 +1,6 @@
 export { default as loadMarkdownURL } from "./load-markdown-url.js";
-export { scrollAnchorClickEvent, scrollIntoView } from "./misc";
+export {
+  scrollAnchorClickEvent,
+  scrollIntoView,
+  getCustomEleHandling,
+} from "./misc";

--- a/elements/storytelling/src/helpers/misc.js
+++ b/elements/storytelling/src/helpers/misc.js
@@ -5,7 +5,7 @@
  * @param {String} selector - element selector string
  */
 export function scrollAnchorClickEvent(that, selector) {
-  that.shadowRoot.querySelectorAll(selector).forEach((doc) => {
+  (that.shadowRoot || that).querySelectorAll(selector).forEach((doc) => {
     doc.addEventListener("click", (e) => {
       e.preventDefault();
       window.parent.location.hash = e.target.hash.replace("#", "");
@@ -33,7 +33,7 @@ export function scrollIntoView(that) {
  */
 export function getCustomEleHandling(md) {
   const tagNameCheck = (tagName) =>
-    tagName.match(new RegExp(md.customElements.join("|")));
+    tagName.match(new RegExp(/^[a-z]+(-[a-z0-9]+)*$/));
   const attributeNameCheck = (attr) =>
     attr.match(new RegExp(md.attrs.join("|")));
 

--- a/elements/storytelling/src/helpers/misc.js
+++ b/elements/storytelling/src/helpers/misc.js
@@ -24,3 +24,22 @@ export function scrollIntoView(that) {
   const element = hash ? that.shadowRoot.querySelector(hash) : null;
   if (element) element.scrollIntoView({ behavior: "smooth" });
 }
+
+/**
+ * Generate custom element handling config.
+ *
+ * @param {import("markdown-it").default} md - Markdown-It instances
+ * @return {{tagNameCheck: String, attributeNameCheck: String, allowCustomizedBuiltInElements: Boolean}}
+ */
+export function getCustomEleHandling(md) {
+  const tagNameCheck = (tagName) =>
+    tagName.match(new RegExp(md.customElements.join("|")));
+  const attributeNameCheck = (attr) =>
+    attr.match(new RegExp(md.attrs.join("|")));
+
+  return {
+    tagNameCheck,
+    attributeNameCheck,
+    allowCustomizedBuiltInElements: true,
+  };
+}

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -99,7 +99,16 @@ export class EOxStoryTelling extends LitElement {
 
     // Check if 'markdown' property itself has changed and generate sanitized html
     if (changedProperties.has("markdown")) {
-      this.#html = DOMPurify.sanitize(md.render(this.markdown));
+      const unsafeHTML = md.render(this.markdown);
+      this.#html = DOMPurify.sanitize(unsafeHTML, {
+        CUSTOM_ELEMENT_HANDLING: {
+          tagNameCheck: (tagName) =>
+            tagName.match(new RegExp(md.customElements.join("|"))),
+          attributeNameCheck: (attr) =>
+            attr.match(new RegExp(md.attrs.join("|"))),
+          allowCustomizedBuiltInElements: () => true,
+        },
+      });
       this.#config = md.config;
 
       if (typeof this.#config.nav === "boolean")

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -3,6 +3,7 @@ import { when } from "lit/directives/when.js";
 import markdownit from "markdown-it";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import {
+  getCustomEleHandling,
   loadMarkdownURL,
   scrollAnchorClickEvent,
   scrollIntoView,
@@ -101,13 +102,7 @@ export class EOxStoryTelling extends LitElement {
     if (changedProperties.has("markdown")) {
       const unsafeHTML = md.render(this.markdown);
       this.#html = DOMPurify.sanitize(unsafeHTML, {
-        CUSTOM_ELEMENT_HANDLING: {
-          tagNameCheck: (tagName) =>
-            tagName.match(new RegExp(md.customElements.join("|"))),
-          attributeNameCheck: (attr) =>
-            attr.match(new RegExp(md.attrs.join("|"))),
-          allowCustomizedBuiltInElements: () => true,
-        },
+        CUSTOM_ELEMENT_HANDLING: getCustomEleHandling(md),
       });
       this.#config = md.config;
 

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -10,7 +10,6 @@ import slugify from "@sindresorhus/slugify";
  */
 export default function attributes(md) {
   md.nav = [];
-  md.customElements = ["eox-", "story-telling-"];
   md.attrs = [];
   md.core.ruler.push("curly_attributes", curlyAttrs);
 }
@@ -96,7 +95,7 @@ function curlyAttrs(state) {
   if (sectionStart)
     finalTokens.push(addNewHTMLSection(state, "</div>", -1, -1));
 
-  generateCustomEleAndAttrsList(finalTokens, state.md);
+  generateCustomAttrsList(finalTokens, state.md);
 
   omissions.forEach((idx) => tokens.splice(idx, 1));
   state.tokens = finalTokens;
@@ -377,20 +376,16 @@ function trimRight(obj, attr) {
 }
 
 /**
- * Generate list of custom elements tag and it's attribute for DOM sanitize whitelist.
+ * Generate list of custom attributes for DOM sanitize whitelist.
  *
  * @param {Array<Object>} tokens - List of markdown tokens
  * @param {import("markdown-it").default} md - Markdown-It instances
  */
-function generateCustomEleAndAttrsList(tokens, md) {
+function generateCustomAttrsList(tokens, md) {
   tokens.forEach((token) => {
     const attrs = token.attrs || [];
     attrs.forEach((attr) => {
       if (!md.attrs.includes(attr[0])) md.attrs = [...md.attrs, attr[0]];
-      if (attr[0] === "as") {
-        if (!md.customElements.includes(attr[1]))
-          md.customElements.push(attr[1]);
-      }
     });
   });
 }

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -212,7 +212,7 @@ function curlyInline(
 }
 
 /**
- * Transform H1 to custom element based on `as`
+ * Transform H2 to custom element based on `as`
  *
  * @param {Object} token - List of markdown tokens
  * @param {String} as - value of custom element

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -96,17 +96,8 @@ function curlyAttrs(state) {
   if (sectionStart)
     finalTokens.push(addNewHTMLSection(state, "</div>", -1, -1));
 
-  finalTokens.forEach((token) => {
-    const attrs = token.attrs || [];
-    attrs.forEach((attr) => {
-      if (!state.md.attrs.includes(attr[0]))
-        state.md.attrs = [...state.md.attrs, attr[0]];
-      if (attr[0] === "as") {
-        if (!state.md.customElements.includes(attr[1]))
-          state.md.customElements.push(attr[1]);
-      }
-    });
-  });
+  generateCustomEleAndAttrsList(finalTokens, state.md);
+
   omissions.forEach((idx) => tokens.splice(idx, 1));
   state.tokens = finalTokens;
   state.md.nav = nav || [];
@@ -383,4 +374,23 @@ function sPush(stack, token) {
  */
 function trimRight(obj, attr) {
   obj[attr] = obj[attr].replace(/\s*$/, "");
+}
+
+/**
+ * Generate list of custom elements tag and it's attribute for DOM sanitize whitelist.
+ *
+ * @param {Array<Object>} tokens - List of markdown tokens
+ * @param {import("markdown-it").default} md - Markdown-It instances
+ */
+function generateCustomEleAndAttrsList(tokens, md) {
+  tokens.forEach((token) => {
+    const attrs = token.attrs || [];
+    attrs.forEach((attr) => {
+      if (!md.attrs.includes(attr[0])) md.attrs = [...md.attrs, attr[0]];
+      if (attr[0] === "as") {
+        if (!md.customElements.includes(attr[1]))
+          md.customElements.push(attr[1]);
+      }
+    });
+  });
 }

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -79,12 +79,12 @@ function curlyAttrs(state) {
 
     if (
       token.type === "heading_open" &&
-      token.tag === "h1" &&
+      token.tag === "h2" &&
       tokens[i + 1].content.includes("as=")
     )
       continue;
 
-    if (stack.last.tag === "h1" && token.content.includes("as=")) {
+    if (stack.last.tag === "h2" && token.content.includes("as=")) {
       i += 1;
       continue;
     }
@@ -188,10 +188,7 @@ function curlyInline(
     ].content.replace("{id}", id);
 
     nav.push({ title, id });
-  }
 
-  // Generate custom element if h1 has `as` attribute.
-  if (stack.last.tag === "h1") {
     const attrAs = (stack.last.attrs || []).find(
       (subArr) => subArr[0] === "as"
     )?.[1];
@@ -203,7 +200,8 @@ function curlyInline(
           children[1],
           attrAs,
           state,
-          stack.last.attrs
+          stack.last.attrs,
+          title
         ),
       ];
   }
@@ -219,14 +217,16 @@ function curlyInline(
  * @param {Object} token - List of markdown tokens
  * @param {String} as - value of custom element
  * @param {{tokens: Array<Object>}} state - Token state
- * @param {{tokens: Array}} attrs - List of attribute with key and value
+ * @param {Array<Object>} attrs - List of attribute with key and value
+ * @param {String} text - Text inside heading
  * @return {Array<Object>} finalTokens
  *
  */
-function transformToCustomElement(token, as, state, attrs) {
+function transformToCustomElement(token, as, state, attrs, text) {
   // Generate HTML open token for custom element
   const openToken = new state.Token("html_open", as, 1);
   openToken.attrs = attrs;
+  openToken.attrs.push(["text", text]);
 
   // Generate HTML inline token for custom element
   const contentToken = new state.Token("html_inline", as, 0);

--- a/elements/storytelling/stories/custom-element.js
+++ b/elements/storytelling/stories/custom-element.js
@@ -23,7 +23,6 @@ export const CustomElement = {
         width: 100%;
       }
       .custom-block:before {
-        width: 100%;
         padding: 1rem;
         display: block;
         font-weight: 600;

--- a/elements/storytelling/stories/custom-element.js
+++ b/elements/storytelling/stories/custom-element.js
@@ -13,7 +13,7 @@ export const CustomElement = {
   render: (args) => html`
     <!-- Render eox-storytelling with basic markdown. -->
     <eox-storytelling
-      id="markdown-str"
+      id="markdown-custom-element"
       markdown=${args.markdown}
       no-shadow
     ></eox-storytelling>

--- a/elements/storytelling/stories/custom-element.js
+++ b/elements/storytelling/stories/custom-element.js
@@ -1,0 +1,51 @@
+/**
+ * It will render custom elements using h1 and 'as' attribute in decorate
+ */
+import { html } from "lit";
+import "../src/main.js";
+
+export const CustomElement = {
+  args: {
+    markdown: `# First Custom Element <!--{as="foo-bar" .custom-block}-->
+# Second Custom Element <!--{as="baz-que" .custom-block}-->
+# Third Custom Element <!--{as="quux-corge" .custom-block}-->`,
+  },
+  render: (args) => html`
+    <!-- Render eox-storytelling with basic markdown. -->
+    <eox-storytelling
+      id="markdown-str"
+      markdown=${args.markdown}
+      no-shadow
+    ></eox-storytelling>
+    <style>
+      .custom-block {
+        display: block;
+        width: 100%;
+      }
+      .custom-block:before {
+        width: 100%;
+        padding: 1rem;
+        display: block;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.1rem;
+        color: darkred;
+      }
+      foo-bar:before {
+        content: "First Element";
+        background: lightgoldenrodyellow;
+      }
+      baz-que:before {
+        content: "Second Element";
+        background: antiquewhite;
+      }
+      quux-corge:before {
+        content: "Third Element";
+        background: wheat;
+      }
+    </style>
+  `,
+};
+
+export default CustomElement;

--- a/elements/storytelling/stories/custom-element.js
+++ b/elements/storytelling/stories/custom-element.js
@@ -6,9 +6,9 @@ import "../src/main.js";
 
 export const CustomElement = {
   args: {
-    markdown: `# First Custom Element <!--{as="foo-bar" .custom-block}-->
-# Second Custom Element <!--{as="baz-que" .custom-block}-->
-# Third Custom Element <!--{as="quux-corge" .custom-block}-->`,
+    markdown: `## First Custom Element <!--{as="foo-bar" .custom-block}-->
+## Second Custom Element <!--{as="baz-que" .custom-block}-->
+## Third Custom Element <!--{as="quux-corge" .custom-block}-->`,
   },
   render: (args) => html`
     <!-- Render eox-storytelling with basic markdown. -->

--- a/elements/storytelling/stories/custom-element.js
+++ b/elements/storytelling/stories/custom-element.js
@@ -1,5 +1,5 @@
 /**
- * It will render custom elements using h1 and 'as' attribute in decorate
+ * It will render custom elements using H2 and 'as' attribute in decorate
  */
 import { html } from "lit";
 import "../src/main.js";

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -4,3 +4,4 @@ export { default as MarkdownSlotStory } from "./markdown-slot"; // StoryTelling 
 export { default as MarkdownAttrCommentStory } from "./markdown-attr-comment"; // StoryTelling using attribute as comments in markdown
 export { default as NavigationStory } from "./navigation"; // StoryTelling with Navigation
 export { default as MarkdownBasicConfigStory } from "./markdown-basic-config"; // StoryTelling with basic config
+export { default as CustomElementStory } from "./custom-element"; // StoryTelling with custom element

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -61,6 +61,7 @@ export const MarkdownWithBasicConfig = MarkdownBasicConfigStory;
 export const MarkdownWithNavigation = NavigationStory;
 
 /**
- * StoryTelling with custom element
+ * With the `as` attribute, `h2` sections can be replaced by other elements (native and custom elements).
+ * The newly rendered element replaces the original `h2' text content (fallback for vanilla md rendering) completely.
  */
 export const CustomElement = CustomElementStory;

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -9,6 +9,7 @@ import {
   MarkdownAttrCommentStory,
   NavigationStory,
   MarkdownBasicConfigStory,
+  CustomElementStory,
 } from "./index";
 import { html } from "lit";
 
@@ -58,3 +59,8 @@ export const MarkdownWithBasicConfig = MarkdownBasicConfigStory;
  * StoryTelling with Navigation
  */
 export const MarkdownWithNavigation = NavigationStory;
+
+/**
+ * StoryTelling with custom element
+ */
+export const CustomElement = CustomElementStory;

--- a/elements/storytelling/test/cases/index.js
+++ b/elements/storytelling/test/cases/index.js
@@ -7,3 +7,4 @@ export { default as loadMarkdownAttrComment } from "./load-markdown-attribute-co
 export { default as loadSectionsTest } from "./load-sections";
 export { default as loadNavigationTest } from "./load-navigation";
 export { default as loadMarkdownConfigTest } from "./load-markdown-config";
+export { default as LoadCustomElementTest } from "./load-custom-element";

--- a/elements/storytelling/test/cases/load-custom-element.js
+++ b/elements/storytelling/test/cases/load-custom-element.js
@@ -11,7 +11,7 @@ const LoadCustomElementTest = () => {
   let testText = "";
 
   TAGS.forEach((tag) => {
-    testText += `# ${tag} <!--{as="${tag}" .custom-block}--> \n`;
+    testText += `## ${tag} <!--{as="${tag}" .custom-block}--> \n`;
   });
 
   cy.mount(`<eox-storytelling markdown='${testText}'></eox-storytelling>`).as(

--- a/elements/storytelling/test/cases/load-custom-element.js
+++ b/elements/storytelling/test/cases/load-custom-element.js
@@ -1,0 +1,30 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { storyTelling } = TEST_SELECTORS;
+
+/**
+ * Loads custom element through h1 and decorate.
+ */
+const LoadCustomElementTest = () => {
+  const TAGS = ["foo-bar", "baz-que", "quux-corge"];
+  let testText = "";
+
+  TAGS.forEach((tag) => {
+    testText += `# ${tag} <!--{as="${tag}" .custom-block}--> \n`;
+  });
+
+  cy.mount(`<eox-storytelling markdown='${testText}'></eox-storytelling>`).as(
+    storyTelling
+  );
+
+  cy.get(storyTelling)
+    .shadow()
+    .within(() => {
+      TAGS.forEach((tag) => {
+        cy.get(tag).should("exist");
+      });
+    });
+};
+
+export default LoadCustomElementTest;

--- a/elements/storytelling/test/cases/load-custom-element.js
+++ b/elements/storytelling/test/cases/load-custom-element.js
@@ -4,7 +4,7 @@ import { TEST_SELECTORS } from "../../src/enums";
 const { storyTelling } = TEST_SELECTORS;
 
 /**
- * Loads custom element through h1 and decorate.
+ * Loads custom element through H2 and decorate.
  */
 const LoadCustomElementTest = () => {
   const TAGS = ["foo-bar", "baz-que", "quux-corge"];

--- a/elements/storytelling/test/general.cy.js
+++ b/elements/storytelling/test/general.cy.js
@@ -9,6 +9,7 @@ import {
   loadSectionsTest,
   loadNavigationTest,
   loadMarkdownConfigTest,
+  LoadCustomElementTest,
 } from "./cases";
 
 // Test suite for Storytelling
@@ -35,4 +36,7 @@ describe("Storytelling", () => {
   // Test case to loads basic config through storytelling markdown
   it("loads basic config through storytelling markdown", () =>
     loadMarkdownConfigTest());
+
+  // Test case to load custom element
+  it("Load custom element", () => LoadCustomElementTest());
 });


### PR DESCRIPTION
## Implemented changes
- Add custom element using markdown `h2` (`#`) and `as` attribute in decorate 
- It will generate a custom element as per the value given in `as`
- `as` should always be in `kabab-case` otherwise it won't get generated.
- This PR will automatically generate custom elements and attributes used in markdown so that DOM sanitizer doesn't remove it from HTML code. 

```markdown
## foo-bar <!--{as="foo-bar" .block #foo}-->
```

converts to - 

```html
<foo-bar text="foo-bar" class="block" id="foo"></foo-bar>
```


<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos


https://github.com/EOX-A/EOxElements/assets/10809211/5e559136-196b-4355-be15-e6611b11b76d



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
