### PR TITLE
fix: update internal `_jsonDefinition`

### DIFF
--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -392,6 +392,7 @@ export function updateLayer(
     layerCollection.changed();
   }
   setSyncListeners(existingLayer, newLayerDefinition);
+  existingLayer.set("_jsonDefinition", newLayerDefinition, true);
   return existingLayer;
 }
 

--- a/elements/map/test/addOrUpdateLayer.cy.ts
+++ b/elements/map/test/addOrUpdateLayer.cy.ts
@@ -20,6 +20,7 @@ describe("Map", () => {
         type: "Vector",
         properties: {
           id: "regions",
+          value: 1,
         },
         visible: true,
         opacity: 0.9,
@@ -34,13 +35,14 @@ describe("Map", () => {
       eoxMap.layers = [layerDefinition];
 
       const layer = eoxMap.getLayerById("regions");
-      expect(layer).to.exist;
-      expect(layer.getOpacity()).to.be.equal(0.9);
+      expect(layer, "add layer").to.exist;
+      expect(layer.getOpacity(), "set opacity on new layer").to.be.equal(0.9);
 
       const updatedLayerDefinition = {
         type: "Vector",
         properties: {
           id: "regions",
+          value: 2,
         },
         visible: true,
         opacity: 1,
@@ -53,7 +55,11 @@ describe("Map", () => {
       } as EoxLayer;
 
       eoxMap.addOrUpdateLayer(updatedLayerDefinition);
-      expect(layer.getOpacity()).to.be.equal(1);
+      expect(layer.getOpacity(), "update opacity").to.be.equal(1);
+      expect(
+        layer.get("_jsonDefinition").properties.value,
+        "update json definition object"
+      ).to.be.equal(2);
     });
   });
 });


### PR DESCRIPTION
This PR handles the Issue https://github.com/EOX-A/EOxElements/issues/732, where the second change was not properly detected. The problem was a bit tricky to find, but the solution quite simple, as the `_jsonDefinition`-object was simply not set correctly when updating a layer.


- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
