### PR TITLE
feat: added autoSpreadSingle option to not show summary for single item groups

### DIFF
--- a/elements/itemfilter/itemfilter.stories.js
+++ b/elements/itemfilter/itemfilter.stories.js
@@ -80,6 +80,43 @@ export const Primary = {
   },
 };
 
+export const AutoSpread = {
+  args: {
+    config: {
+      titleProperty: "title",
+      filterProperties: [
+        {
+          keys: ["title", "themes"],
+          title: "Search",
+          type: "text",
+          expanded: true,
+        },
+        {
+          key: "themes",
+          title: "Theme",
+          type: "multiselect",
+        },
+        {
+          key: "timestamp",
+          type: "range",
+          format: "date",
+        },
+        {
+          key: "geometry",
+          type: "spatial",
+        },
+      ],
+      aggregateResults: "themes",
+      autoSpreadSingle: true,
+      enableHighlighting: true,
+      onSelect: (item) => {
+        console.log(item);
+      },
+    },
+    items,
+  },
+};
+
 export const MultiSelect = {
   args: {
     config: {

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -592,7 +592,7 @@ export class EOxItemFilter extends TemplateElement {
                                         >
                                       </span>
                                     </summary>
-                                    <div style="margin-left: 15px">
+                                    <div>
                                       ${this.createItemList(
                                         aggregationProperty
                                       )}

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -559,38 +559,41 @@ export class EOxItemFilter extends TemplateElement {
                                   aggregationProperty
                                 ).length
                             ),
-                            (aggregationProperty) => html` ${when(
-                              this.aggregateResults(
-                                this.results,
-                                aggregationProperty
-                              ).length > 1,
-                              () => html`
-                                <details
-                                  class="details-results"
-                                  @toggle=${this.toggleAccordion}
-                                  ?open=${this._config.expandResults ||
-                                  (nothing as null)}
-                                >
-                                  <summary>
-                                    <span class="title">
-                                      ${aggregationProperty}
-                                      <span class="count"
-                                        >${this.aggregateResults(
-                                          this.results,
-                                          aggregationProperty
-                                        ).length}</span
-                                      >
-                                    </span>
-                                  </summary>
-                                  <div style="margin-left: 15px">
-                                    ${this.createItemList(aggregationProperty)}
-                                  </div>
-                                </details>
-                              `,
-                              () => html` <div style="margin-left: -8px">
-                                ${this.createItemList(aggregationProperty)}
-                              </div>`
-                            )}`
+                            (aggregationProperty) =>
+                              html` ${when(
+                                this.aggregateResults(
+                                  this.results,
+                                  aggregationProperty
+                                ).length > 1,
+                                () => html`
+                                  <details
+                                    class="details-results"
+                                    @toggle=${this.toggleAccordion}
+                                    ?open=${this._config.expandResults ||
+                                    (nothing as null)}
+                                  >
+                                    <summary>
+                                      <span class="title">
+                                        ${aggregationProperty}
+                                        <span class="count"
+                                          >${this.aggregateResults(
+                                            this.results,
+                                            aggregationProperty
+                                          ).length}</span
+                                        >
+                                      </span>
+                                    </summary>
+                                    <div style="margin-left: 15px">
+                                      ${this.createItemList(
+                                        aggregationProperty
+                                      )}
+                                    </div>
+                                  </details>
+                                `,
+                                () => html` <div style="margin-left: -8px">
+                                  ${this.createItemList(aggregationProperty)}
+                                </div>`
+                              )}`
                           )
                         : map(
                             this.results,

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -319,6 +319,68 @@ export class EOxItemFilter extends TemplateElement {
     });
   }
 
+  createItemList(aggregationProperty: string) {
+    return html`
+    <ul>
+      ${repeat(
+        this.aggregateResults(
+          this.results,
+          aggregationProperty
+        ),
+        (item: Item) => item.id,
+        (item: Item) => html`
+          <li
+            class=${this.selectedResult?.[
+              this._config.titleProperty
+            ] === item[this._config.titleProperty]
+              ? "highlighted"
+              : (nothing as null)}
+          >
+            <label>
+              <input
+                data-cy="result-radio"
+                type="radio"
+                class="result-radio"
+                name="result"
+                id="${<string>item.id}"
+                ?checked=${this.selectedResult?.[
+                  this._config.titleProperty
+                ] ===
+                  item[this._config.titleProperty] ||
+                (nothing as null)}
+                @click=${() => {
+                  this.selectedResult = item;
+                  this._config.onSelect(item);
+                }}
+              />
+              ${when(
+                this.hasTemplate("result"),
+                () =>
+                  this.renderTemplate(
+                    "result",
+                    item,
+                    `result-${item.id}`
+                  ),
+                () => html`
+                  <span class="title"
+                    >${unsafeHTML(
+                      <string>(
+                        item[
+                          this._config.titleProperty
+                        ]
+                      )
+                    )}</span
+                  >
+                `
+              )}
+            </label>
+          </li>
+        `
+      )}
+    </ul>
+    `;
+  }
+
   sortResults(items: Record<string, unknown>[]) {
     return [...items].sort((a: Item, b: Item) =>
       (<string>a[this._config.titleProperty]).localeCompare(
@@ -511,7 +573,10 @@ export class EOxItemFilter extends TemplateElement {
                                   aggregationProperty
                                 ).length
                             ),
-                            (aggregationProperty) => html`<details
+                            (aggregationProperty) => html`
+                            ${when(this.aggregateResults(this.results,aggregationProperty).length > 1,
+                              () => html`
+                              <details
                               class="details-results"
                               @toggle=${this.toggleAccordion}
                               ?open=${this._config.expandResults ||
@@ -528,64 +593,16 @@ export class EOxItemFilter extends TemplateElement {
                                   >
                                 </span>
                               </summary>
-                              <ul>
-                                ${repeat(
-                                  this.aggregateResults(
-                                    this.results,
-                                    aggregationProperty
-                                  ),
-                                  (item: Item) => item.id,
-                                  (item: Item) => html`
-                                    <li
-                                      class=${this.selectedResult?.[
-                                        this._config.titleProperty
-                                      ] === item[this._config.titleProperty]
-                                        ? "highlighted"
-                                        : (nothing as null)}
-                                    >
-                                      <label>
-                                        <input
-                                          data-cy="result-radio"
-                                          type="radio"
-                                          class="result-radio"
-                                          name="result"
-                                          id="${<string>item.id}"
-                                          ?checked=${this.selectedResult?.[
-                                            this._config.titleProperty
-                                          ] ===
-                                            item[this._config.titleProperty] ||
-                                          (nothing as null)}
-                                          @click=${() => {
-                                            this.selectedResult = item;
-                                            this._config.onSelect(item);
-                                          }}
-                                        />
-                                        ${when(
-                                          this.hasTemplate("result"),
-                                          () =>
-                                            this.renderTemplate(
-                                              "result",
-                                              item,
-                                              `result-${item.id}`
-                                            ),
-                                          () => html`
-                                            <span class="title"
-                                              >${unsafeHTML(
-                                                <string>(
-                                                  item[
-                                                    this._config.titleProperty
-                                                  ]
-                                                )
-                                              )}</span
-                                            >
-                                          `
-                                        )}
-                                      </label>
-                                    </li>
-                                  `
-                                )}
-                              </ul>
-                            </details>`
+                              <div style="margin-left: 15px">
+                              ${this.createItemList(aggregationProperty)}
+                              </div>
+                              </details>
+                            `,
+                            () => html`
+                            <div style="margin-left: -8px">
+                            ${this.createItemList(aggregationProperty)}
+                            </div>`
+                            )}`
                           )
                         : map(
                             this.results,

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -27,6 +27,12 @@ export class ElementConfig {
   public aggregateResults?: string = undefined;
 
   /**
+   * Automatically spread single item summaries
+   * removing the summary header
+   */
+  public autoSpreadSingle?: boolean = false;
+
+  /**
    * Highlighting of search result character matches
    */
   public enableHighlighting?: boolean = false;
@@ -564,7 +570,10 @@ export class EOxItemFilter extends TemplateElement {
                                 this.aggregateResults(
                                   this.results,
                                   aggregationProperty
-                                ).length > 1,
+                                ).length === 1 && this.config.autoSpreadSingle,
+                                () => html` <div style="margin-left: -8px">
+                                  ${this.createItemList(aggregationProperty)}
+                                </div>`,
                                 () => html`
                                   <details
                                     class="details-results"
@@ -589,10 +598,7 @@ export class EOxItemFilter extends TemplateElement {
                                       )}
                                     </div>
                                   </details>
-                                `,
-                                () => html` <div style="margin-left: -8px">
-                                  ${this.createItemList(aggregationProperty)}
-                                </div>`
+                                `
                               )}`
                           )
                         : map(

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -321,63 +321,49 @@ export class EOxItemFilter extends TemplateElement {
 
   createItemList(aggregationProperty: string) {
     return html`
-    <ul>
-      ${repeat(
-        this.aggregateResults(
-          this.results,
-          aggregationProperty
-        ),
-        (item: Item) => item.id,
-        (item: Item) => html`
-          <li
-            class=${this.selectedResult?.[
-              this._config.titleProperty
-            ] === item[this._config.titleProperty]
-              ? "highlighted"
-              : (nothing as null)}
-          >
-            <label>
-              <input
-                data-cy="result-radio"
-                type="radio"
-                class="result-radio"
-                name="result"
-                id="${<string>item.id}"
-                ?checked=${this.selectedResult?.[
-                  this._config.titleProperty
-                ] ===
-                  item[this._config.titleProperty] ||
-                (nothing as null)}
-                @click=${() => {
-                  this.selectedResult = item;
-                  this._config.onSelect(item);
-                }}
-              />
-              ${when(
-                this.hasTemplate("result"),
-                () =>
-                  this.renderTemplate(
-                    "result",
-                    item,
-                    `result-${item.id}`
-                  ),
-                () => html`
-                  <span class="title"
-                    >${unsafeHTML(
-                      <string>(
-                        item[
-                          this._config.titleProperty
-                        ]
-                      )
-                    )}</span
-                  >
-                `
-              )}
-            </label>
-          </li>
-        `
-      )}
-    </ul>
+      <ul>
+        ${repeat(
+          this.aggregateResults(this.results, aggregationProperty),
+          (item: Item) => item.id,
+          (item: Item) => html`
+            <li
+              class=${this.selectedResult?.[this._config.titleProperty] ===
+              item[this._config.titleProperty]
+                ? "highlighted"
+                : (nothing as null)}
+            >
+              <label>
+                <input
+                  data-cy="result-radio"
+                  type="radio"
+                  class="result-radio"
+                  name="result"
+                  id="${<string>item.id}"
+                  ?checked=${this.selectedResult?.[
+                    this._config.titleProperty
+                  ] === item[this._config.titleProperty] || (nothing as null)}
+                  @click=${() => {
+                    this.selectedResult = item;
+                    this._config.onSelect(item);
+                  }}
+                />
+                ${when(
+                  this.hasTemplate("result"),
+                  () =>
+                    this.renderTemplate("result", item, `result-${item.id}`),
+                  () => html`
+                    <span class="title"
+                      >${unsafeHTML(
+                        <string>item[this._config.titleProperty]
+                      )}</span
+                    >
+                  `
+                )}
+              </label>
+            </li>
+          `
+        )}
+      </ul>
     `;
   }
 
@@ -573,35 +559,37 @@ export class EOxItemFilter extends TemplateElement {
                                   aggregationProperty
                                 ).length
                             ),
-                            (aggregationProperty) => html`
-                            ${when(this.aggregateResults(this.results,aggregationProperty).length > 1,
+                            (aggregationProperty) => html` ${when(
+                              this.aggregateResults(
+                                this.results,
+                                aggregationProperty
+                              ).length > 1,
                               () => html`
-                              <details
-                              class="details-results"
-                              @toggle=${this.toggleAccordion}
-                              ?open=${this._config.expandResults ||
-                              (nothing as null)}
-                            >
-                              <summary>
-                                <span class="title">
-                                  ${aggregationProperty}
-                                  <span class="count"
-                                    >${this.aggregateResults(
-                                      this.results,
-                                      aggregationProperty
-                                    ).length}</span
-                                  >
-                                </span>
-                              </summary>
-                              <div style="margin-left: 15px">
-                              ${this.createItemList(aggregationProperty)}
-                              </div>
-                              </details>
-                            `,
-                            () => html`
-                            <div style="margin-left: -8px">
-                            ${this.createItemList(aggregationProperty)}
-                            </div>`
+                                <details
+                                  class="details-results"
+                                  @toggle=${this.toggleAccordion}
+                                  ?open=${this._config.expandResults ||
+                                  (nothing as null)}
+                                >
+                                  <summary>
+                                    <span class="title">
+                                      ${aggregationProperty}
+                                      <span class="count"
+                                        >${this.aggregateResults(
+                                          this.results,
+                                          aggregationProperty
+                                        ).length}</span
+                                      >
+                                    </span>
+                                  </summary>
+                                  <div style="margin-left: 15px">
+                                    ${this.createItemList(aggregationProperty)}
+                                  </div>
+                                </details>
+                              `,
+                              () => html` <div style="margin-left: -8px">
+                                ${this.createItemList(aggregationProperty)}
+                              </div>`
                             )}`
                           )
                         : map(


### PR DESCRIPTION
## Implemented changes

When setting `autoSpreadSingle` to true and a summary section only contains one entry this removes the summary section and shows directly the item.

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/4036819/a4484c33-459d-45c5-97c7-ba3b59cfc4f2)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
