### PR TITLE
feat: render sections from h1, show hero title

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -129,6 +129,54 @@ const styleEOX = `
     justify-items: start;
     display: grid;
   }
+  .story-telling .hero {
+    position: relative;      
+    width: 100%;
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+  .story-telling .hero * {
+    color: white;
+    margin: 0rem 0.8rem;
+  }
+  .story-telling .hero::after {
+    content: "";
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    top: 0;
+    left:0;
+    background-image: linear-gradient(to bottom,rgba(0,0,0,0.7) 25%,rgba(0,0,0,0.06) 100%);
+    z-index: -1;
+  }
+  .story-telling .hero.center {
+    align-items: center;
+    text-align: center;
+  }
+  .story-telling .hero.left {
+    align-items: start;
+    text-align: left;
+  }
+  .story-telling .hero.right {
+    align-items: end;
+    text-align: right;
+  }
+  .story-telling .hero img, 
+  .story-telling .hero video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    margin: 0rem;
+  }
   .story-telling .tour.left {
     justify-items: start;
   }

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -9,3 +9,4 @@ export { default as MarkdownSectionsStory } from "./markdown-sections"; // Story
 export { default as MarkdownMapSectionStory } from "./markdown-map-section"; // StoryTelling with eox-map sections
 export { default as MarkdownMapTourStory } from "./markdown-map-tour"; // StoryTelling with map tour
 export { default as MarkdownEditorStory } from "./markdown-editor"; // StoryTelling with editor
+export { default as MarkdownHeroStory } from "./markdown-hero"; // StoryTelling with Hero Section

--- a/elements/storytelling/stories/markdown-hero.js
+++ b/elements/storytelling/stories/markdown-hero.js
@@ -1,0 +1,28 @@
+/**
+ * Renders storytelling with hero section.
+ */
+import { html } from "lit";
+import "../src/main.js";
+
+export const MarkdownHero = {
+  args: {
+    markdown: `
+## Hero Bg Image <!--{ as="img" mode="hero" position="center" src="https://www.gstatic.com/prettyearth/assets/full/14617.jpg" }-->
+# StoryTelling with EOxElements
+#### by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->
+
+## Hero Bg Video <!--{ as="video" mode="hero" position="center" loop="true" muted="true" autoplay="true" src="https://dlmultimedia.esa.int/download/public/videos/2023/06/010/2306_010_AR_EN.mp4" }-->
+# StoryTelling with EOxElements
+#### by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->
+`,
+  },
+  render: (args) => html`
+    <!-- TEMP: no-shadow needed because of font-awesome -->
+    <eox-storytelling
+      id="markdown-hero"
+      markdown=${args.markdown}
+    ></eox-storytelling>
+  `,
+};
+
+export default MarkdownHero;

--- a/elements/storytelling/stories/markdown-hero.js
+++ b/elements/storytelling/stories/markdown-hero.js
@@ -17,7 +17,6 @@ export const MarkdownHero = {
 `,
   },
   render: (args) => html`
-    <!-- TEMP: no-shadow needed because of font-awesome -->
     <eox-storytelling
       id="markdown-hero"
       markdown=${args.markdown}

--- a/elements/storytelling/stories/markdown-hero.js
+++ b/elements/storytelling/stories/markdown-hero.js
@@ -7,13 +7,17 @@ import "../src/main.js";
 export const MarkdownHero = {
   args: {
     markdown: `
-## Hero Bg Image <!--{ as="img" mode="hero" position="center" src="https://www.gstatic.com/prettyearth/assets/full/14617.jpg" }-->
-# StoryTelling with EOxElements
-#### by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->
+# StoryTelling Hero A <!--{ as="img" mode="hero" position="center" src="https://www.gstatic.com/prettyearth/assets/full/14617.jpg" }-->
+by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->
 
