### PR TITLE
fix(style): improve property columns, description and link rendering

### DIFF
--- a/elements/stacinfo/src/helpers/properties.ts
+++ b/elements/stacinfo/src/helpers/properties.ts
@@ -1,4 +1,7 @@
-export const transformProperties = (properties: Array<any>) => {
+export const transformProperties = (
+  properties: Array<any>,
+  type: string = "property"
+) => {
   return properties.map(([key, property]) => {
     // Transform extent to only show temporal
     if (key === "extent") {
@@ -37,38 +40,36 @@ export const transformProperties = (properties: Array<any>) => {
 
     // Format assets to look like button
     if (key === "assets" || key === "links" || key === "providers") {
-      // console.log(property);
-      // property.formatted = `<ul>${filterLinks(property.value)
-      //   .map(
-      //     ([itemKey, itemValue]) =>
-      //       `<li>
-      //         <a target="_blank" href="${itemValue.href}"
-      //           >${itemValue.title || itemKey}</a
-      //         >${
-      //           itemValue.description
-      //             ? `<div><p>${itemValue.description}</p></div>`
-      //             : ``
-      //         }
-      //       </li>`
-      //   )
-      //   .join("")}</ul>`;
-      property.formatted = filterLinks(property.value)
-        .map(
-          ([itemKey, itemValue]) =>
-            `<div class="button-container">
-              ${
-                itemValue.description
-                  ? `<div><p>${itemValue.description}</p></div>`
-                  : ``
-              }
-              <a class="button icon-text small block" target="_blank" href="${
-                itemValue.href || itemValue.url
-              }"
-                >${itemValue.name || itemValue.title || itemKey}
-                </a>
-            </div>`
-        )
-        .join("");
+      if (type === "property") {
+        property.formatted = `<ul>${filterLinks(property.value)
+          .map(
+            ([itemKey, itemValue]) =>
+              `<li>
+                <a target="_blank" href="${itemValue.href || itemValue.url}"
+                  >${itemValue.name || itemValue.title || itemKey}</a
+                >
+              </li>`
+          )
+          .join("")}</ul>`;
+      } else if (type === "featured") {
+        property.formatted = filterLinks(property.value)
+          .map(
+            ([itemKey, itemValue]) =>
+              `<div class="button-container">
+                ${
+                  itemValue.description
+                    ? `<div><p>${itemValue.description}</p></div>`
+                    : ``
+                }
+                <a class="button icon-text small block" target="_blank" href="${
+                  itemValue.href || itemValue.url
+                }"
+                  >${itemValue.name || itemValue.title || itemKey}
+                  </a>
+              </div>`
+          )
+          .join("");
+      }
     }
 
     // Add length information to display in list

--- a/elements/stacinfo/src/main.ts
+++ b/elements/stacinfo/src/main.ts
@@ -88,7 +88,7 @@ export class EOxStacInfo extends LitElement {
   buildProperties(stacArray: Array<typeof STAC>) {
     Formatters.allowHtmlInCommonMark = this.allowHtml !== undefined;
 
-    const parseEntries = (list: Array<string>) =>
+    const parseEntries = (list: Array<string>, type: string) =>
       transformProperties(
         Object.entries(this.stacProperties)
           .filter(([key]) => {
@@ -99,7 +99,8 @@ export class EOxStacInfo extends LitElement {
           .reverse()
           .sort(([keyA], [keyB]) =>
             list?.indexOf(keyA) > list?.indexOf(keyB) ? 1 : -1
-          )
+          ),
+        type
       );
 
     if (stacArray.length < 1) {
@@ -196,11 +197,11 @@ export class EOxStacInfo extends LitElement {
               </section>
             `
           : nothing}
-        ${parseEntries(this.featured).length > 0
+        ${parseEntries(this.featured, "featured").length > 0
           ? html`
               <section id="featured" part="featured">
                 ${map(
-                  parseEntries(this.featured).filter(([_, value]) =>
+                  parseEntries(this.featured, "featured").filter(([_, value]) =>
                     value.length !== undefined ? value.length > 0 : true
                   ),
                   ([, value]) => html`

--- a/elements/stacinfo/src/main.ts
+++ b/elements/stacinfo/src/main.ts
@@ -172,11 +172,21 @@ export class EOxStacInfo extends LitElement {
                               ><span class="colon">:</span>`
                           )}
                           <span class="value">
-                            ${
-                              // TODO
-                              // @ts-ignore
-                              unsafeHTML(value.formatted)
-                            }
+                            ${when(
+                              value.label.toLowerCase() === "description",
+                              () => html`
+                                <eox-stacinfo-shadow
+                                  .content=${value.formatted}
+                                >
+                                </eox-stacinfo-shadow>
+                              `,
+                              () =>
+                                html`${unsafeHTML(
+                                  // TODO
+                                  // @ts-ignore
+                                  value.formatted
+                                )}`
+                            )}
                           </span>
                         </li>
                       </slot>
@@ -215,10 +225,18 @@ export class EOxStacInfo extends LitElement {
                       </summary>
                       <div class="featured-container">
                         <slot name="featured-${value.label.toLowerCase()}">
-                          ${unsafeHTML(
-                            // TODO
-                            // @ts-ignore
-                            value.formatted
+                          ${when(
+                            value.label.toLowerCase() === "description",
+                            () => html`
+                              <eox-stacinfo-shadow .content=${value.formatted}>
+                              </eox-stacinfo-shadow>
+                            `,
+                            () =>
+                              html`${unsafeHTML(
+                                // TODO
+                                // @ts-ignore
+                                value.formatted
+                              )}`
                           )}
                         </slot>
                       </div>
@@ -281,5 +299,21 @@ export class EOxStacInfo extends LitElement {
     if (_changedProperties.has("for")) {
       this.fetchStac(this.for);
     }
+  }
+}
+
+/**
+ * For some property renderings, we want a separate
+ * custom element with its own shadow root, so that
+ * the general styling does not affect it (except globals
+ * like fonts, variables etc.)
+ */
+@customElement("eox-stacinfo-shadow")
+export class EOxStacInfoShadow extends LitElement {
+  @property()
+  content: null;
+
+  render() {
+    return html`<div>${unsafeHTML(this.content)}</div>`;
   }
 }

--- a/elements/stacinfo/src/main.ts
+++ b/elements/stacinfo/src/main.ts
@@ -88,7 +88,7 @@ export class EOxStacInfo extends LitElement {
   buildProperties(stacArray: Array<typeof STAC>) {
     Formatters.allowHtmlInCommonMark = this.allowHtml !== undefined;
 
-    const parseEntries = (list: Array<string>, type: string) =>
+    const parseEntries = (list: Array<string>, type?: string) =>
       transformProperties(
         Object.entries(this.stacProperties)
           .filter(([key]) => {

--- a/elements/stacinfo/src/style.eox.ts
+++ b/elements/stacinfo/src/style.eox.ts
@@ -50,7 +50,7 @@ main {
 section#properties ul {
   padding: 0;
 }
-section#properties > ul {
+section#properties > ul:not(.single-property) {
   columns: 2;
   -webkit-columns: 2;
   -moz-columns: 2;

--- a/elements/stacinfo/test/general.cy.js
+++ b/elements/stacinfo/test/general.cy.js
@@ -93,7 +93,11 @@ describe("Stacinfo", () => {
     cy.get("eox-stacinfo")
       .shadow()
       .within(() => {
-        cy.get("#properties button").should("exist");
+        cy.get("#properties eox-stacinfo-shadow")
+          .shadow()
+          .within(() => {
+            cy.get("button").should("exist");
+          });
       });
   });
 });


### PR DESCRIPTION
## Implemented changes

This PR introduces some more styling fixes:
- single properties are now correctly rendered with only one column
- `description` is rendered in dedicated custom element with shadow root, avoiding CSS bleed
- `links`, `providers`, `assets` are rendered differently when used inside properties (`a` tags) or featured (`buttons`) 

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/26576876/2b5dc3a1-b852-4002-abc5-43300aa2d2a1)
![image](https://github.com/EOX-A/EOxElements/assets/26576876/0312c901-d6fd-48f8-b435-159cfa16312e)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
