### PR TITLE
fix(style): improve link rendering, tag rendering, details styling etc.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,13 @@
   "root": true,
   "rules": {
     "@typescript-eslint/ban-ts-comment": "warn",
-    "@typescript-eslint/no-explicit-any": "warn"
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "varsIgnorePattern": "^_",
+        "argsIgnorePattern": "^_"
+      }
+    ]
   }
 }

--- a/elements/stacinfo/src/helpers/index.ts
+++ b/elements/stacinfo/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export { transformProperties } from "./properties";

--- a/elements/stacinfo/src/helpers/properties.ts
+++ b/elements/stacinfo/src/helpers/properties.ts
@@ -1,0 +1,81 @@
+export const transformProperties = (properties: Array<any>) => {
+  return properties.map(([key, property]) => {
+    // Transform extent to only show temporal
+    if (key === "extent") {
+      if (property.value?.temporal?.interval.length > 0) {
+        let extent = property.value.temporal.interval[0];
+        if (
+          Array.isArray(extent) &&
+          (typeof extent[0] === "string" || typeof extent[1] === "string")
+        ) {
+          property.formatted = `${new Date(extent[0])
+            .toISOString()
+            .substring(0, 10)} - ${new Date(extent[1])
+            .toISOString()
+            .substring(0, 10)}`;
+        }
+      }
+    }
+
+    // Replace all links (that haven't been converted yet)
+    property.formatted = property.formatted.replaceAll(
+      /(?<!href=")(http|https|ftp):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gi,
+      (url: string) => {
+        return `<a target="_blank" href="${url}">${url}</a>`;
+      }
+    );
+
+    // Only show assets with roles "metadata" and links with rel "example"
+    const filterLinks = (links: Array<any>) => {
+      return Object.entries(links).filter(([_, itemValue]) => {
+        let pass = true;
+        if (itemValue.roles) pass = itemValue.roles.includes("metadata");
+        if (itemValue.rel) pass = itemValue.rel === "example";
+        return pass;
+      });
+    };
+
+    // Format assets to look like button
+    if (key === "assets" || key === "links" || key === "providers") {
+      // console.log(property);
+      // property.formatted = `<ul>${filterLinks(property.value)
+      //   .map(
+      //     ([itemKey, itemValue]) =>
+      //       `<li>
+      //         <a target="_blank" href="${itemValue.href}"
+      //           >${itemValue.title || itemKey}</a
+      //         >${
+      //           itemValue.description
+      //             ? `<div><p>${itemValue.description}</p></div>`
+      //             : ``
+      //         }
+      //       </li>`
+      //   )
+      //   .join("")}</ul>`;
+      property.formatted = filterLinks(property.value)
+        .map(
+          ([itemKey, itemValue]) =>
+            `<div class="button-container">
+              ${
+                itemValue.description
+                  ? `<div><p>${itemValue.description}</p></div>`
+                  : ``
+              }
+              <a class="button icon-text small block" target="_blank" href="${
+                itemValue.href
+              }"
+                >${itemValue.name || itemValue.title || itemKey}
+                </a>
+            </div>`
+        )
+        .join("");
+    }
+
+    // Add length information to display in list
+    if (["providers", "assets", "links"].includes(key)) {
+      property.length = filterLinks(property.value).length;
+    }
+
+    return [key, property];
+  });
+};

--- a/elements/stacinfo/src/helpers/properties.ts
+++ b/elements/stacinfo/src/helpers/properties.ts
@@ -62,7 +62,7 @@ export const transformProperties = (properties: Array<any>) => {
                   : ``
               }
               <a class="button icon-text small block" target="_blank" href="${
-                itemValue.href
+                itemValue.href || itemValue.url
               }"
                 >${itemValue.name || itemValue.title || itemKey}
                 </a>

