### PR TITLE
chore(tests): run filtered suite of component tests when element changed

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,6 +55,5 @@ jobs:
           else
             exit 1
           fi
-        shell: bash
       - name: Run e2e tests 👀
         run: npm run test:e2e

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: Checkout 🛎
         uses: actions/checkout@v4
+        # necessary for git diff of changed files in the PR
+        with:
+          fetch-depth: 2
 
       - name: Setup node env 🏗
         uses: actions/setup-node@v4
@@ -42,7 +45,9 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Run component tests 👀
-        run: npm run test:component
+        run: |
+          export CI_PATHS_CHANGED=$(git diff --name-only -r HEAD^1 HEAD)
+          npm run test:component
 
       - name: Run e2e tests 👀
         run: npm run test:e2e

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,7 +50,7 @@ jobs:
           echo $CI_PATHS_CHANGED
           output=$(npm run test:component || true)
           echo "$output"
-          if [[ "$output" == *"Can't run because no spec files were found."* ]]; then
+          if [[ "$output" =~ "run because no spec files were found" ]]; then
             exit 0
           else
             exit 1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -53,7 +53,8 @@ jobs:
           if [[ "$output" == *"Can't run because no spec files were found."* ]]; then
             exit 0
           else
-            exit 1 # Replace with appropriate failure check
+            exit 1
           fi
+        shell: bash
       - name: Run e2e tests 👀
         run: npm run test:e2e

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -47,7 +47,13 @@ jobs:
       - name: Run component tests 👀
         run: |
           export CI_PATHS_CHANGED=$(git diff --name-only -r HEAD^1 HEAD)
-          npm run test:component
-
+          echo $CI_PATHS_CHANGED
+          output=$(npm run test:component || true)
+          echo "$output"
+          if [[ "$output" == *"Can't run because no spec files were found."* ]]; then
+            exit 0
+          else
+            exit 1 # Replace with appropriate failure check
+          fi
       - name: Run e2e tests 👀
         run: npm run test:e2e

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -47,13 +47,6 @@ jobs:
       - name: Run component tests 👀
         run: |
           export CI_PATHS_CHANGED=$(git diff --name-only -r HEAD^1 HEAD)
