### PR TITLE
fix: add fallback values if config properties are not defined

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -231,11 +231,11 @@ export class EOxMap extends LitElement {
 
   set config(config: ConfigObject) {
     this._config = config;
-    this.zoom = config?.view?.zoom;
+    this.zoom = config?.view?.zoom || 0;
     this.projection = config?.view?.projection || "EPSG:3857";
-    this.center = config.view?.center; // set center after projection, order matters
-    this.layers = config?.layers;
-    this.controls = config?.controls;
+    this.center = config.view?.center || [0, 0]; // set center after projection, order matters
+    this.layers = config?.layers || [];
+    this.controls = config?.controls || {};
     if (this.preventScroll === undefined) {
       this.preventScroll = config?.preventScroll;
     }


### PR DESCRIPTION
## Implemented changes

This PR adds some fallback values when parsing the config property in order to prevent breaking the map when things like `layers` or `controls` are omitted. Fixes #771.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
