### PR TITLE
Fix: Add default sensitive tags to dom purify list

### DIFF
--- a/elements/storytelling/src/enums/index.js
+++ b/elements/storytelling/src/enums/index.js
@@ -5,4 +5,4 @@ export {
   TAGS_SELF_CLOSING,
   DEFAULT_MODE_ATTRS,
 } from "./plugin";
-export { EVENT_REQ_MODES } from "./render";
+export { EVENT_REQ_MODES, DEFAULT_SENSITIVE_TAGS } from "./render";

--- a/elements/storytelling/src/enums/render.js
+++ b/elements/storytelling/src/enums/render.js
@@ -1,1 +1,2 @@
 export const EVENT_REQ_MODES = ["tour"];
+export const DEFAULT_SENSITIVE_TAGS = ["iframe"];

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -15,6 +15,7 @@ import {
   markdownItDecorateImproved,
 } from "./markdown-it-plugin";
 import styleEOX from "./style.eox.js";
+import { DEFAULT_SENSITIVE_TAGS } from "./enums";
 const md = markdownit({ html: true });
 
 md.use(markdownItDecorateImproved).use(markdownItConfig);
@@ -104,6 +105,7 @@ export class EOxStoryTelling extends LitElement {
       this.#html = renderHtmlString(
         DOMPurify.sanitize(unsafeHTML, {
           CUSTOM_ELEMENT_HANDLING: getCustomEleHandling(md),
+          ADD_TAGS: DEFAULT_SENSITIVE_TAGS,
         }),
         md.sections,
         this

--- a/elements/storytelling/stories/markdown-attr-comment.js
+++ b/elements/storytelling/stories/markdown-attr-comment.js
@@ -11,6 +11,8 @@ export const MarkdownAttrComment = {
   Some text with red color <!--{#red-color style="color:red;"}-->
   
   ![Image](https://www.gstatic.com/prettyearth/assets/full/14617.jpg)<!-- {width=300} -->
+  
+  ## Natural Disasters <!--{as="iframe" src="https://ourworldindata.org/grapher/deaths-and-missing-persons-due-to-natural-disasters" style="width: 100%; height: 600px; border: none;"}-->
 `,
   },
   render: (args) => html`


### PR DESCRIPTION
## Implemented changes
- DOM Purify also removes some of the default tags from its purify HTML list and we need to pass it into a separate key called `ADD_TAGS` to enable it again and it is not part of custom tags. That's why `iframe` was not loading as it is part of sensitive tags.

## Screenshots/Videos

<img width="1400" alt="image" src="https://github.com/EOX-A/EOxElements/assets/10809211/9337c55f-1ff6-4c02-98a9-37fc1e125e18">


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