-          echo $CI_PATHS_CHANGED
-          output=$(npm run test:component || true)
-          echo "$output"
-          if [[ "$output" =~ "run because no spec files were found" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
+          npm run test:component
       - name: Run e2e tests 👀
         run: npm run test:e2e

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,9 @@ const pathsChanged = process.env.CI_PATHS_CHANGED;
 let specPatternComponentTests = ["**/*.cy.{js,jsx,ts,tsx}"];
 console.log(pathsChanged);
 if (pathsChanged) {
-  const changed = pathsChanged.split(" ");
+  const changed = pathsChanged.split("\n");
+  console.log("changed");
+  console.log(changed);
   // if cypress folder changed, always run all component tests
   if (!changed.some((item) => item.startsWith("cypress"))) {
     // otherwise filter the tests to run specs only for that component based on list of changed paths

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,11 +3,8 @@ const pathsChanged = process.env.CI_PATHS_CHANGED;
 
 // by default all component tests are run
 let specPatternComponentTests = ["**/*.cy.{js,jsx,ts,tsx}"];
-console.log(pathsChanged);
 if (pathsChanged) {
   const changed = pathsChanged.split("\n");
-  console.log("changed");
-  console.log(changed);
   // if cypress folder changed, always run all component tests
   if (!changed.some((item) => item.startsWith("cypress"))) {
     // otherwise filter the tests to run specs only for that component based on list of changed paths
@@ -20,14 +17,9 @@ if (pathsChanged) {
       specPatternComponentTests = uniqueElementFolders.map(
         (item) => `elements/${item}/**/*.cy.{js,jsx,ts,tsx}`
       );
-    } else {
-      // no elements were changed, no need to run component tests
-      specPatternComponentTests = [];
-      // CI action takes care of handling graceful exit
     }
   }
 }
-console.log(specPatternComponentTests);
 export default defineConfig({
   e2e: {
     // specPattern: "**/*.cy.{js,jsx,ts,tsx}",

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,10 +3,11 @@ const pathsChanged = process.env.CI_PATHS_CHANGED;
 
 // by default all component tests are run
 let specPatternComponentTests = ["**/*.cy.{js,jsx,ts,tsx}"];
+console.log(pathsChanged);
 if (pathsChanged) {
   const changed = pathsChanged.split(" ");
   // if cypress folder changed, always run all component tests
-  if (changed.every((item) => !item.startsWith("cypress"))) {
+  if (!changed.some((item) => item.startsWith("cypress"))) {
     // otherwise filter the tests to run specs only for that component based on list of changed paths
     const filteredElementsFolders = changed
       .filter((filePath) => filePath.startsWith("elements/"))
@@ -24,6 +25,7 @@ if (pathsChanged) {
     }
   }
 }
+console.log(specPatternComponentTests);
 export default defineConfig({
   e2e: {
     // specPattern: "**/*.cy.{js,jsx,ts,tsx}",

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,7 +6,7 @@ let specPatternComponentTests = ["**/*.cy.{js,jsx,ts,tsx}"];
 if (pathsChanged) {
   const changed = pathsChanged.split(" ");
   // if cypress folder changed, always run all component tests
-  if (changed.every((item) => !item.startsWith("cypress/"))) {
+  if (changed.every((item) => !item.startsWith("cypress"))) {
     // otherwise filter the tests to run specs only for that component based on list of changed paths
     const filteredElementsFolders = changed
       .filter((filePath) => filePath.startsWith("elements/"))

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,25 @@
 import { defineConfig } from "cypress";
+const pathsChanged = process.env.CI_PATHS_CHANGED;
 
+// by default all component tests are run
+let specPatternComponentTests = ["**/*.cy.{js,jsx,ts,tsx}"];
+if (pathsChanged) {
+  const changed = pathsChanged.split(" ");
+  // if cypress folder changed, always run all component tests
+  if (changed.every((item) => !item.startsWith("cypress/"))) {
+    // otherwise filter the tests to run specs only for that component based on list of changed paths
+    const filteredElementsFolders = changed
+      .filter((filePath) => filePath.startsWith("elements/"))
+      .map((filePath) => filePath.split("/")[1]);
+    const uniqueElementFolders = [...new Set(filteredElementsFolders)];
+    // if only one folder was modified update spec
+    if (uniqueElementFolders.length > 0) {
+      specPatternComponentTests = uniqueElementFolders.map(
+        (item) => `elements/${item}/**/*.cy.{js,jsx,ts,tsx}`
+      );
+    }
+  }
+}
 export default defineConfig({
   e2e: {
     // specPattern: "**/*.cy.{js,jsx,ts,tsx}",
@@ -11,7 +31,7 @@ export default defineConfig({
     devServer: {
       bundler: "vite",
     },
-    specPattern: "**/*.cy.{js,jsx,ts,tsx}",
+    specPattern: specPatternComponentTests,
     indexHtmlFile: "cypress/support/component-index.html",
   },
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -17,6 +17,9 @@ if (pathsChanged) {
       specPatternComponentTests = uniqueElementFolders.map(
         (item) => `elements/${item}/**/*.cy.{js,jsx,ts,tsx}`
       );
+    } else {
+      // no elements were changed, no need to run component tests
+      specPatternComponentTests = [];
     }
   }
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -20,6 +20,7 @@ if (pathsChanged) {
     } else {
       // no elements were changed, no need to run component tests
       specPatternComponentTests = [];
+      // CI action takes care of handling graceful exit
     }
   }
 }


### PR DESCRIPTION
## Implemented changes

Suite of component tests being run is filtered based on elements which are affected by PR. The list of files changed is parsed from git diff. If cypress folder changed, all component tests are run.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)

New functionality is shown in Draft PR https://github.com/EOX-A/EOxElements/pull/758 which can be closed and branch deleted after this PR is merged.