--- a/elements/stacinfo/src/helpers/properties.ts
+++ b/elements/stacinfo/src/helpers/properties.ts
@@ -3,7 +3,7 @@ export const transformProperties = (properties: Array<any>) => {
     // Transform extent to only show temporal
     if (key === "extent") {
       if (property.value?.temporal?.interval.length > 0) {
-        let extent = property.value.temporal.interval[0];
+        const extent = property.value.temporal.interval[0];
         if (
           Array.isArray(extent) &&
           (typeof extent[0] === "string" || typeof extent[1] === "string")
@@ -19,7 +19,7 @@ export const transformProperties = (properties: Array<any>) => {
 
     // Replace all links (that haven't been converted yet)
     property.formatted = property.formatted.replaceAll(
-      /(?<!href=")(http|https|ftp):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gi,
+      /(?<!href=")(http|https|ftp):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])/gi,
       (url: string) => {
         return `<a target="_blank" href="${url}">${url}</a>`;
       }

--- a/elements/stacinfo/src/main.ts
+++ b/elements/stacinfo/src/main.ts
@@ -191,7 +191,7 @@ export class EOxStacInfo extends LitElement {
               <section id="featured" part="featured">
                 ${map(
                   parseEntries(this.featured).filter(([_, value]) =>
-                    value.length ? value.length > 0 : true
+                    value.length !== undefined ? value.length > 0 : true
                   ),
                   ([, value]) => html`
                     <details>

--- a/elements/stacinfo/src/main.ts
+++ b/elements/stacinfo/src/main.ts
@@ -4,6 +4,7 @@ import { map } from "lit/directives/map.js";
 import { when } from "lit/directives/when.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { html as staticHTML, unsafeStatic } from "lit/static-html.js";
+import { transformProperties } from "./helpers";
 import { style } from "./style";
 import { styleEOX } from "./style.eox";
 import StacFields, { Formatters } from "@radiantearth/stac-fields";
@@ -43,6 +44,9 @@ export class EOxStacInfo extends LitElement {
 
   @property({ type: Array })
   header: Array<string> = [];
+
+  @property({ type: Array })
+  tags: Array<string> = [];
 
   @property({ type: Array })
   properties: Array<string> = [];
@@ -85,16 +89,19 @@ export class EOxStacInfo extends LitElement {
     Formatters.allowHtmlInCommonMark = this.allowHtml !== undefined;
 
     const parseEntries = (list: Array<string>) =>
-      Object.entries(this.stacProperties)
-        .filter(([key]) => {
-          return list === this.properties && (!list || list.length < 1)
-            ? true
-            : list?.includes(key);
-        })
-        .reverse()
-        .sort(([keyA], [keyB]) =>
-          list?.indexOf(keyA) > list?.indexOf(keyB) ? 1 : -1
-        );
+      transformProperties(
+        Object.entries(this.stacProperties)
+          .filter(([key]) => {
+            return list === this.properties && (!list || list.length < 1)
+              ? true
+              : list?.includes(key);
+          })
+          .reverse()
+          .sort(([keyA], [keyB]) =>
+            list?.indexOf(keyA) > list?.indexOf(keyB) ? 1 : -1
+          )
+      );
+
     if (stacArray.length < 1) {
       return null;
     }
@@ -125,8 +132,24 @@ export class EOxStacInfo extends LitElement {
           `
         : nothing}
       <main>
-        ${parseEntries(this.properties).length > 0
+        ${parseEntries(this.tags).length +
+          parseEntries(this.properties).length >
+        0
           ? html`
+              <section id="tags" part="tags">
+                <ul>
+                  ${map(
+                    parseEntries(this.tags),
+                    ([, value]) => html`<slot name=${value.label.toLowerCase()}
+                      ><li>
+                        <span class="label"
+                          >${unsafeHTML(value.formatted)}</span
+                        >
+                      </li></slot
+                    >`
+                  )}
+                </ul>
+              </section>
               <section id="properties" part="properties">
                 <ul
                   class=${parseEntries(this.properties).length === 1
@@ -140,15 +163,13 @@ export class EOxStacInfo extends LitElement {
                         <li>
                           ${when(
                             parseEntries(this.properties).length > 1,
-                            () => html`
-                              <span class="label">
+                            () => html` <span class="label">
                                 ${
                                   // TODO
                                   // @ts-ignore
                                   value.label
-                                } </span
-                              >:
-                            `
+                                }</span
+                              ><span class="colon">:</span>`
                           )}
                           <span class="value">
                             ${
@@ -169,27 +190,38 @@ export class EOxStacInfo extends LitElement {
           ? html`
               <section id="featured" part="featured">
                 ${map(
-                  parseEntries(this.featured),
+                  parseEntries(this.featured).filter(([_, value]) =>
+                    value.length ? value.length > 0 : true
+                  ),
                   ([, value]) => html`
                     <details>
                       <summary>
                         <slot
                           name="featured-${value.label.toLowerCase()}-summary"
+                          class="title"
                         >
                           ${
                             // TODO
                             // @ts-ignore
                             value.label
                           }
+                          ${when(
+                            value.length,
+                            () => html`
+                              <span class="count">${value.length}</span>
+                            `
+                          )}
                         </slot>
                       </summary>
-                      <slot name="featured-${value.label.toLowerCase()}">
-                        ${unsafeHTML(
-                          // TODO
-                          // @ts-ignore
-                          value.formatted
-                        )}
-                      </slot>
+                      <div class="featured-container">
+                        <slot name="featured-${value.label.toLowerCase()}">
+                          ${unsafeHTML(
+                            // TODO
+                            // @ts-ignore
+                            value.formatted
+                          )}
+                        </slot>
+                      </div>
                     </details>
                   `
                 )}
@@ -213,15 +245,13 @@ export class EOxStacInfo extends LitElement {
                 ${when(
                   key === "sci:citation",
                   () => html`
-                    <div>
-                      <button
-                        class="copy icon-text"
-                        @click=${() =>
-                          navigator.clipboard.writeText(value.formatted)}
-                      >
-                        copy
-                      </button>
-                    </div>
+                    <button
+                      class="copy icon"
+                      @click=${() =>
+                        navigator.clipboard.writeText(value.formatted)}
+                    >
+                      copy
+                    </button>
                   `
                 )}
               `

--- a/elements/stacinfo/src/style.eox.ts
+++ b/elements/stacinfo/src/style.eox.ts
@@ -42,13 +42,6 @@ section#tags ul {
 section#tags li {
   list-style: none;
 }
-section#tags ul>li {
-  background: #00000033;
-  border-radius: 12px;
-  padding: 4px 8px;
-  margin: 0 4px 4px 0;
-  font-size: small;
-}
 main {
   padding-bottom: 50px;
   flex: 1;
@@ -185,6 +178,7 @@ details summary::before {
 details[open] summary::before {
   transform: rotate(90deg);
 }
+section#tags ul>li,
 .count {
   display: flex;
   justify-content: center;
@@ -196,5 +190,9 @@ details[open] summary::before {
   color: #004170;
   font-weight: 500;
   margin-left: 9px;
+}
+section#tags ul>li {
+  padding: 2px 12px;
+  margin: 0 4px 4px 0;
 }
 `;

--- a/elements/stacinfo/src/style.eox.ts
+++ b/elements/stacinfo/src/style.eox.ts
@@ -9,6 +9,9 @@ ${button}
   display: flex;
   flex-direction: column;
   min-height: 100%;
+  height: auto;
+  line-height: 1.5;
+  box-sizing: border-box;
 }
 img,
 video,
@@ -31,14 +34,88 @@ header h2 {
   font-size: 22px;
   color: var(--color-primary);
 }
+section#tags ul {
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+section#tags li {
+  list-style: none;
+}
+section#tags ul>li {
+  background: #00000033;
+  border-radius: 12px;
+  padding: 4px 8px;
+  margin: 0 4px 4px 0;
+  font-size: small;
+}
 main {
   padding-bottom: 50px;
   flex: 1;
+  font-size: small;
+}
+section#properties ul {
+  padding: 0;
+}
+section#properties > ul {
+  columns: 2;
+  -webkit-columns: 2;
+  -moz-columns: 2;
+}
+section#properties slot > li {
+  margin-bottom: 8px;
+  break-inside: avoid;
+}
+section#properties slot:not([name=description]) ul li {
+  list-style: none;
+}
+section#properties .colon {
+  margin-right: 4px;
+}
+section#properties .label {
+  font-weight: bold;
+}
+section#properties ul li,
+section#properties ul li ul {
+  display: flex;
+  flex-wrap: wrap;
+}
+section#properties ul li ul li:not(:last-child):after {
+  content: ",";
+  margin-right: 4px;
+}
+section#featured details > div {
+  padding: 10px 12px 20px;
+}
+section#featured .button-container {
+  text-align: center;
+  margin-bottom: 24px;
+}
+section#featured .button-container .button {
+  /*height: 14px;*/
+  padding: 8px;
+  margin: 8px 0;
+  height: auto;
+  text-decoration: none;
+  /*display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;*/
+}
+section#featured .button-container .button:before {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 24 24'%3E%3Ctitle%3Eopen-in-new%3C/title%3E%3Cpath d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z' /%3E%3C/svg%3E");
+}
+section#featured .button-container > div {
+  text-align: left;
+}
+section#featured .button-container > div > p {
+  margin-bottom: 0;
 }
 footer {
   background: var(--color-primary);
   color: white;
   padding: 10px 30px 20px;
+  position: relative;
 }
 footer a {
   color: white;
@@ -51,51 +128,73 @@ footer h2 {
 }
 footer .copy {
   background: none;
-  border: 2px solid #fff;
-  border-radius: 5px;
+  border: none;
+  position: absolute;
+  top: 15px;
+  right: 30px;
 }
 footer .copy:before {
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 24 24'%3E%3Ctitle%3Econtent-copy%3C/title%3E%3Cpath d='M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z' /%3E%3C/svg%3E");
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='-6 -6 36 36'%3E%3Ctitle%3Econtent-copy%3C/title%3E%3Cpath d='M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z' /%3E%3C/svg%3E");
 }
-slot[name=footer] {
-  display: flex;
-  align-items: center;
-}
-#properties ul {
-  display: flex;
-  flex-wrap: wrap;
-  list-style: none;
-  padding: 0;
-}
-#properties ul:not(.single-property) li {
-  flex-basis: 50%;
-  padding: 20px 0;
-}
-#properties li > .label {
-}
-#properties li > .value {
+dt {
   font-weight: bold;
+  text-transform: uppercase;
 }
