### PR TITLE
Storytelling/feature/lighbox alternative

### DIFF
--- a/elements/storytelling/package.json
+++ b/elements/storytelling/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@sindresorhus/slugify": "^2.2.1",
+    "glightbox": "^3.3.0",
     "isomorphic-dompurify": "^2.4.0",
     "js-yaml": "^4.1.0",
     "lit": "^3.0.2",

--- a/elements/storytelling/src/helpers/misc.js
+++ b/elements/storytelling/src/helpers/misc.js
@@ -47,7 +47,7 @@ export function getCustomEleHandling(md) {
 /**
  * Add lightbox external library CSS
  */
-export function addLightBoxScript(element) {
+export function addLightBoxScript() {
   const style = document.createElement("style");
   style.innerHTML = `
       @import url("https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css");

--- a/elements/storytelling/src/helpers/misc.js
+++ b/elements/storytelling/src/helpers/misc.js
@@ -45,14 +45,12 @@ export function getCustomEleHandling(md) {
 }
 
 /**
- * Add lightbox external library script
- *
- * @param element - the lit element instance
+ * Add lightbox external library CSS
  */
 export function addLightBoxScript(element) {
-  const script = document.createElement("script");
-  script.src =
-    "https://cdnjs.cloudflare.com/ajax/libs/fslightbox/3.0.9/index.min.js";
-
-  element.renderRoot.appendChild(script);
+  const style = document.createElement("style");
+  style.innerHTML = `
+      @import url("https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css");
+    `;
+  document.body.appendChild(style);
 }

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -1,4 +1,5 @@
 import { EVENT_REQ_MODES } from "../enums/index.js";
+import GLightbox from "glightbox";
 
 let sectionObservers = [];
 let stepSectionObservers = [];
@@ -95,9 +96,7 @@ export function renderHtmlString(htmlString, sections, that) {
   });
 
   // Process child nodes of the document body
-  return Array.from(doc.body.childNodes).map((node) =>
-    processNode(node, that.noShadow)
-  );
+  return Array.from(doc.body.childNodes).map(processNode);
 }
 
 /**
@@ -120,10 +119,9 @@ function assignNewAttrValue(section, index, elementSelector, parent) {
  * Processes a DOM node by potentially modifying its attributes value based on it's datatype
  *
  * @param {Element} node - The DOM node to process.
- * @param {Boolean} noShadow - noShadow state
  * @returns {Element} The processed DOM node.
  */
-function processNode(node, noShadow) {
+function processNode(node) {
   if (
     node.nodeType === Node.ELEMENT_NODE &&
     node.classList.contains("section-custom")
@@ -143,26 +141,36 @@ function processNode(node, noShadow) {
     });
   }
 
-  if (noShadow) {
-    const images = node.querySelectorAll("img");
+  /**
+   * Lightbox setup
+   * See https://github.com/biati-digital/glightbox?tab=readme-ov-file#lightbox-options
+   */
+  if (node.querySelectorAll) {
+    // Set up empty Lightbox
+    const lightboxGallery = GLightbox({
+      autoplayVideos: true,
+    });
+    const lightboxElements = [];
 
+    const images = node.querySelectorAll("img");
     // Loop over each image
     images.forEach((img) => {
       // Check if the image is already inside a link (to avoid double wrapping)
       const mode = img.getAttribute("mode");
 
       if (img.parentNode.tagName !== "A" && mode !== "hero") {
-        const anchor = document.createElement("a");
+        img.style.cursor = "zoom-in";
+        img.addEventListener("click", () => {
+          lightboxGallery.open();
+        });
 
-        // Add the data-fslightbox attribute
-        anchor.setAttribute("data-fslightbox", true);
-        anchor.href = img.src;
-
-        // Insert the anchor in the DOM tree just before the image
-        img.parentNode.insertBefore(anchor, img);
-        anchor.appendChild(img);
+        lightboxElements.push({
+          type: "image",
+          href: img.src,
+        });
       }
     });
+    lightboxGallery.setElements(lightboxElements);
   }
 
   return node;

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -171,7 +171,7 @@ export class EOxStoryTelling extends LitElement {
   }
 
   async firstUpdated() {
-    if (this.noShadow) addLightBoxScript(this);
+    addLightBoxScript(this);
 
     // Check if this.#html is initialized, if not, wait for it
     if (this.#html === undefined) await this.waitForHtmlInitialization();

--- a/elements/storytelling/stories/markdown-lightbox.js
+++ b/elements/storytelling/stories/markdown-lightbox.js
@@ -6,7 +6,8 @@ import { html } from "lit";
 export const MarkdownLightBox = {
   args: {
     markdown: `
-  ## Satellite Data <!--{.some-comment}-->
+  ## Lightbox Images <!--{.some-comment}-->
+  Click on any image to open it in a lightbox.
   ![Image](https://i.imgur.com/GDAStfX.jpeg)<!-- {width=700} -->
   
   ## Img Section <!--{ as="img" src="https://i.imgur.com/6ldFbdn.gif" style="height:600px;" }-->
@@ -15,7 +16,6 @@ export const MarkdownLightBox = {
   render: (args) => html`
     <!-- Render eox-storytelling with attribute as comment markdown. -->
     <eox-storytelling
-      no-shadow
       id="markdown-lightbox"
       markdown=${args.markdown}
     ></eox-storytelling>

--- a/elements/storytelling/stories/markdown-lightbox.js
+++ b/elements/storytelling/stories/markdown-lightbox.js
@@ -8,7 +8,9 @@ export const MarkdownLightBox = {
     markdown: `
   ## Lightbox Images <!--{.some-comment}-->
   Click on any image to open it in a lightbox.
+
   ![Image](https://i.imgur.com/GDAStfX.jpeg)<!-- {width=700} -->
+  ![Image](https://i.imgur.com/m6A4LzQ.jpeg)<!-- {width=700} -->
   
   ## Img Section <!--{ as="img" src="https://i.imgur.com/6ldFbdn.gif" style="height:600px;" }-->
 `,

--- a/elements/storytelling/test/cases/load-lightbox.js
+++ b/elements/storytelling/test/cases/load-lightbox.js
@@ -12,15 +12,17 @@ const loadMarkdownLightBox = () => {
 ![Image](${imgURL})
   `;
 
-  cy.mount(
-    `<eox-storytelling no-shadow markdown="${testText}"></eox-storytelling>`
-  ).as(storyTelling);
+  cy.mount(`<eox-storytelling markdown="${testText}"></eox-storytelling>`).as(
+    storyTelling
+  );
 
-  cy.get(storyTelling).within(() => {
-    cy.get("img").click();
-  });
+  cy.get(storyTelling)
+    .shadow()
+    .within(() => {
+      cy.get("img").click();
+    });
 
-  cy.get("img.fslightbox-source").should("have.attr", "src", imgURL);
+  cy.get(".glightbox-container img").should("have.attr", "src", imgURL);
 };
 
 export default loadMarkdownLightBox;

--- a/package-lock.json
+++ b/package-lock.json
@@ -191,7 +191,7 @@
     },
     "elements/map": {
       "name": "@eox/map",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "lit": "^3.0.2",
         "ol": "^9.0.0",
@@ -214,7 +214,7 @@
     },
     "elements/stacinfo": {
       "name": "@eox/stacinfo",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@radiantearth/stac-fields": "^1.3.2",
         "lit": "^3.0.2"
@@ -238,6 +238,7 @@
       "version": "0.4.0",
       "dependencies": {
         "@sindresorhus/slugify": "^2.2.1",
+        "glightbox": "^3.3.0",
         "isomorphic-dompurify": "^2.4.0",
         "js-yaml": "^4.1.0",
         "lit": "^3.0.2",
@@ -8860,6 +8861,11 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "dev": true
+    },
+    "node_modules/glightbox": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/glightbox/-/glightbox-3.3.0.tgz",
+      "integrity": "sha512-SJukatHBZZ/POMOpLUQ6/dhXf/wJTDx1wZ/FwApjseXw2WrRj3Ze9DzNCFYzca0oU7RjXQhi9o02aIZ9SuCz1A=="
     },
     "node_modules/glob": {
       "version": "10.3.10",


### PR DESCRIPTION
## Implemented changes

This PR introduces GLightbox, as it allows directly passing the lightbox elements (thus makes it work inside a shadow DOM).
Known issues:
- it needs to globally load the lightbox CSS; solved with a CSS import from CDN for now with hopes of browser caching
- adding titles or descriptions to images doesn't work yet since the library doesn't find the correct item for height calculation

## Screenshots/Videos

[Screencast from 2024-04-15 20:50:15.webm](https://github.com/EOX-A/EOxElements/assets/26576876/ba24daf1-064d-49ed-96e1-3e4bc2759a53)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
