### PR TITLE
fix: don't replace image src links

### DIFF
--- a/elements/stacinfo/src/helpers/properties.ts
+++ b/elements/stacinfo/src/helpers/properties.ts
@@ -22,7 +22,7 @@ export const transformProperties = (
 
     // Replace all links (that haven't been converted yet)
     property.formatted = property.formatted.replaceAll(
-      /(?<!href=")(http|https|ftp):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])/gi,
+      /(?<!href="|src=")(http|https|ftp):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])/gi,
       (url: string) => {
         return `<a target="_blank" href="${url}">${url}</a>`;
       }


### PR DESCRIPTION
## Implemented changes

This PR fixes https://github.com/EOX-A/EOxElements/issues/853. The negative lookahead in the regex was only looking for `href="`, but now has been extended to also ignore links preceded by `src="`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