-## Hero Bg Video <!--{ as="video" mode="hero" position="center" loop="true" muted="true" autoplay="true" src="https://dlmultimedia.esa.int/download/public/videos/2023/06/010/2306_010_AR_EN.mp4" }-->
-# StoryTelling with EOxElements
-#### by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->
+# StoryTelling Hero B <!--{ as="video" mode="hero" position="center" loop="true" muted="true" autoplay="true" src="https://dlmultimedia.esa.int/download/public/videos/2023/06/010/2306_010_AR_EN.mp4" }-->
+by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->
+
+## Section A
+Hello Section A
+
+## Section B
+Hello Section B
 `,
   },
   render: (args) => html`

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -14,6 +14,7 @@ import {
   MarkdownSectionsStory,
   MarkdownMapTourStory,
   MarkdownEditorStory,
+  MarkdownHeroStory,
 } from "./index";
 import { html } from "lit";
 import "../../jsonform/src/main";
@@ -91,3 +92,8 @@ export const MarkdownMapTour = MarkdownMapTourStory;
  * StoryTelling with editor
  */
 export const MarkdownWithEditor = MarkdownEditorStory;
+
+/**
+ * StoryTelling with Hero Image and Video
+ */
+export const MarkdownWithHeroSection = MarkdownHeroStory;

--- a/elements/storytelling/test/cases/index.js
+++ b/elements/storytelling/test/cases/index.js
@@ -11,3 +11,4 @@ export { default as LoadCustomElementTest } from "./load-custom-element";
 export { default as loadMapSectionTest } from "./load-map-section";
 export { default as loadMapTourTest } from "./load-map-tour";
 export { default as loadMarkdownEditorTest } from "./load-editor";
+export { default as loadHeroSectionTest } from "./load-hero-section";

--- a/elements/storytelling/test/cases/load-hero-section.js
+++ b/elements/storytelling/test/cases/load-hero-section.js
@@ -1,0 +1,31 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { storyTelling } = TEST_SELECTORS;
+
+/**
+ * Ensure the hero section loaded
+ */
+const loadHeroSectionTest = () => {
+  const img = "https://www.gstatic.com/prettyearth/assets/full/14617.jpg";
+  const testText = `
+## Hero Bg Image <!--{ as="img" mode="hero" position="center" src="${img}" }-->
+# Foo
+#### Bar
+`;
+
+  cy.mount(`<eox-storytelling markdown='${testText}'></eox-storytelling>`).as(
+    storyTelling
+  );
+
+  cy.get(storyTelling)
+    .shadow()
+    .within(() => {
+      cy.get(".section-wrap.hero img").should("exist");
+      cy.get(".section-wrap.hero img").should("have.attr", "src", img);
+      cy.get(".section-wrap.hero h1").should("have.text", "Foo");
+      cy.get(".section-wrap.hero h4").should("have.text", "Bar");
+    });
+};
+
+export default loadHeroSectionTest;

--- a/elements/storytelling/test/general.cy.js
+++ b/elements/storytelling/test/general.cy.js
@@ -13,6 +13,7 @@ import {
   loadMapSectionTest,
   loadMapTourTest,
   loadMarkdownEditorTest,
+  loadHeroSectionTest,
 } from "./cases";
 
 // Test suite for Storytelling
@@ -51,4 +52,7 @@ describe("Storytelling", () => {
 
   // Test case to load markdown editor
   it("Load markdown editor", () => loadMarkdownEditorTest());
+
+  // Test case to ensure hero section loaded with content
+  it("Load hero section", () => loadHeroSectionTest());
 });


### PR DESCRIPTION
## Implemented changes

This allows `h1`tags to also create sections, thus changes the structure to 
```md
# StoryTelling Hero Title <!--{ as="img" mode="hero" position="center" src="https://www.gstatic.com/prettyearth/assets/full/14617.jpg" }-->
by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->

## Section A
Hello Section A

## Section B
Hello Section B
```

Which has a nice md fallback:

---
# StoryTelling Hero Title <!--{ as="img" mode="hero" position="center" src="https://www.gstatic.com/prettyearth/assets/full/14617.jpg" }-->
by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->

## Section A
Hello Section A

## Section B
Hello Section B

---

To be discussed!

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/26576876/13aa5804-13ef-4fbb-959e-7aafa4f9e3f2)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
