### PR TITLE
Fix: Change scroll logic from `threshold` to `rootMargin`

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -42,7 +42,7 @@ export function renderHtmlString(htmlString, sections, that) {
             }
           });
         },
-        { threshold: 1 }
+        { rootMargin: "-50% 0px" }
       );
 
       setTimeout(() => {


### PR DESCRIPTION
## Implemented changes
- Threshold of `IntersectionObserver` acting weird and not able to trigger scroll change while intersecting the threshold. So converted  `Threshold` to `rootMargin` 

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos


https://github.com/EOX-A/EOxElements/assets/10809211/b3b76519-afe4-4fa5-9849-3ac24c41092d



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
