### PR TITLE
feat: markdown editor for fields with type "markdown"

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,3 +50,9 @@ jobs:
           npm run test:component
       - name: Run e2e tests 👀
         run: npm run test:e2e
+      - name: Upload failed test screenshots 📷
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots

--- a/elements/jsonform/jsonform.stories.js
+++ b/elements/jsonform/jsonform.stories.js
@@ -52,3 +52,25 @@ export const External = {
     value: externalValue,
   },
 };
+
+export const Markdown = {
+  args: {
+    schema: {
+      type: "object",
+      properties: {
+        md: {
+          type: "string",
+          format: "markdown",
+          options: {
+            simplemde: {
+              spellChecker: false,
+            },
+          },
+        },
+      },
+    },
+    value: {
+      md: "# Hello world! This is [markdown](https://en.wikipedia.org/wiki/Markdown).",
+    },
+  },
+};

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -1,0 +1,16 @@
+import { JSONEditor } from "@json-editor/json-editor/src/core.js";
+import addCustomInputs from "../custom-inputs";
+
+export const createEditor = (element) => {
+  addCustomInputs(element.value || {});
+
+  const formEle = element.renderRoot.querySelector("form");
+
+  return new JSONEditor(formEle, {
+    schema: element.schema,
+    ...(element.value ? { startval: element.value } : {}),
+    theme: "html",
+    ajax: true,
+    ...element.options,
+  });
+};

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -32,12 +32,12 @@ export const createEditor = (element) => {
         editor.destroy();
 
         // Add SimpleMDE styles
-        const style = element.renderRoot.querySelector("style");
+        const style = document.createElement("style");
         style.innerHTML = `
           @import url("https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css");
           @import url("https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css");
-          ${style.innerHTML}
         `;
+        element.renderRoot.appendChild(style);
 
         // Add SimpleMDE bundle
         const script = document.createElement("script");

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -50,7 +50,6 @@ export const createEditor = (element) => {
         });
         element.renderRoot.appendChild(script);
       } else {
-        console.log("default");
         resolve(editor);
       }
     });

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -1,16 +1,62 @@
 import { JSONEditor } from "@json-editor/json-editor/src/core.js";
+import { SimplemdeEditor } from "@json-editor/json-editor/src/editors/simplemde.js";
 import addCustomInputs from "../custom-inputs";
 
+/**
+ * Create the editor instance
+ * @param element the eox-jsonform instance
+ */
 export const createEditor = (element) => {
-  addCustomInputs(element.value || {});
+  return new Promise((resolve) => {
+    addCustomInputs(element.value || {});
 
-  const formEle = element.renderRoot.querySelector("form");
+    const formEle = element.renderRoot.querySelector("form");
 
-  return new JSONEditor(formEle, {
-    schema: element.schema,
-    ...(element.value ? { startval: element.value } : {}),
-    theme: "html",
-    ajax: true,
-    ...element.options,
+    const initEditor = () =>
+      new JSONEditor(formEle, {
+        schema: element.schema,
+        ...(element.value ? { startval: element.value } : {}),
+        theme: "html",
+        ajax: true,
+        ...element.options,
+      });
+
+    let editor = initEditor();
+
+    editor.on("ready", () => {
+      // Check if one of the editors requires SimpleMDE and it's not yet installed.
+      // If so, destroy the editor instance, load SimpleMDE and re-init the editor.
+      if (
+        Object.values(editor.editors).some(
+          (e) => e instanceof SimplemdeEditor
+        ) &&
+        !window.SimpleMDE
+      ) {
+        editor.destroy();
+
+        // Add SimpleMDE styles
+        const style = element.renderRoot.querySelector("style");
+        style.innerHTML = `
+          @import url("https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css");
+          @import url("https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css");
+          ${style.innerHTML}
+        `;
+
+        // Add SimpleMDE bundle
+        const script = document.createElement("script");
+        script.src =
+          "https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js";
+        script.addEventListener("load", () => {
+          // Create new editor, this time already using SimpleMDE
+          editor = initEditor();
+          resolve(editor);
+        });
+        element.renderRoot.appendChild(script);
+      } else {
+        resolve(editor);
+      }
+    });
+
+    return editor;
   });
 };

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -27,10 +27,7 @@ export const createEditor = (element) => {
       // Check if one of the editors requires SimpleMDE and it's not yet installed.
       // If so, destroy the editor instance, load SimpleMDE and re-init the editor.
       if (
-        Object.values(editor.editors).some(
-          (e) => e instanceof SimplemdeEditor
-        ) &&
-        !window.SimpleMDE
+        Object.values(editor.editors).some((e) => e instanceof SimplemdeEditor)
       ) {
         editor.destroy();
 
@@ -53,6 +50,7 @@ export const createEditor = (element) => {
         });
         element.renderRoot.appendChild(script);
       } else {
+        console.log("default");
         resolve(editor);
       }
     });

