### PR TITLE
fix: allow empty section titles

### DIFF
--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -167,7 +167,7 @@ function curlyInline(children, stack, nav, finalTokens, sectionStartIndex) {
 
   // Generate nav value and transform div section to `as` attribute
   if (stack.last.tag === "h2") {
-    const title = (lastText && lastText["content"]) || children[0].content;
+    const title = (lastText && lastText["content"]) || children[0]?.content;
     const attrsId = getAttr(stack.last.attrs, "id");
     const titleSlug = slugify(title);
     const id = `section-${attrsId || titleSlug}`;
@@ -186,7 +186,9 @@ function curlyInline(children, stack, nav, finalTokens, sectionStartIndex) {
       // Combining div attribute with h2 attributes
       applyToToken(
         currentSectionToken,
-        `title='${lastText.content}' ${stack.last.attrStr} #${id} .${currentSectionToken.attrs[0][1]}`
+        `${lastText ? `title='${lastText.content}'` : ""}${
+          stack.last.attrStr
+        } #${id} .${currentSectionToken.attrs[0][1]}`
       );
     }
   }


### PR DESCRIPTION
## Implemented changes

This fix makes the changes implemented in https://github.com/EOX-A/EOxElements/pull/759 more robust, as it introducs a check if the title is actually present before accessing it.

This allows things as 
```md
## <!--{as="custom-element"}-->
```
without breaking.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
