### PR TITLE
feat: geolocation control

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -14,7 +14,7 @@ import {
   addOrUpdateControl,
   controlDictionary,
   controlType,
-} from "./src/controls";
+} from "./src/controls/controls";
 import { buffer } from "ol/extent";
 import "./src/compare";
 import {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -4,6 +4,8 @@ import Map from "ol/Map.js";
 import View, { ViewObjectEventTypes } from "ol/View.js";
 // @ts-ignore
 import olCss from "ol/ol.css?inline";
+// @ts-ignore
+import controlCss from "./src/controls/controls.css?inline";
 import { EOxSelectInteraction } from "./src/select";
 import { EoxLayer, createLayer, updateLayer } from "./src/generate";
 import { Draw, Modify } from "ol/interaction";
@@ -478,6 +480,7 @@ export class EOxMap extends LitElement {
       <style>
         ${shadowStyleFix}
         ${olCss}
+        ${controlCss}
       </style>
       <div style="width: 100%; height: 100%"></div>
       <slot></slot>

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -216,6 +216,8 @@ export const Geolocation = {
           "circle-stroke-color": "white",
           "circle-stroke-width": 2,
         },
+        buttonIcon:
+          "https://upload.wikimedia.org/wikipedia/commons/7/74/Location_icon_from_Noun_Project.png",
       },
       Zoom: {},
     },

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -202,8 +202,22 @@ export const Controls = {
 
 export const Geolocation = {
   args: {
+    zoom: 7,
     controls: {
-      Geolocation: {},
+      Geolocation: {
+        tracking: true,
+        trackHeading: true,
+        centerWhenReady: true,
+        highAccuracy: true,
+        trackAccuracy: true,
+        style: {
+          "circle-radius": 10,
+          "circle-fill-color": "red",
+          "circle-stroke-color": "white",
+          "circle-stroke-width": 2,
+        },
+      },
+      Zoom: {},
     },
     layers: [
       {

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -200,6 +200,25 @@ export const Controls = {
   },
 };
 
+export const Geolocation = {
+  args: {
+    controls: {
+      Geolocation: {},
+    },
+    layers: [
+      {
+        type: "Tile",
+        properties: {
+          id: "customId",
+        },
+        source: {
+          type: "OSM",
+        },
+      },
+    ],
+  },
+};
+
 export const HoverSelect = {
   args: {
     layers: [

--- a/elements/map/src/controls/Geolocation.ts
+++ b/elements/map/src/controls/Geolocation.ts
@@ -42,15 +42,13 @@ export default class GeolocationControl extends Control {
     const options = opt_options || {};
 
     const element = document.createElement("div");
-    element.className = "ol-unselectable ol-control";
-    element.style.top = "65px";
-    element.style.left = ".5em";
+    element.className = "geolocation ol-unselectable ol-control";
     const button = document.createElement("button");
     if (options.buttonIcon) {
       const image = document.createElement("img");
       image.src = options.buttonIcon;
-      image.style.height = "22px";
-      image.style.width = "22px";
+      image.style.height = "100%";
+      image.style.width = "100%";
       image.style.position = "absolute";
       image.style.pointerEvents = "none";
       element.appendChild(image);

--- a/elements/map/src/controls/Geolocation.ts
+++ b/elements/map/src/controls/Geolocation.ts
@@ -71,6 +71,7 @@ export default class GeolocationControl extends Control {
 
     this._positionFeature = new Feature({
       geometry: new Point([0, 0]),
+      heading: 0
     });
 
     this._source = new VectorSource({

--- a/elements/map/src/controls/Geolocation.ts
+++ b/elements/map/src/controls/Geolocation.ts
@@ -71,7 +71,7 @@ export default class GeolocationControl extends Control {
 
     this._positionFeature = new Feature({
       geometry: new Point([0, 0]),
-      heading: 0
+      heading: 0,
     });
 
     this._source = new VectorSource({

--- a/elements/map/src/controls/Geolocation.ts
+++ b/elements/map/src/controls/Geolocation.ts
@@ -1,0 +1,144 @@
+import { Control } from "ol/control.js";
+import Feature from "ol/Feature.js";
+import Geolocation from "ol/Geolocation.js";
+import Point from "ol/geom/Point.js";
+import { Circle as CircleStyle, Fill, Stroke, Style } from "ol/style.js";
+import { Vector as VectorSource } from "ol/source.js";
+import { Vector as VectorLayer } from "ol/layer.js";
+
+
+// The certificate is at "./localhost.pem" and the key at "./localhost-key.pem" ✅
+
+export default class GeolocationControl extends Control {
+  /**
+   * @param {Object} [opt_options] Control options.
+   */
+  constructor(opt_options: import("ol/control/Control").Options) {
+    const options = opt_options || {};
+
+    const button = document.createElement("button");
+    //button.innerHTML = '&#1792;';
+    button.innerHTML = "&#6816";
+
+    const element = document.createElement("div");
+    element.className = "rotate-north ol-unselectable ol-control";
+    element.appendChild(button);
+
+    super({
+      element: element,
+      target: options.target,
+    });
+
+    this.centerWhenReady_ = options.centerWhenReady;
+    this.highAccuracy_ = options.highAccuracy;
+    this.trackAccuracy_ = true;
+    button.addEventListener("click", this.centerOnPosition.bind(this), false);
+  }
+
+  /**
+   * Remove the control from its current map and attach it to the new map.
+   * Pass `null` to just remove the control from the current map.
+   * Subclasses may set up event handlers to get notified about changes to
+   * the map here.
+   * @param {import("../Map.js").default|null} map Map.
+   * @api
+   */
+  setMap(map: import("ol/Map.js").default | null) {
+    console.log("set map");
+    if (map) {
+      console.log(map);
+      console.log(map.getView().getProjection());
+      this.geolocation_ = new Geolocation({
+        // take the projection to use from the map's view
+        tracking: true,
+        trackingOptions: {
+          enableHighAccuracy: this.highAccuracy_,
+        },
+        projection: map.getView().getProjection(),
+      });
+      
+      if (this.centerWhenReady_) {
+        this.geolocation_.once('change:position', (e) => {
+          map.getView().setCenter(e.target.getPosition());
+        })
+      }
+
+      this.accuracyFeature_ = new Feature();
+
+      this.positionFeature_ = new Feature({
+        geometry: new Point([0, 0]),
+      })
+      this.positionFeature_.setStyle(new Style({
+        image: new CircleStyle({
+          radius: 6,
+          fill: new Fill({
+            color: "orangered",
+          }),
+          stroke: new Stroke({
+            color: "#fff",
+            width: 2,
+          }),
+        }),
+      }))
+      this.source_ = new VectorSource({
+        features: [this.positionFeature_]
+      })
+      this.layer_ = new VectorLayer({
+        source: this.source_
+      })
+      this.layer_.setMap(map);
+
+      // listen to changes in position
+      this.geolocation_.on("change", function (e) {
+        console.log("geolocation changed");
+        console.log(e);
+        console.log(e.target.getPosition());
+      });
+
+      this.geolocation_.on("error", function (evt) {
+        console.log(evt);
+      });
+
+      this.geolocation_.on('change:accuracyGeometry', () => {
+        if (this.trackAccuracy_) {
+          this.accuracyFeature_.setGeometry(this.geolocation_.getAccuracyGeometry());
+        }
+      });
+      this.geolocation_.on('change:heading', (e) => {
+        console.log('changeHeading');
+        console.log(e);
+        if (this.trackHeading_ && this.highAccuracy_) {
+          this.accuracyFeature_.getStyle().setRotation(e.target.getHeading());
+        }
+      });
+
+
+      this.geolocation_.on("change:position", () => {
+        console.log("change position");
+        const coordinates = this.geolocation_.getPosition();
+        console.log(coordinates);
+        this.positionFeature_.getGeometry().setCoordinates(coordinates ? coordinates : null)
+      });
+
+      this.geolocation_.on("change:accuracyGeometry", () => {
+        this.accuracyFeature_.setGeometry(this.geolocation_.getAccuracyGeometry());
+      });
+    }
+
+    super.setMap(map);
+  }
+
+  centerWhenReady_: boolean;
+  highAccuracy_: boolean;
+  positionFeature_: Feature<Point>;
+  accuracyFeature_: Feature;
+  trackAccuracy_: boolean;
+  trackHeading_: boolean;
+  layer_: VectorLayer<VectorSource>;
+  source_: VectorSource;
+  geolocation_: Geolocation;
+
+  centerOnPosition() {
+    this.getMap().getView().setCenter(this.geolocation_.getPosition());
+  }
+}

--- a/elements/map/src/controls/controls.css
+++ b/elements/map/src/controls/controls.css
@@ -1,0 +1,7 @@
+.geolocation {
+  top: 65px;
+  left: 0.5em;
+}
+.ol-touch .geolocation {
+  top: 80px;
+}

--- a/elements/map/src/controls/controls.ts
+++ b/elements/map/src/controls/controls.ts
@@ -73,7 +73,7 @@ export function addInitialControls(EOxMap: EOxMap) {
   if (controls) {
     if (Array.isArray(controls)) {
       controls.forEach((controlName) => {
-        const control = new availableControls[controlName]();
+        const control = new availableControls[controlName]({});
         EOxMap.map.addControl(control);
         EOxMap.mapControls[controlName] = control;
       });

--- a/elements/map/src/controls/controls.ts
+++ b/elements/map/src/controls/controls.ts
@@ -1,6 +1,12 @@
-import { EOxMap } from "../main";
+import { EOxMap } from "../../main";
 import * as olControls from "ol/control";
-import { generateLayers } from "./generate";
+import { generateLayers } from "../generate";
+import Geolocation from "./Geolocation";
+
+const availableControls = {
+  ...olControls,
+  Geolocation,
+};
 
 export type controlType =
   | "Attribution"
@@ -11,7 +17,8 @@ export type controlType =
   | "ScaleLine"
   | "ZoomSlider"
   | "ZoomToExtent"
-  | "Zoom";
+  | "Zoom"
+  | "Geolocation";
 
 export type controlDictionary = {
   [key in controlType]?: object;
@@ -53,7 +60,7 @@ export function addControl(EOxMap: EOxMap, type: controlType, options: object) {
     //@ts-ignore
     controlOptions.layers = generateLayers(EOxMap, options.layers); // parse layers (OverviewMap)
   }
-  const control = new olControls[type](controlOptions);
+  const control = new availableControls[type](controlOptions);
   EOxMap.map.addControl(control);
   EOxMap.mapControls[type] = control;
 }
@@ -66,7 +73,7 @@ export function addInitialControls(EOxMap: EOxMap) {
   if (controls) {
     if (Array.isArray(controls)) {
       controls.forEach((controlName) => {
-        const control = new olControls[controlName]();
+        const control = new availableControls[controlName]();
         EOxMap.map.addControl(control);
         EOxMap.mapControls[controlName] = control;
       });
@@ -80,7 +87,7 @@ export function addInitialControls(EOxMap: EOxMap) {
           // @ts-ignore
           controlOptions.layers = generateLayers(controlOptions.layers); // parse layers (OverviewMap)
         }
-        const control = new olControls[controlName](controlOptions);
+        const control = new availableControls[controlName](controlOptions);
         EOxMap.map.addControl(control);
         EOxMap.mapControls[controlName] = control;
       }

--- a/elements/map/test/controls.cy.ts
+++ b/elements/map/test/controls.cy.ts
@@ -86,33 +86,4 @@ describe("webcomponent property parsing", () => {
       ).to.be.equal("AWS_NO2-VISUALISATION");
     });
   });
-
-  it("Geolocation Control", () => {
-    cy.mount(
-      html`<eox-map
-        .zoom=${0}
-        .center=${[0, 0]}
-        .layers=${[
-          {
-            type: "Tile",
-            properties: {
-              id: "customId",
-            },
-            source: {
-              type: "OSM",
-            },
-          },
-        ]}
-        .controls=${{
-          Geolocation: {},
-        }}
-      ></eox-map>`
-    ).as("eox-map");
-    cy.get("eox-map").and(async ($el) => {
-      const eoxMap = <EOxMap>$el[0];
-      expect(
-        eoxMap.map.getControls().getLength(),
-      ).to.be.equal(1);
-    });
-  });
 });

--- a/elements/map/test/controls.cy.ts
+++ b/elements/map/test/controls.cy.ts
@@ -3,19 +3,6 @@ import "../main";
 import tileWmsLayerStyleJson from "./tileWmsLayer.json";
 
 describe("webcomponent property parsing", () => {
-  /*it("set simple initial controls via webcomponent properties as Array", () => {
-    cy.mount(
-      html`<eox-map
-        .controls=${["Zoom", "Attribution", "FullScreen"]}
-      ></eox-map>`
-    ).as("eox-map");
-    cy.get("eox-map").and(($el) => {
-      expect(
-        (<EOxMap>$el[0]).map.getControls().getLength(),
-        "set controls via webcomponent properties (Array)"
-      ).to.be.equal(3);
-    });
-  });*/
   it("set controls via webcomponent properties", () => {
     cy.mount(
       html`<eox-map
@@ -84,6 +71,35 @@ describe("webcomponent property parsing", () => {
           .getParams().LAYERS,
         "update controls by changing the control prop"
       ).to.be.equal("AWS_NO2-VISUALISATION");
+    });
+  });
+
+  it("Geolocation Control", () => {
+    cy.mount(
+      html`<eox-map
+        .zoom=${0}
+        .center=${[0, 0]}
+        .layers=${[
+          {
+            type: "Tile",
+            properties: {
+              id: "customId",
+            },
+            source: {
+              type: "OSM",
+            },
+          },
+        ]}
+        .controls=${{
+          Geolocation: {},
+        }}
+      ></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(async ($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      expect(eoxMap.map.getControls().getLength()).to.be.equal(1);
+      //@ts-ignore
+      expect(eoxMap.map.getControls().getArray()[0].getElement()).to.exist;
     });
   });
 });

--- a/elements/map/test/controls.cy.ts
+++ b/elements/map/test/controls.cy.ts
@@ -86,4 +86,33 @@ describe("webcomponent property parsing", () => {
       ).to.be.equal("AWS_NO2-VISUALISATION");
     });
   });
+
+  it("Geolocation Control", () => {
+    cy.mount(
+      html`<eox-map
+        .zoom=${0}
+        .center=${[0, 0]}
+        .layers=${[
+          {
+            type: "Tile",
+            properties: {
+              id: "customId",
+            },
+            source: {
+              type: "OSM",
+            },
+          },
+        ]}
+        .controls=${{
+          Geolocation: {},
+        }}
+      ></eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(async ($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      expect(
+        eoxMap.map.getControls().getLength(),
+      ).to.be.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
## Implemented changes

This PR brings a custom Geolocation-control as defined in #562, that can be used just like any other `ol`-control. The user has to agree to the location-prompt by the browser, which will only show up when served via https (which is also true for testing, workarounds like ngrok or mkcert will be needed).

The `centerWhenReady`-prop will pan the view to the user position on the first update of the geolocator.

Rotation is not implemented by default, but the `heading`-property of the position feature is set, so by setting the `style`-property of the geolocation control a rotation get be set by accessing that property via style expressions.
(to enable tracking the heading, `highAccuracy` and `trackHeading` have to be set).

With `trackAccuracy` the accuracy feature will be shown in addition to the position feature, indicating possible low accuracy of the sensor.

A custom Icon for the button can be set via the `buttonIcon`-prop. The button element get be retrieved via `Geolocation.getElement()`


<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