--- a/elements/jsonform/src/helpers/index.js
+++ b/elements/jsonform/src/helpers/index.js
@@ -1,0 +1,1 @@
+export { createEditor } from "./editor";

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -86,16 +86,24 @@ export class EOxJSONForm extends LitElement {
     }
     return property;
   }
+
+  /**
+   * The JSONEditor instance
+   */
+  get editor() {
+    return this.#editor;
+  }
+
   /**
    * JSON schema used to render the form
    */
   get schema() {
     return this._schema;
   }
+
   /**
    * @param {JsonSchema} newSchema
    */
-
   set schema(newSchema) {
     let oldValue = this._schema;
     this._schema = newSchema;

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -1,8 +1,7 @@
-import { JSONEditor } from "@json-editor/json-editor/src/core.js";
 import { LitElement, html } from "lit";
+import { createEditor } from "./helpers";
 import { style } from "./style";
 import { styleEOX } from "./style.eox";
-import addCustomInputs from "./custom-inputs";
 
 /**
  * @typedef {JSON & {properties: object}} JsonSchema
@@ -102,18 +101,7 @@ export class EOxJSONForm extends LitElement {
     this._schema = newSchema;
     if (this.#editor) {
       this.#editor.destroy();
-      addCustomInputs(this.value || {});
-
-      const formEle = this.renderRoot.querySelector("form");
-
-      this.#editor = new JSONEditor(formEle, {
-        schema: this.schema,
-        ...(this.value ? { startval: this.value } : {}),
-        theme: "html",
-        ajax: true,
-        ...this.options,
-      });
-
+      this.#editor = createEditor(this);
       this.#dispatchEvent();
     }
     this.requestUpdate("schema", oldValue);
@@ -172,18 +160,7 @@ export class EOxJSONForm extends LitElement {
     this.value = await this.parseProperty(this.value);
 
     if (!this.#editor) {
-      addCustomInputs(this.value || {});
-
-      const formEle = this.renderRoot.querySelector("form");
-
-      this.#editor = new JSONEditor(formEle, {
-        schema: this.schema,
-        ...(this.value ? { startval: this.value } : {}),
-        theme: "html",
-        ajax: true,
-        ...this.options,
-      });
-
+      this.#editor = createEditor(this);
       this.#dispatchEvent();
     }
   }
@@ -199,7 +176,7 @@ export class EOxJSONForm extends LitElement {
     return html`
       <style>
         ${style}
-          ${!this.unstyled && styleEOX}
+        ${!this.unstyled && styleEOX}
       </style>
       <form></form>
     `;

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -101,8 +101,6 @@ export class EOxJSONForm extends LitElement {
     this._schema = newSchema;
     if (this.#editor) {
       this.#editor.destroy();
-      this.#editor = createEditor(this);
-      this.#dispatchEvent();
     }
     this.requestUpdate("schema", oldValue);
   }
@@ -160,7 +158,7 @@ export class EOxJSONForm extends LitElement {
     this.value = await this.parseProperty(this.value);
 
     if (!this.#editor) {
-      this.#editor = createEditor(this);
+      this.#editor = await createEditor(this);
       this.#dispatchEvent();
     }
   }

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -151,7 +151,7 @@ export class EOxJSONForm extends LitElement {
     const events = ["ready", "change"];
 
     events.map((evt) => {
-      this.#editor.on(evt, async () => {
+      this.#editor.on(evt, () => {
         this._value = this.#editor.getValue();
         this.#emitValue();
       });

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -6,3 +6,4 @@ export { default as loadExternalSchemaTest } from "./load-external-schema";
 export { default as loadExternalValueTest } from "./load-external-value";
 export { default as loadReRenderFormOnChangeTest } from "./re-render-form-on-change";
 export { default as loadMarkdownTest } from "./load-markdown";
+export { default as triggerChangeEventTest } from "./trigger-change-event";

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -5,3 +5,4 @@ export { default as loadJsonFormNoShadowTest } from "./load-jsonform-no-shadow";
 export { default as loadExternalSchemaTest } from "./load-external-schema";
 export { default as loadExternalValueTest } from "./load-external-value";
 export { default as loadReRenderFormOnChangeTest } from "./re-render-form-on-change";
+export { default as loadMarkdownTest } from "./load-markdown";

--- a/elements/jsonform/test/cases/load-markdown.js
+++ b/elements/jsonform/test/cases/load-markdown.js
@@ -1,0 +1,54 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+const testVals = {
+  key: "foo",
+  value: "# bar",
+};
+/**
+ * Test to verify if the jsonform component loads successfully.
+ */
+const loadMarkdownTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "markdown",
+            options: {
+              simplemde: {
+                spellChecker: false,
+              },
+            },
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: testVals.value,
+      }}
+    ></eox-jsonform>`
+  ).as(jsonForm);
+  // Find the jsonForm element and access its shadow DOM
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      // Check if CodeMirror editor has loaded
+      cy.get(".CodeMirror").should("exist");
+      // Check if text was rendered as h1
+      cy.get(".cm-header-1").invoke("text").should("eq", testVals.value);
+    });
+  cy.get(jsonForm).and(($el) => {
+    // Check if editor settings were applied
+    expect(
+      $el[0].editor.editors[`root.${testVals.key}`].options.simplemde
+        .spellChecker
+    ).to.eq(false);
+  });
+};
+
+export default loadMarkdownTest;

--- a/elements/jsonform/test/cases/trigger-change-event.js
+++ b/elements/jsonform/test/cases/trigger-change-event.js
@@ -1,0 +1,44 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+const testVals = {
+  key: "foo",
+  value: "bar",
+};
+/**
+ * Test to verify if the jsonform component triggers a change event successfully.
+ */
+const triggerChangeEventTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+          },
+        },
+      }}
+    ></eox-jsonform>`
+  ).as(jsonForm);
+  cy.get(jsonForm)
+    .and(($el) => {
+      $el[0].addEventListener("change", cy.stub().as("change"));
+    })
+
+    // Find the jsonForm element and access its shadow DOM
+    // then type text into the input field
+    .shadow()
+    .within(() => {
+      cy.get("input[name]").type(testVals.value);
+      // String input needs blur to trigger change event
+      // see https://github.com/json-editor/json-editor/issues/1081
+      cy.get(".form-control").click();
+    });
+  cy.get("@change").should("have.been.calledOnce");
+};
+
+export default triggerChangeEventTest;

