### PR TITLE
fix: apply max-width to img, videos and iframes inside shadow element

### DIFF
--- a/elements/stacinfo/src/main.ts
+++ b/elements/stacinfo/src/main.ts
@@ -315,6 +315,13 @@ export class EOxStacInfoShadow extends LitElement {
   content: null;
 
   render() {
-    return html`<div>${unsafeHTML(this.content)}</div>`;
+    return html`<style>
+        img,
+        video,
+        iframe {
+          max-width: 100%;
+        }
+      </style>
+      <div>${unsafeHTML(this.content)}</div>`;
   }
 }


### PR DESCRIPTION
## Implemented changes

This PR fixes https://github.com/EOX-A/EOxElements/issues/854 by introducing the max-width style rule also to the shadow element used for the description.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
