### PR TITLE
chore(ci): use json value for step check, fixes #567

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,22 +20,22 @@ jobs:
         uses: actions/checkout@v4
         # these if statements ensure that a publication only occurs when
         # a new release is created:
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
       - name: Set up NPM 🔧
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
       - name: Install dependencies 🔧
         run: npm ci
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
       - name: Build and publish package 🚀
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          ELEMENT_DIR: ${{ steps.release.outputs.paths_released }}
+          ELEMENT_DIR: ${{ fromJSON(steps.release.outputs.paths_released) }}
         run: |
           cd `echo ${ELEMENT_DIR} | tr -d '[]"'` && \
           npm run build && \
           npm publish --access=public
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}


### PR DESCRIPTION
## Implemented changes

Starting with v4, release-please now sends a string (`"true"`) instead of a boolean (`true`) as release step output. This messed up our (and many other pipelines). By using `from JSON()`, it should parse the string as boolean, and if in future this is fixed back to a boolean, it should still work.


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
