### PR TITLE
chore: remove simplemde cdn link

### DIFF
--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -1,5 +1,4 @@
 import { LitElement, html } from "lit";
-import "https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js";
 import { initEditorEvents } from "../helpers";
 import { EDITOR_SCHEMA } from "../enums";
 
@@ -123,7 +122,6 @@ class StoryTellingEditor extends LitElement {
         </label>
       </div>
       <style>
-        @import url("https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css");
         eox-jsonform#storytelling-editor {
           display: block;
           height: 100%;


### PR DESCRIPTION
## Implemented changes

Since https://github.com/EOX-A/EOxElements/pull/810 introduces a markdown editor built into eox-jsonform, the dependency in eox-storytelling can be removed.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
