### PR TITLE
Feat: Sticky navigation after hero

### DIFF
--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -1,5 +1,5 @@
 export { default as loadMarkdownURL } from "./load-markdown-url.js";
-export { renderHtmlString } from "./render-html-string";
+export { renderHtmlString, parseNav } from "./render-html-string";
 export {
   scrollAnchorClickEvent,
   scrollIntoView,

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -138,3 +138,34 @@ export function convertAttributeValueBasedOnItsType(
 
   return convertedValue;
 }
+
+/**
+ * Parse Nav and generate a new Element Node
+ *
+ * @param {Array<Element>} html - List of html elements
+ * @param {Array} nav - List of nav elements
+ * @returns {Element[]} An array of processed DOM nodes after adding navigation.
+ */
+export function parseNav(html, nav) {
+  const parser = new DOMParser();
+  let navIndex = 0;
+
+  const navHtml = `
+    <div class="navigation">
+      <div class="container">
+        <ul>
+          ${nav.map(
+            ({ id, title }) =>
+              `<li class="nav-${id}"><a href="#${id}">${title}</a></li>`
+          )}
+        </ul>
+      </div>
+    </div>
+  `;
+  const navDOM = parser.parseFromString(navHtml, "text/html").body.firstChild;
+
+  if (html[0].classList.contains("hero")) navIndex = 1;
+  html.splice(navIndex, 0, navDOM);
+
+  return html;
+}

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -154,10 +154,12 @@ export function parseNav(html, nav) {
     <div class="navigation">
       <div class="container">
         <ul>
-          ${nav.map(
-            ({ id, title }) =>
-              `<li class="nav-${id}"><a href="#${id}">${title}</a></li>`
-          )}
+          ${nav
+            .map(
+              ({ id, title }) =>
+                `<li class="nav-${id}"><a href="#${id}">${title}</a></li>`
+            )
+            .join("")}
         </ul>
       </div>
     </div>

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -7,6 +7,7 @@ import {
   scrollAnchorClickEvent,
   scrollIntoView,
   renderHtmlString,
+  parseNav,
 } from "./helpers";
 import mainStyle from "../../../utils/styles/dist/main.style";
 import DOMPurify from "isomorphic-dompurify";
@@ -126,6 +127,9 @@ export class EOxStoryTelling extends LitElement {
 
       if (this.showNav) this.nav = md.nav;
 
+      if (this.showNav && this.nav.length && this.#html.length)
+        this.#html = parseNav(this.#html, this.nav);
+
       if (this.showEditor) {
         const parent = this.shadowRoot || this;
         const editorDOM = parent.querySelector("eox-storytelling-editor");
@@ -194,23 +198,6 @@ export class EOxStoryTelling extends LitElement {
       </style>
 
       <div class="story-telling">
-        ${when(
-          this.showNav && this.nav.length,
-          () => html`
-            <div class="navigation">
-              <div class="container">
-                <ul>
-                  ${this.nav.map(
-                    ({ id, title }) =>
-                      html`<li class="nav-${id}">
-                        <a href="#${id}">${title}</a>
-                      </li>`
-                  )}
-                </ul>
-              </div>
-            </div>
-          `
-        )}
         <div>${when(this.#html, () => html`${this.#html}`)}</div>
         ${when(
           this.showEditor,

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -12,3 +12,4 @@ export { default as MarkdownMapSectionStory } from "./markdown-map-section"; // 
 export { default as MarkdownMapTourStory } from "./markdown-map-tour"; // StoryTelling with map tour
 export { default as MarkdownEditorStory } from "./markdown-editor"; // StoryTelling with editor
 export { default as MarkdownHeroStory } from "./markdown-hero"; // StoryTelling with Hero Section
+export { default as MarkdownHeroWithNavStory } from "./markdown-hero-with-nav"; // StoryTelling with Hero Section with Nav

--- a/elements/storytelling/stories/markdown-hero-with-nav.js
+++ b/elements/storytelling/stories/markdown-hero-with-nav.js
@@ -1,0 +1,42 @@
+/**
+ * Renders storytelling with nav below hero section
+ */
+import { html } from "lit";
+import "../src/main.js";
+
+export const MarkdownHeroWithNav = {
+  args: {
+    markdown: `
+# Hero Bg Image <!--{ as="img" mode="hero" src="https://www.gstatic.com/prettyearth/assets/full/14617.jpg" }-->
+### by EOX <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->
+
+## EarthCODE Portal <!--{as="esa-main-section" title="EarthCODE Portal"}-->
+### EarthCODE
+This portal shall provide an entry point to the collaborative development tools and resources, as well as access to community guidelines and open documentation to help researchers adopt FAIR principles in their scientific practice.
+
+Through community and capacity building focused on Open Science, the activity shall promote a trusted collaborative experience of conducting Earth system science.
+
+Just like the European Space Agency (ESA), we advocate for and actively support Open Science, as we believe in the significance of collaborative efforts in advancing scientific knowledge and addressing global challenges. We acknowledge the transformative power of Open Science in driving interdisciplinary collaboration, facilitating reproducibility, and ultimately contributing to a more sustainable and resilient future for our world.
+
+The OSC aims to advance science initiatives and projects by providing a platform to store catalog records for science themes, variables, projects, products, and contributing (EO) missions. This system allows users an easy way to browse, search, and access metadata information associated with these records. This blog post provides some technical details about the OSC.
+
+## OSC <!--{as="div" style="width: 100%;"}-->
+![](https://eox.at/images/osc-title.jpg) <!--{style="min-width: 40vw;"}-->
+
+The contents of the catalog is actually managed by a public GitHub repository, allowing for a full history of changes to the contents of records. Additionally changes to the repository are done using the mechanism of a Pull Request. Users can suggest changes, which can be revised by the data administrators of the Open Science Catalog, and run through rigorous checks using GitHub actions, which perform checks on the validity and the integrity of the changes. When a Pull Request is accepted, the changes are incorporated in the main branch of the catalog, triggering a new release of the static catalog, which is subsequently merged into the resource catalog.
+
+## FutureEO <!--{as="esa-main-section"}-->
+### FutureEO
+For all components (technology, community, partnerships), the Reproducible Open Science Environment can rely on elements developed as part of other FutureEO activities and on readily available operational services provided by Member States' public and industrial facilities, including interoperable building blocks, platform services, Open Science capacity building, scientific communication, and international cooperation.
+`,
+  },
+  render: (args) => html`
+    <eox-storytelling
+      id="markdown-hero-with-nav"
+      show-nav
+      markdown=${args.markdown}
+    ></eox-storytelling>
+  `,
+};
+
+export default MarkdownHeroWithNav;

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -15,6 +15,7 @@ import {
   MarkdownMapTourStory,
   MarkdownEditorStory,
   MarkdownHeroStory,
+  MarkdownHeroWithNavStory,
 } from "./index";
 import { html } from "lit";
 
@@ -95,3 +96,8 @@ export const MarkdownWithEditor = MarkdownEditorStory;
  * StoryTelling with Hero Image and Video
  */
 export const MarkdownWithHeroSection = MarkdownHeroStory;
+
+/**
+ * StoryTelling with Hero and Nav
+ */
+export const MarkdownHeroWithNav = MarkdownHeroWithNavStory;

--- a/elements/storytelling/test/cases/load-hero-section.js
+++ b/elements/storytelling/test/cases/load-hero-section.js
@@ -11,11 +11,14 @@ const loadHeroSectionTest = () => {
   const testText = `
 # Foo <!--{ as="img" mode="hero" src="${img}" }-->
 #### Bar
+
+## Hello World
+Section 1 Content Here
 `;
 
-  cy.mount(`<eox-storytelling markdown='${testText}'></eox-storytelling>`).as(
-    storyTelling
-  );
+  cy.mount(
+    `<eox-storytelling show-nav markdown='${testText}'></eox-storytelling>`
+  ).as(storyTelling);
 
   cy.get(storyTelling)
     .shadow()
@@ -24,6 +27,11 @@ const loadHeroSectionTest = () => {
       cy.get(".section-wrap.hero img").should("have.attr", "src", img);
       cy.get(".section-wrap.hero h1").should("have.text", "Foo");
       cy.get(".section-wrap.hero h4").should("have.text", "Bar");
+
+      cy.get(".story-telling div > :nth-child(1)").filter('[class*="hero"]');
+      cy.get(".story-telling div > :nth-child(2)").filter(
+        '[class*="navigation"]'
+      );
     });
 };
 


### PR DESCRIPTION
## Implemented changes

- If the first section is a `hero` section along with `show-nav` the navigation will stick below the `hero` section.
- If the first `hero` is after any other section, the navigation will be at top. The first `section` should be `hero`, then only it will work.
- If there are `multiple` hero sections then also first `hero` will be taken into account. 

```markdown
# Foo <!--{ as="img" mode="hero" src="image-url" }-->
#### Foo description
  
## Bar
Bar description
```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/EOX-A/EOxElements/assets/10809211/e29a1660-23f9-4a1e-a08d-17a8dfb17d2f


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
