### PR TITLE
feat: add no-shadow attribute/property

### DIFF
--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -14,6 +14,7 @@ export class EOxJSONForm extends LitElement {
     schema: { attribute: false, type: Object },
     value: { attribute: false, type: Object },
     options: { attribute: false, type: Object },
+    noShadow: { attribute: "no-shadow", type: Boolean },
     unstyled: { type: Boolean },
   };
 
@@ -51,6 +52,13 @@ export class EOxJSONForm extends LitElement {
       disable_array_delete_last_row: true,
       array_controls_top: true,
     };
+
+    /**
+     * Renders the element without a shadow root
+     *
+     * @type {Boolean}
+     */
+    this.noShadow = false;
 
     /**
      * Render the element without additional styles
@@ -178,6 +186,13 @@ export class EOxJSONForm extends LitElement {
 
       this.#dispatchEvent();
     }
+  }
+
+  /**
+   * Overrides createRenderRoot to handle shadow DOM creation based on the noShadow property.
+   */
+  createRenderRoot() {
+    return this.noShadow ? this : super.createRenderRoot();
   }
 
   render() {

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -1,6 +1,7 @@
 // Exported test methods
 
 export { default as loadJsonFormTest } from "./load-jsonform";
+export { default as loadJsonFormNoShadowTest } from "./load-jsonform-no-shadow";
 export { default as loadExternalSchemaTest } from "./load-external-schema";
 export { default as loadExternalValueTest } from "./load-external-value";
 export { default as loadReRenderFormOnChangeTest } from "./re-render-form-on-change";

--- a/elements/jsonform/test/cases/load-jsonform-no-shadow.js
+++ b/elements/jsonform/test/cases/load-jsonform-no-shadow.js
@@ -1,0 +1,37 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+const testVals = {
+  key: "foo",
+  value: "bar",
+};
+/**
+ * Test to verify if the jsonform component loads successfully without shadow.
+ */
+const loadJsonFormNoShadowTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      no-shadow
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: testVals.value,
+      }}
+    ></eox-jsonform>`
+  ).as(jsonForm);
+  // Find the jsonForm element and assure there is no shadow DOM
+  cy.get(jsonForm).shadow().should("not.exist");
+  cy.get(".je-form-input-label").invoke("html").should("eq", testVals.key);
+  cy.get("input[name]").invoke("val").should("eq", testVals.value);
+};
+
+export default loadJsonFormNoShadowTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -2,6 +2,7 @@
 import "../src/main";
 import {
   loadJsonFormTest,
+  loadJsonFormNoShadowTest,
   loadExternalSchemaTest,
   loadExternalValueTest,
   loadReRenderFormOnChangeTest,
@@ -11,6 +12,8 @@ import {
 describe("Jsonform", () => {
   // Test case to ensure the jsonform component loads successfully
   it("loads the jsonform", () => loadJsonFormTest());
+  it("loads the jsonform without shadow root", () =>
+    loadJsonFormNoShadowTest());
   it("loads schema from url", () => loadExternalSchemaTest());
   it("loads value from url", () => loadExternalValueTest());
   it("re-renders form on change", () => loadReRenderFormOnChangeTest());


### PR DESCRIPTION
## Implemented changes

This adds the `noShadow` functionality to jsonform, offering a way to create the element without shadow root. This is hand if the eox-jsonform is used as a sub-element where global styling is wanted.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