--- a/elements/jsonform/test/cases/trigger-change-event.js
+++ b/elements/jsonform/test/cases/trigger-change-event.js
@@ -38,7 +38,7 @@ const triggerChangeEventTest = () => {
       // see https://github.com/json-editor/json-editor/issues/1081
       cy.get(".form-control").click();
     });
-  cy.get("@change").should("have.been.calledOnce");
+  cy.get("@change", { timeout: 7000 }).should("have.been.calledOnce");
 };
 
 export default triggerChangeEventTest;

--- a/elements/jsonform/test/cases/trigger-change-event.js
+++ b/elements/jsonform/test/cases/trigger-change-event.js
@@ -36,7 +36,7 @@ const triggerChangeEventTest = () => {
       cy.get("input[name]").type(testVals.value);
       // String input needs blur to trigger change event
       // see https://github.com/json-editor/json-editor/issues/1081
-      cy.get(".form-control").click();
+      cy.get(".form-control").click({ force: true });
     });
   cy.get("@change", { timeout: 7000 }).should("have.been.calledOnce");
 };

--- a/elements/jsonform/test/cases/trigger-change-event.js
+++ b/elements/jsonform/test/cases/trigger-change-event.js
@@ -38,7 +38,7 @@ const triggerChangeEventTest = () => {
       // see https://github.com/json-editor/json-editor/issues/1081
       cy.get(".form-control").click({ force: true });
     });
-  cy.get("@change", { timeout: 7000 }).should("have.been.calledOnce");
+  cy.get("@change").should("have.been.calledOnce");
 };
 
 export default triggerChangeEventTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -7,6 +7,7 @@ import {
   loadExternalValueTest,
   loadReRenderFormOnChangeTest,
   loadMarkdownTest,
+  triggerChangeEventTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -19,4 +20,5 @@ describe("Jsonform", () => {
   it("loads value from url", () => loadExternalValueTest());
   it("re-renders form on change", () => loadReRenderFormOnChangeTest());
   it("loads the markdown editor", () => loadMarkdownTest());
+  it("triggers a change event when typing", () => triggerChangeEventTest());
 });

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -6,6 +6,7 @@ import {
   loadExternalSchemaTest,
   loadExternalValueTest,
   loadReRenderFormOnChangeTest,
+  loadMarkdownTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -17,4 +18,5 @@ describe("Jsonform", () => {
   it("loads schema from url", () => loadExternalSchemaTest());
   it("loads value from url", () => loadExternalValueTest());
   it("re-renders form on change", () => loadReRenderFormOnChangeTest());
+  it("loads the markdown editor", () => loadMarkdownTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR implements SimpleMDE markdown editor for eox-jsonform (which uses [JSONEditor](https://github.com/json-editor/json-editor) under the hood).

It moves the creation of the JSONEditor to a centralized promise. Inside, an editor instance is first created, then once it is ready it is checked if at least one of the editors of the form uses markdown format. If not, it returns the editor instance. Otherwise, it destroys the instance again, loads the necessary SimpleMDE bundles, and creates a new editor instance instead, which is then returned.

This PR also adds a test that checks if the `update` event was triggered.

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/26576876/27115936-a6c4-45a8-a646-0e1d03a1c6f8)
![image](https://github.com/EOX-A/EOxElements/assets/26576876/924f275a-319d-4e9d-a99c-4666c730ac2b)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
