### PR TITLE
Feat: Storytelling map section powered by @eox/map

### DIFF
--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -1,4 +1,5 @@
 export { default as loadMarkdownURL } from "./load-markdown-url.js";
+export { renderHtmlString } from "./render-html-string";
 export {
   scrollAnchorClickEvent,
   scrollIntoView,

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -1,44 +1,61 @@
+/**
+ * Converts an HTML string into DOM nodes and processes each node.
+ *
+ * @param {string} htmlString - The HTML string to be rendered.
+ * @returns {Element[]} An array of processed DOM nodes.
+ */
 export function renderHtmlString(htmlString) {
   // Parse the HTML string into a document
   const parser = new DOMParser();
   const doc = parser.parseFromString(htmlString, "text/html");
 
   // Process child nodes of the document body
-  const dom = Array.from(doc.body.childNodes).map(processNode);
-
-  console.log(dom);
-  return dom;
+  return Array.from(doc.body.childNodes).map(processNode);
 }
 
 /**
- * Process a DOM node, handling specific node types.
+ * Processes a DOM node by potentially modifying its attributes value based on it's datatype
+ *
+ * @param {Element} node - The DOM node to process.
+ * @returns {Element} The processed DOM node.
  */
 function processNode(node) {
-  if (node.classList.contains("section-custom")) {
-    for (let i = 0; i < node.attributes.length; i++) {
-      const attr = node.attributes[i].name;
-      node[attr] = convertAndSetAttributeValue(node, attr);
-    }
+  if (
+    node.nodeType === Node.ELEMENT_NODE &&
+    node.classList.contains("section-custom")
+  ) {
+    Array.from(node.attributes).forEach(
+      // Update the attribute with its converted value
+      (attr) =>
+        (node[attr.name] = convertAttributeValueBasedOnItsType(node, attr.name))
+    );
   }
   return node;
 }
 
-function convertAndSetAttributeValue(element, attributeName) {
+/**
+ * Converts an attribute value of a DOM element into its detected type and returns the converted value.
+ *
+ * @param {Element} element - The DOM element containing the attribute.
+ * @param {string} attributeName - The name of the attribute to convert.
+ * @returns {string|number|boolean|array|object} The attribute value converted to its detected type.
+ */
+function convertAttributeValueBasedOnItsType(element, attributeName) {
   const attributeValue = element.getAttribute(attributeName);
   let convertedValue;
 
   try {
     convertedValue = JSON.parse(attributeValue);
   } catch (e) {
-    if (!isNaN(attributeValue) && attributeValue.trim() !== "")
+    if (!isNaN(attributeValue) && attributeValue.trim() !== "") {
       convertedValue = Number(attributeValue);
-    else
-      convertedValue =
-        attributeValue === "true"
-          ? true
-          : attributeValue === "false"
-          ? false
-          : attributeValue;
+    } else if (attributeValue === "true") {
+      convertedValue = true;
+    } else if (attributeValue === "false") {
+      convertedValue = false;
+    } else {
+      convertedValue = attributeValue;
+    }
   }
 
   return convertedValue;

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -1,0 +1,32 @@
+export function renderHtmlString(htmlString) {
+  // Parse the HTML string into a document
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(htmlString, "text/html");
+
+  // Process child nodes of the document body
+  const dom = Array.from(doc.body.childNodes).map(processNode);
+
+  console.log(dom);
+}
+
+/**
+ * Process a DOM node, handling specific node types.
+ */
+function processNode(node) {
+  console.log(node.classList.contains("section-custom"));
+  console.log(node.attributes);
+  if (
+    node.nodeName === "P" ||
+    node.nodeName === "DIV" ||
+    node.nodeName === "MAIN"
+  ) {
+    // Process custom elements within child nodes
+    // const childElements = node.querySelectorAll("*");
+    // childElements.forEach((element) => {
+    //   if (/^(eox-|story-telling-)/.test(element.tagName.toLowerCase())) {
+    //     processCustomElement(element);
+    //   }
+    // });
+  }
+  return node;
+}

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -7,26 +7,39 @@ export function renderHtmlString(htmlString) {
   const dom = Array.from(doc.body.childNodes).map(processNode);
 
   console.log(dom);
+  return dom;
 }
 
 /**
  * Process a DOM node, handling specific node types.
  */
 function processNode(node) {
-  console.log(node.classList.contains("section-custom"));
-  console.log(node.attributes);
-  if (
-    node.nodeName === "P" ||
-    node.nodeName === "DIV" ||
-    node.nodeName === "MAIN"
-  ) {
-    // Process custom elements within child nodes
-    // const childElements = node.querySelectorAll("*");
-    // childElements.forEach((element) => {
-    //   if (/^(eox-|story-telling-)/.test(element.tagName.toLowerCase())) {
-    //     processCustomElement(element);
-    //   }
-    // });
+  if (node.classList.contains("section-custom")) {
+    for (let i = 0; i < node.attributes.length; i++) {
+      const attr = node.attributes[i].name;
+      node[attr] = convertAndSetAttributeValue(node, attr);
+    }
   }
   return node;
+}
+
+function convertAndSetAttributeValue(element, attributeName) {
+  const attributeValue = element.getAttribute(attributeName);
+  let convertedValue;
+
+  try {
+    convertedValue = JSON.parse(attributeValue);
+  } catch (e) {
+    if (!isNaN(attributeValue) && attributeValue.trim() !== "")
+      convertedValue = Number(attributeValue);
+    else
+      convertedValue =
+        attributeValue === "true"
+          ? true
+          : attributeValue === "false"
+          ? false
+          : attributeValue;
+  }
+
+  return convertedValue;
 }

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -102,10 +102,12 @@ export class EOxStoryTelling extends LitElement {
     // Check if 'markdown' property itself has changed and generate sanitized html
     if (changedProperties.has("markdown")) {
       const unsafeHTML = md.render(this.markdown);
-      this.#html = DOMPurify.sanitize(unsafeHTML, {
-        CUSTOM_ELEMENT_HANDLING: getCustomEleHandling(md),
-      });
-      renderHtmlString(this.#html);
+      this.#html = renderHtmlString(
+        DOMPurify.sanitize(unsafeHTML, {
+          CUSTOM_ELEMENT_HANDLING: getCustomEleHandling(md),
+        })
+      );
+      // renderHtmlString(this.#html);
       this.#config = md.config;
 
       if (typeof this.#config.nav === "boolean")
@@ -189,7 +191,7 @@ export class EOxStoryTelling extends LitElement {
           `
         )}
         <div class="container">
-          ${when(this.#html, () => html`${unsafeHTML(this.#html)}`)}
+          ${when(this.#html, () => html`${this.#html}`)}
         </div>
       </div>
     `;

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -1,7 +1,6 @@
 import { LitElement, html } from "lit";
 import { when } from "lit/directives/when.js";
 import markdownit from "markdown-it";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import {
   getCustomEleHandling,
   loadMarkdownURL,
@@ -107,7 +106,6 @@ export class EOxStoryTelling extends LitElement {
           CUSTOM_ELEMENT_HANDLING: getCustomEleHandling(md),
         })
       );
-      // renderHtmlString(this.#html);
       this.#config = md.config;
 
       if (typeof this.#config.nav === "boolean")

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -7,6 +7,7 @@ import {
   loadMarkdownURL,
   scrollAnchorClickEvent,
   scrollIntoView,
+  renderHtmlString,
 } from "./helpers";
 import mainStyle from "../../../utils/styles/dist/main.style";
 import DOMPurify from "isomorphic-dompurify";
@@ -104,6 +105,7 @@ export class EOxStoryTelling extends LitElement {
       this.#html = DOMPurify.sanitize(unsafeHTML, {
         CUSTOM_ELEMENT_HANDLING: getCustomEleHandling(md),
       });
+      renderHtmlString(this.#html);
       this.#config = md.config;
 
       if (typeof this.#config.nav === "boolean")

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -186,7 +186,7 @@ function curlyInline(children, stack, nav, finalTokens, sectionStartIndex) {
       // Combining div attribute with h2 attributes
       applyToToken(
         currentSectionToken,
-        `${stack.last.attrStr} #${id} .${currentSectionToken.attrs[0][1]}`
+        `${stack.last.attrStr} #${id} .${currentSectionToken.attrs[0][1]} .section-custom`
       );
     }
   }

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -17,6 +17,7 @@ const styleEOX = `
     justify-content: center;
     position: sticky;
     top: 0;
+    z-index: 1;
   }
   .navigation .container {
     padding: 0px;

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -6,3 +6,4 @@ export { default as NavigationStory } from "./navigation"; // StoryTelling with 
 export { default as MarkdownBasicConfigStory } from "./markdown-basic-config"; // StoryTelling with basic config
 export { default as CustomElementStory } from "./custom-element"; // StoryTelling with custom element
 export { default as MarkdownSectionsStory } from "./markdown-sections"; // StoryTelling with sections
+export { default as MarkdownMapSectionStory } from "./markdown-map-section"; // StoryTelling with eox-map sections

--- a/elements/storytelling/stories/markdown-map-section.js
+++ b/elements/storytelling/stories/markdown-map-section.js
@@ -8,7 +8,7 @@ import "../../map/src/plugins/advancedLayersAndSources";
 export const MarkdownMapSection = {
   args: {
     markdown: `
-## EOX Map <!--{as="eox-map" prevent-scroll="true" style="width: 100%; height: 500px;" center="[15,48]" zoom="2" config='{ "controls": { "Zoom": {}, "Attribution": {}, "FullScreen": {}, "OverviewMap": { "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "OSM" } } ] } }, "layers": [ { "type": "Tile", "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ], "view": { "center": [ 16.8, 48.2 ], "zoom": 9 } }'}-->
+## EOX Map <!--{as="eox-map" prevent-scroll="true" style="width: 100%; height: 500px;" config='{ "controls": { "Zoom": {}, "Attribution": {}, "FullScreen": {}, "OverviewMap": { "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "OSM" } } ] } }, "layers": [ { "type": "Tile", "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ], "view": { "center": [15,48], "zoom": 1 } }'}-->
 
 ### What is Lorem Ipsum? <!--{ style="padding-top: 2rem;" }-->
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.

--- a/elements/storytelling/stories/markdown-map-section.js
+++ b/elements/storytelling/stories/markdown-map-section.js
@@ -1,0 +1,29 @@
+/**
+ * Renders storytelling with eox-map sections.
+ */
+import { html } from "lit";
+import "../src/main.js";
+import "../../map/src/plugins/advancedLayersAndSources";
+
+export const MarkdownMapSection = {
+  args: {
+    markdown: `
+## EOX Map <!--{as="eox-map" prevent-scroll="true" style="width: 100%; height: 500px;" center="[15,48]" zoom="2" config='{ "controls": { "Zoom": {}, "Attribution": {}, "FullScreen": {}, "OverviewMap": { "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "OSM" } } ] } }, "layers": [ { "type": "Tile", "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ], "view": { "center": [ 16.8, 48.2 ], "zoom": 9 } }'}-->
+
+### What is Lorem Ipsum? <!--{ style="padding-top: 2rem;" }-->
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+
+### Why do we use it?
+It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).
+
+`,
+  },
+  render: (args) => html`
+    <eox-storytelling
+      id="markdown-map-sections"
+      markdown=${args.markdown}
+    ></eox-storytelling>
+  `,
+};
+
+export default MarkdownMapSection;

--- a/elements/storytelling/stories/markdown-sections.js
+++ b/elements/storytelling/stories/markdown-sections.js
@@ -7,6 +7,8 @@ import "../src/main.js";
 export const MarkdownSections = {
   args: {
     markdown: `
+## Eox Map <!--{as="eox-map" center="[15,48]" layers='[ { "type": "Tile", "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ]'}-->
+
 ## EarthCODE Portal <!--{as="esa-main-section" title="EarthCODE Portal"}-->
 ### EarthCODE
 This portal shall provide an entry point to the collaborative development tools and resources, as well as access to community guidelines and open documentation to help researchers adopt FAIR principles in their scientific practice.

--- a/elements/storytelling/stories/markdown-sections.js
+++ b/elements/storytelling/stories/markdown-sections.js
@@ -7,8 +7,6 @@ import "../src/main.js";
 export const MarkdownSections = {
   args: {
     markdown: `
-## Eox Map <!--{as="eox-map" center="[15,48]" layers='[ { "type": "Tile", "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ]'}-->
-
 ## EarthCODE Portal <!--{as="esa-main-section" title="EarthCODE Portal"}-->
 ### EarthCODE
 This portal shall provide an entry point to the collaborative development tools and resources, as well as access to community guidelines and open documentation to help researchers adopt FAIR principles in their scientific practice.

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -10,6 +10,7 @@ import {
   NavigationStory,
   MarkdownBasicConfigStory,
   CustomElementStory,
+  MarkdownMapSectionStory,
   MarkdownSectionsStory,
 } from "./index";
 import { html } from "lit";
@@ -67,4 +68,12 @@ export const MarkdownWithNavigation = NavigationStory;
  */
 export const CustomElement = CustomElementStory;
 
+/**
+ * StoryTelling with simple and custom sections
+ */
 export const MarkdownWithSections = MarkdownSectionsStory;
+
+/**
+ * StoryTelling with @eox-map sections
+ */
+export const MarkdownMapSection = MarkdownMapSectionStory;

--- a/elements/storytelling/test/cases/index.js
+++ b/elements/storytelling/test/cases/index.js
@@ -8,3 +8,4 @@ export { default as loadSectionsTest } from "./load-sections";
 export { default as loadNavigationTest } from "./load-navigation";
 export { default as loadMarkdownConfigTest } from "./load-markdown-config";
 export { default as LoadCustomElementTest } from "./load-custom-element";
+export { default as loadMapSectionTest } from "./load-map-section";

--- a/elements/storytelling/test/cases/load-map-section.js
+++ b/elements/storytelling/test/cases/load-map-section.js
@@ -1,0 +1,31 @@
+import { TEST_SELECTORS } from "../../src/enums";
+import "../../../map/main";
+
+// Destructure TEST_SELECTORS object
+const { storyTelling } = TEST_SELECTORS;
+
+/**
+ * Ensure all the map sections loaded
+ */
+const loadMapSectionTest = () => {
+  const zoom = 10;
+  const testText = `
+## EOX Map <!--{as=eox-map zoom=${zoom}}-->
+`;
+
+  cy.mount(`<eox-storytelling markdown='${testText}'></eox-storytelling>`).as(
+    storyTelling
+  );
+
+  cy.get(storyTelling)
+    .shadow()
+    .within(() => {
+      cy.get("eox-map").should("exist");
+      cy.get("eox-map").then(($eoxMap) => {
+        const zoom = $eoxMap[0].map.getView().getZoom();
+        expect($eoxMap[0].zoom).to.eq(zoom);
+      });
+    });
+};
+
+export default loadMapSectionTest;

--- a/elements/storytelling/test/general.cy.js
+++ b/elements/storytelling/test/general.cy.js
@@ -10,6 +10,7 @@ import {
   loadNavigationTest,
   loadMarkdownConfigTest,
   LoadCustomElementTest,
+  loadMapSectionTest,
 } from "./cases";
 
 // Test suite for Storytelling
@@ -39,4 +40,7 @@ describe("Storytelling", () => {
 
   // Test case to load custom element
   it("Load custom element", () => LoadCustomElementTest());
+
+  // Test case to load eox-map as a section
+  it("Load eox-map section", () => loadMapSectionTest());
 });


### PR DESCRIPTION
## Implemented changes

- Added `eox-map` as a section to StoryTelling
  ```markdown
  ## EOX Map <!--{as=eox-map zoom=10 layers=[]-->
  ``` 
  converted to - 
  ```html
  <eox-map zoom="10" layers="[]"></eox-map>
  ```
- We can now add any custom element using `h2`, and it will dynamically pass the value according to the required data type.
- I created a render function that automatically identifies and parses attributes based on their data type. This is necessary because HTML is stored as a string, and LitElement cannot identify the desired data type on its own, as discussed during our MVP phase.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
https://github.com/EOX-A/EOxElements/assets/10809211/e5a5e913-a9b2-442a-8e60-a38d23cd319c

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