-details {
-  border-top: 1px solid lightgrey;
-  border-bottom: 1px solid lightgrey;
-  padding: 10px 0;
+dd dt {
+  text-transform: unset;
 }
-details > summary {
-  font-weight: bold;
-}
-dl {
+dd, dt {
   margin: 0;
 }
-dd {
-  margin-left: 0;
+dt {
+  margin-top: 20px;
 }
-li ul, dd ul {
-  padding-left: 0;
-  display: initial;
-  list-style: initial;
+dd dt {
+  margin-top: 8px;
 }
-dd li, li ul li {
-  padding: 0;
+
+/* from eox-itemfilter
+TODO harmonize/refactor */
+details summary > * {
+  display: inline;
+}
+details summary {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #0002;
+  padding: .5rem 0;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.title {
+  font-size: small;
+  align-items: center;
+}
+details summary .title {
+  display: flex;
+  font-weight: 500;
+}
+details summary::before {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%230009' viewBox='0 0 24 24'%3E%3Ctitle%3Echevron-right%3C/title%3E%3Cpath d='M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z' /%3E%3C/svg%3E");
+  height: 24px;
+  width: 24px;
+}
+details[open] summary::before {
+  transform: rotate(90deg);
+}
+.count {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #00417044;
+  padding: 0 12px;
+  height: 20px;
+  border-radius: 10px;
+  color: #004170;
+  font-weight: 500;
+  margin-left: 9px;
 }
 `;

--- a/elements/stacinfo/stacinfo.stories.js
+++ b/elements/stacinfo/stacinfo.stories.js
@@ -7,17 +7,17 @@ export default {
   component: "eox-stacinfo",
   parameters: {
     componentSubtitle: "Automatically fetch & display properties of STAC files",
-    layout: "centered",
+    layout: "fullscreen",
   },
   render: (args) => html`
     <eox-stacinfo
       for=${args.for}
       .header=${args.header}
+      .tags="${args.tags}"
       .properties="${args.properties}"
       .featured=${args.featured}
       .footer=${args.footer}
       ?unstyled=${args.unstyled}
-      style="width: 400px"
     ></eox-stacinfo>
   `,
 };
@@ -29,8 +29,10 @@ export const Basic = {
   args: {
     for: `${window.location.href.split("iframe.html")[0]}/collection.json`,
     header: ["title"],
-    properties: ["osc:region", "osc:status", "osc:missions", "created"],
-    footer: ["osc:project"],
+    tags: ["tags"],
+    properties: ["satellite", "sensor", "agency", "extent"],
+    featured: ["description", "providers", "assets", "links"],
+    footer: ["sci:citation"],
   },
 };
 

--- a/elements/stacinfo/stories/public/collection.json
+++ b/elements/stacinfo/stories/public/collection.json
@@ -1,110 +1,106 @@
 {
   "type": "Collection",
-  "id": "bedrock-topography-antarctica-bedmachine",
+  "id": "ports_cars_aq",
   "stac_version": "1.0.0",
-  "description": "This data set, part of the NASA Making Earth System Data Records for Use in Research Environments (MEaSUREs) program, contains a bed topography/bathymetry map of Antarctica based on mass conservation, streamline diffusion, and other methods. The data set also includes ice thickness, surface elevation, an ice/ocean/land mask, ice thickness estimation errors, and a map showing where each method was utilized.",
+  "description": "## Ports and cars - impact on air quality \n\nThis indicator aims at assessing ports pollution levels over the time interval 2019-2020 by correlating:\n- normalized NO2 data from the TROPOMI sensor onboard Sentinel-5P satellite (daily observations)\n- Automatic Identification Systems (AIS) data from all the boats coming to the ports\n- GNSS data (TomTom) quantifying the mean daily number of cars accessing the main street to the ports\n- Anonymised cellular data (Vodafone) providing the total number of people present in the port area (2020 observations)   \n\nThis integrated analysis shows:\n- **high correlation** between NO2 levels and boat traffic\n- **low correlation** between NO2 levels and car traffic\n\nOn the indicator chart, for each day, the light/dark red-colored background indicates whether there were \nCOVID-19 restrictions or lockdown measure in place in the country where the city is located.\n",
   "links": [
     {
       "rel": "root",
       "href": "../../catalog.json",
       "type": "application/json",
-      "title": "Open Science Catalog"
+      "title": "RACE"
     },
     {
-      "rel": "via",
-      "href": "https://nsidc.org/data/nsidc-0756/versions/3",
-      "title": "Access"
-    },
-    {
-      "rel": "via",
-      "href": "https://nsidc.org/sites/default/files/documents/user-guide/nsidc-0756-v003-userguide.pdf",
-      "title": "Documentation"
-    },
-    {
-      "rel": "child",
-      "href": "https://s3.waw2-1.cloudferro.com/swift/v1/AUTH_3f7e5dd853f54cebb046a29a69f1bba6/Catalogs/4DANTARCTICA/bedrock-topography-antarctica-bedmachine/catalog.json",
+      "rel": "item",
+      "href": "./ports_cars_aq/2020/Gioia Tauro.json",
       "type": "application/json",
-      "title": "Items"
+      "id": "IT16",
+      "latlng": "38.45339,15.9024",
+      "country": "IT",
+      "city": "Gioia Tauro"
+    },
+    {
+      "rel": "item",
+      "href": "./ports_cars_aq/2020/Genoa.json",
+      "type": "application/json",
+      "id": "IT3",
+      "latlng": "44.40572,8.93364",
+      "country": "IT",
+      "city": "Genoa"
     },
     {
       "rel": "parent",
-      "href": "../catalog.json",
+      "href": "../collection.json",
       "type": "application/json",
-      "title": "Products"
-    },
-    {
-      "rel": "related",
-      "href": "../../projects/4d-antarctica/collection.json",
-      "type": "application/json",
-      "title": "Project: 4D-ANTARCTICA"
-    },
-    {
-      "rel": "related",
-      "href": "../../themes/cryosphere/catalog.json",
-      "type": "application/json",
-      "title": "Theme: Cryosphere"
-    },
-    {
-      "rel": "related",
-      "href": "../../variables/ice-depth-thickness/catalog.json",
-      "type": "application/json",
-      "title": "Variable: Ice Depth/Thickness"
-    },
-    {
-      "rel": "related",
-      "href": "../../variables/glacier-thickness-ice-sheet-thickness/catalog.json",
-      "type": "application/json",
-      "title": "Variable: Glacier Thickness/Ice Sheet Thickness"
-    },
-    {
-      "rel": "related",
-      "href": "../../eo-missions/numerical-models/catalog.json",
-      "type": "application/json",
-      "title": "EO Mission: Numerical models"
+      "title": "Air quality in ports"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/osc/v1.0.0-rc.2/schema.json"
+    "https://stac-extensions.github.io/web-map-links/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/example-links/v0.0.1/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
-  "osc:themes": ["Cryosphere"],
-  "osc:missions": ["Numerical models"],
-  "osc:project": "4D-ANTARCTICA",
-  "osc:variables": [
-    "Ice Depth/Thickness",
-    "Glacier Thickness/Ice Sheet Thickness"
-  ],
-  "osc:status": "ongoing",
-  "osc:region": "Antarctica",
-  "osc:type": "product",
-  "osc:standard_name": "bedrock-topography-antarctica-bedmachine",
-  "created": "2022-10-11T00:00:00Z",
-  "version": "3.0",
-  "sci:doi": "10.5067/FPSU0V1MWUB6",
-  "start_datetime": "1970-01-01T00:00:00Z",
-  "end_datetime": "2019-10-01T23:59:59Z",
-  "updated": "2024-03-01T10:20:42Z",
-  "title": "Bedrock topography: MEaSUREs BedMachine Antarctica v.3",
+  "subtitle": "Port Activities, sources of pollution and NO2 levels",
+  "yAxis": "Normalized NO2 concentration & Mean number of people",
+  "themes": ["economy", "air"],
+  "subcode": "C2",
+  "tags": ["Air quality", "NO2", "Ports", "Multi-sensors"],
+  "agency": ["ESA"],
+  "sensor": ["TROPOMI-Very long sensor name with a lot of width"],
+  "satellite": ["Sentinel-5P", "GNSS"],
+  "insituSources": ["AIS", "Mobile"],
+  "geoDBID": "C2",
+  "endpointtype": "GeoDB",
+  "title": "Car sources",
   "extent": {
     "spatial": {
-      "bbox": [[180.0, -53.0, -180.0, -90.0]]
+      "bbox": [[8.92364, 38.44339, 15.9124, 44.41572]]
     },
     "temporal": {
-      "interval": [["1970-01-01T00:00:00Z", "2019-10-01T23:59:59Z"]]
+      "interval": [["2020-02-01T00:00:00Z", "2020-05-01T00:00:00Z"]]
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "Ice Depth/Thickness",
-    "Cryospheric Indicators",
-    "Snow/Ice",
-    "Glaciers/Ice Sheets",
-    "Glacier Thickness/Ice Sheet Thickness",
-    "Sea Ice",
-    "theme:Cryosphere",
-    "variable:Ice Depth/Thickness",
-    "variable:Glacier Thickness/Ice Sheet Thickness",
-    "mission:Numerical models",
-    "region:Antarctica",
-    "project:4D-ANTARCTICA"
-  ]
+  "providers": [
+    {
+      "name": "e-GEOS",
+      "description": "e-GEOS is a leading international player in the Earth Observation (EO) and Geo-Spatial Information business.",
+      "url": "https://www.e-geos.it/#/"
+    },
+    {
+      "name": "ExpertLab",
+      "description": "ExpertLab - Information and Communication Systems",
+      "url": "http://www.expertlab.it/"
+    },
+    {
+      "name": "CherryData",
+      "url": "https://www.cherry-data.com/"
+    }
+  ],
+  "summaries": {
+    "cities": ["Gioia Tauro", "Genoa"],
+    "countries": ["IT"]
+  },
+  "assets": {
+    "reference_1": {
+      "href": "https://www.imo.org/en/OurWork/Safety/Pages/AIS.aspx",
+      "type": "text/html",
+      "title": "AIS data",
+      "description": "Asset description",
+      "roles": ["metadata"]
+    },
+    "reference_2": {
+      "href": "https://www.tomtom.com/products/traffic-and-travel-information/",
+      "type": "text/html",
+      "title": "TomTom data",
+      "roles": ["metadata"]
+    },
+    "reference_3": {
+      "href": "https://covidtracker.bsg.ox.ac.uk/",
+      "type": "text/html",
+      "title": "Oxford University\u2019s coronavirus government response tracker",
+      "roles": ["metadata"]
+    }
+  },
+  "sci:citation": "This is a very long citation citing a lot of long text. The lenght is purely for style-adaptation purposes. EOX et al 2024, powered by stac-fields and other libraries, all subject to different licenses."
 }

--- a/utils/styles/button.css
+++ b/utils/styles/button.css
@@ -42,6 +42,11 @@ button[disabled],
   cursor: not-allowed;
 }
 
+button.block,
+.button.block {
+  display: block;
+}
+
 button.outline,
 .button.outline {
   background: transparent;
@@ -72,6 +77,11 @@ button.icon-text,
   text-indent: 26px;
 }
 
+button.icon-text.block,
+.button.icon-text.block {
+  text-indent: 20px;
+}
+
 button.icon:before,
 button.icon-text:before,
 .button.icon:before,
@@ -79,6 +89,11 @@ button.icon-text:before,
   position: absolute;
   text-indent: 0;
   line-height: initial;
+}
+
+button.icon-text.block:before,
+.button.icon-text.block:before {
+  text-indent: -54px;
 }
 
 button.icon:before,

--- a/utils/styles/button.ts
+++ b/utils/styles/button.ts
@@ -44,6 +44,11 @@ button[disabled],
   cursor: not-allowed;
 }
 
+button.block,
+.button.block {
+  display: block;
+}
+
 button.outline,
 .button.outline {
   background: transparent;
@@ -74,11 +79,21 @@ button.icon-text,
   text-indent: 26px;
 }
 
+button.icon-text.block,
+.button.icon-text.block {
+  text-indent: 20px;
+}
+
 button.icon:before, button.icon-text:before,
 .button.icon:before, .button.icon-text:before {
   position: absolute;
   text-indent: 0;
   line-height: initial;
+}
+
+button.icon-text.block:before,
+.button.icon-text.block:before {
+  text-indent: -54px;
 }
 
 button.icon:before,


### PR DESCRIPTION
## Implemented changes

This PR adds some styling improvements to `eox-stacinfo`, especially how `ul`s and `link`s are rendered: The default style removal of `ul`s is gone but handled more on a case-by-case base. Links in `providers`, `assets` ands `links` are parsed from the `formatted` property and rendered as buttons.
Additional styling fixes have been added for `details`/`summary` rendering, harmonizing with how `eox-itemfilter` looks.
Also, a `tags` section has been introduced which allows specifying some properties as tags that are rendered in a chip-like manner.
Some things might be very opinionated and only suitable for `eodash`, but we'll iterate further.

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/26576876/f1dd1185-acfa-48f6-b8fd-f69591cfd97b)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
