### PR TITLE
Feat: Add `h2` content as `title` attribute in sections 

### DIFF
--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -186,7 +186,7 @@ function curlyInline(children, stack, nav, finalTokens, sectionStartIndex) {
       // Combining div attribute with h2 attributes
       applyToToken(
         currentSectionToken,
-        `${stack.last.attrStr} #${id} .${currentSectionToken.attrs[0][1]}`
+        `title='${lastText.content}' ${stack.last.attrStr} #${id} .${currentSectionToken.attrs[0][1]}`
       );
     }
   }


### PR DESCRIPTION
## Implemented changes
- Adding `h2` content as `title` for the section component.
  ```markdown
  ## EarthCODE Portal <!--{as="esa-main-section"}-->
  ```
  to html - 
  ```html
  <esa-main-section title="EarthCODE Portal"></esa-main-section>
  ```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<img width="985" alt="Screenshot 2024-03-18 at 2 36 19 PM" src="https://github.com/EOX-A/EOxElements/assets/10809211/722d7d36-ac6d-4517-97a9-c33a3e18288d">



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
