### PR TITLE
Fix: StoryTelling styling and highlight active nav item

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -1,6 +1,7 @@
 import { EVENT_REQ_MODES } from "../enums/index.js";
 
-let observers = [];
+let sectionObservers = [];
+let stepSectionObservers = [];
 
 /**
  * Converts an HTML string into DOM nodes and processes each node.
@@ -14,20 +15,55 @@ export function renderHtmlString(htmlString, sections, that) {
   // Parse the HTML string into a document
   const parser = new DOMParser();
   const doc = parser.parseFromString(htmlString, "text/html");
+  const parent = that.shadowRoot || that;
 
-  // Disconnecting old observers to create new observer
-  observers.forEach((observer) => observer?.disconnect());
-  observers = [];
+  const isNavigation = !!(that.showNav && that.nav.length);
 
-  // Creating new scroll observer
+  // Disconnecting old observers to create new empty Observers
+  sectionObservers.forEach((observer) => observer?.disconnect());
+  sectionObservers = [];
+  stepSectionObservers.forEach((observer) => observer?.disconnect());
+  stepSectionObservers = [];
+
+  // Creating new Section Observer for navigation and section intersection
+  if (isNavigation) {
+    that.nav.forEach((section) => {
+      const sectionObserver = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            const intersecting = entry.isIntersecting;
+            const id = entry.target.getAttribute("id");
+            if (intersecting) {
+              parent.querySelectorAll(".navigation li").forEach((nav) => {
+                if (nav.classList.contains(`nav-${id}`))
+                  nav.classList.add("active");
+                else nav.classList.remove("active");
+              });
+            }
+          });
+        },
+        { threshold: 1 }
+      );
+
+      setTimeout(() => {
+        const sectionDom = parent.querySelector(`#${section.id}`);
+        if (sectionDom) {
+          sectionObserver.observe(sectionDom);
+          sectionObservers.push(sectionObserver);
+        }
+      }, 200);
+    });
+  }
+
+  // Creating new scroll Step Section Observer
   Object.keys(sections).forEach((sectionId) => {
     const section = sections[sectionId];
+
     if (EVENT_REQ_MODES.includes(section.mode) && section.steps) {
-      const parent = that.shadowRoot || that;
       const elementSelector = `${section.as}#${section.id}`;
 
-      // Creating new scroll observer and assign new value for attribute of element
-      const observer = new IntersectionObserver((entries) => {
+      // Creating new scroll Step Section Observer and assign new value for attribute of element
+      const stepSectionObserver = new IntersectionObserver((entries) => {
         entries.forEach((entry) => {
           const intersecting = entry.isIntersecting;
           const index = Number(entry.target.getAttribute("key"));
@@ -37,7 +73,7 @@ export function renderHtmlString(htmlString, sections, that) {
         });
       });
 
-      // Create scroll observer with a small delay
+      // Create scroll Step Section Observer with a small delay
       setTimeout(() => {
         const contentParent = parent.querySelector(`#${sectionId}`);
         if (!contentParent) return;
@@ -48,10 +84,10 @@ export function renderHtmlString(htmlString, sections, that) {
 
         contentChildren.forEach((dom, key) => {
           dom.setAttribute("key", `${key}`);
-          observer.observe(dom);
+          stepSectionObserver.observe(dom);
         });
 
-        observers.push(observer);
+        stepSectionObservers.push(stepSectionObserver);
 
         assignNewAttrValue(section, 0, elementSelector, parent);
       }, 100);
@@ -144,13 +180,17 @@ export function convertAttributeValueBasedOnItsType(
  *
  * @param {Array<Element>} html - List of html elements
  * @param {Array} nav - List of nav elements
+ * @param {Boolean} showNav - Whether to show nav or not
  * @returns {Element[]} An array of processed DOM nodes after adding navigation.
  */
-export function parseNav(html, nav) {
+export function parseNav(html, nav, showNav) {
   const parser = new DOMParser();
-  let navIndex = 0;
+  let navIndex = -1;
 
-  const navHtml = `
+  if (showNav && nav.length && html.length) {
+    navIndex = 0;
+
+    const navHtml = `
     <div class="navigation">
       <div class="container">
         <ul>
@@ -164,10 +204,13 @@ export function parseNav(html, nav) {
       </div>
     </div>
   `;
-  const navDOM = parser.parseFromString(navHtml, "text/html").body.firstChild;
+    const navDOM = parser.parseFromString(navHtml, "text/html").body.firstChild;
 
-  if (html[0].classList.contains("hero")) navIndex = 1;
-  html.splice(navIndex, 0, navDOM);
+    if (html[0].classList.contains("hero")) navIndex = 1;
+    html.splice(navIndex, 0, navDOM);
+  }
+
+  html[navIndex + 1].classList.add("section-start");
 
   return html;
 }

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -210,7 +210,7 @@ export function parseNav(html, nav, showNav) {
     html.splice(navIndex, 0, navDOM);
   }
 
-  html[navIndex + 1].classList.add("section-start");
+  if (html.length) html[navIndex + 1].classList.add("section-start");
 
   return html;
 }

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -112,6 +112,14 @@ export class EOxStoryTelling extends LitElement {
     // Check if 'markdown' property itself has changed and generate sanitized html
     if (changedProperties.has("markdown")) {
       const unsafeHTML = md.render(this.markdown);
+
+      this.#config = md.config;
+
+      if (typeof this.#config.nav === "boolean")
+        this.showNav = this.#config.nav;
+
+      if (this.showNav) this.nav = md.nav;
+
       this.#html = renderHtmlString(
         DOMPurify.sanitize(unsafeHTML, {
           CUSTOM_ELEMENT_HANDLING: getCustomEleHandling(md),
@@ -120,15 +128,8 @@ export class EOxStoryTelling extends LitElement {
         md.sections,
         this
       );
-      this.#config = md.config;
 
-      if (typeof this.#config.nav === "boolean")
-        this.showNav = this.#config.nav;
-
-      if (this.showNav) this.nav = md.nav;
-
-      if (this.showNav && this.nav.length && this.#html.length)
-        this.#html = parseNav(this.#html, this.nav);
+      this.#html = parseNav(this.#html, this.nav, this.showNav);
 
       if (this.showEditor) {
         const parent = this.shadowRoot || this;

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -58,7 +58,7 @@ const styleEOX = `
     background: black;
   }
   .navigation li.active a {
-    font-weight: 900;
+    font-weight: 700;
   }
   .navigation li.active a:after {
     background: black;
@@ -122,7 +122,16 @@ const styleEOX = `
   }
   .story-telling .container {
     width: 90%;
-    --block-spacing-vertical: 1rem;
+    --block-spacing-vertical: 2rem;
+  }
+  .story-telling .section-wrap.container.section-start {
+    padding-top: 4rem;
+  }
+  .story-telling p:last-child {
+    margin-bottom: 0;
+  }
+  .story-telling .section-wrap.container:last-child {
+    padding-bottom: 4rem; 
   }
   .story-telling .tour {
     width: 100%;


### PR DESCRIPTION
## Implemented changes
- Increased padding between sections to `2rem` (`3rem` was looking to much white space)
- Increased first and last container section to `4rem` (Also it will go well with navigation)
- Added highlight current active nav (used `IntersectionObserver()`)

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/EOX-A/EOxElements/assets/10809211/0a94e107-161d-44ce-b06d-09aed84bcf7c




## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
