### PR TITLE
Feat: Dedicated fallback mode

### DIFF
--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -193,12 +193,15 @@ function parseFallBack(tokens, nextInlineToken) {
     if (newLineRegex.test(nextInlineToken.content)) {
       const nextLineTextArr = nextInlineToken.content.split(newLineRegex);
 
+      // Remove fallback content and image
       nextLineTextArr.shift();
       nextInlineToken.content = nextLineTextArr.join(/\n/);
 
+      // Remove fallback title from children array
       if (nextInlineToken.children[0].type === "text")
         nextInlineToken.children.shift();
 
+      // Remove fallback image from children array
       nextInlineToken.children.shift();
     } else shouldContinue = true;
   }

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -180,7 +180,7 @@ function isOpener(type) {
  *
  * @param {Array<Object>} tokens - List of markdown tokens
  * @param {Object} nextInlineToken - Next inline token
- * @return {{ shouldContinue: Boolean }} - Final list of updated states
+ * @return {{ shouldContinue: Boolean }} - Status to continue to next opening token or not
  */
 function parseFallBack(tokens, nextInlineToken) {
   const newLineRegex = /\r\n|\r|\n/;

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -192,8 +192,13 @@ function parseFallBack(tokens, nextInlineToken) {
     // Check if any next line content present if true then remove fallback image from rendering
     if (newLineRegex.test(nextInlineToken.content)) {
       const nextLineTextArr = nextInlineToken.content.split(newLineRegex);
+
       nextLineTextArr.shift();
       nextInlineToken.content = nextLineTextArr.join(/\n/);
+
+      if (nextInlineToken.children[0].type === "text")
+        nextInlineToken.children.shift();
+
       nextInlineToken.children.shift();
     } else shouldContinue = true;
   }

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -49,7 +49,7 @@ function curlyAttrs(state) {
       const { shouldContinue } = parseFallBack(tokens, tokens[i + 1]);
       if (shouldContinue) {
         i = i + 2;
-        continue; // continuing with next opening token if just fallback mode is present
+        continue; // continuing with the next opening token if just fallback mode is present
       }
     }
 

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -13,3 +13,4 @@ export { default as MarkdownMapTourStory } from "./markdown-map-tour"; // StoryT
 export { default as MarkdownEditorStory } from "./markdown-editor"; // StoryTelling with editor
 export { default as MarkdownHeroStory } from "./markdown-hero"; // StoryTelling with Hero Section
 export { default as MarkdownHeroWithNavStory } from "./markdown-hero-with-nav"; // StoryTelling with Hero Section with Nav
+export { default as MarkdownFallbackModeStory } from "./markdown-fallback"; // StoryTelling with hidden fallback image

--- a/elements/storytelling/stories/markdown-fallback.js
+++ b/elements/storytelling/stories/markdown-fallback.js
@@ -11,8 +11,8 @@ export const MarkdownFallbackMode = {
 Above fallback image is hidden and can only be visible in a Github markdown renderer.
 
 ## Section 2
-![](https://www.gstatic.com/prettyearth/assets/full/14617.jpg) <!--{ mode="fallback" }-->
-Above fallback image is hidden and can only be visible in a Github markdown renderer.
+This is section 2 fallback image ![](https://www.gstatic.com/prettyearth/assets/full/14617.jpg) <!--{ mode="fallback" }-->
+Above fallback title/image is hidden and can only be visible in a Github markdown renderer.
 `,
   },
   render: (args) => html`

--- a/elements/storytelling/stories/markdown-fallback.js
+++ b/elements/storytelling/stories/markdown-fallback.js
@@ -1,0 +1,26 @@
+/**
+ * Renders storytelling with hidden fallback image
+ */
+import { html } from "lit";
+
+export const MarkdownFallbackMode = {
+  args: {
+    markdown: `
+## Section 1
+![](https://www.gstatic.com/prettyearth/assets/full/14617.jpg) <!--{ mode="fallback" }-->
+Above fallback image is hidden and can only be visible in a Github markdown renderer.
+
+## Section 2
+![](https://www.gstatic.com/prettyearth/assets/full/14617.jpg) <!--{ mode="fallback" }-->
+Above fallback image is hidden and can only be visible in a Github markdown renderer.
+`,
+  },
+  render: (args) => html`
+    <eox-storytelling
+      id="markdown-fallback"
+      markdown=${args.markdown}
+    ></eox-storytelling>
+  `,
+};
+
+export default MarkdownFallbackMode;

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -16,6 +16,7 @@ import {
   MarkdownEditorStory,
   MarkdownHeroStory,
   MarkdownHeroWithNavStory,
+  MarkdownFallbackModeStory,
 } from "./index";
 import { html } from "lit";
 
@@ -101,3 +102,8 @@ export const MarkdownWithHeroSection = MarkdownHeroStory;
  * StoryTelling with Hero and Nav
  */
 export const MarkdownHeroWithNav = MarkdownHeroWithNavStory;
+
+/**
+ * StoryTelling with hidden fallback mode
+ */
+export const MarkdownFallbackMode = MarkdownFallbackModeStory;


### PR DESCRIPTION
## Implemented changes
- Added `fallback` mode so that non-renderable components can have a placeholder while writing markdowns in Github. 
  ```markdown
  ## Section 1
  View on StoryTelling ![](fallback image) <!--{ mode="fallback" }-->
  Description Here
  ```
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
| Github View | StoryTelling View |
| -------- | -------- |
| <img src="https://github.com/EOX-A/EOxElements/assets/10809211/4b0cca47-900e-47e7-ad0f-345cdfbe6e53" />     | <img src="https://github.com/EOX-A/EOxElements/assets/10809211/3090d4cd-a706-4ed0-aa32-ed26892a59c1" />     |


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
