### PR TITLE
Fix: Custom section dom structure

### DIFF
--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -497,7 +497,7 @@ function parseAsSectionWrapper(finalTokens, sectionStartIndex) {
   const as = getAttr(asSectionToken.attrs, "as");
   const mode = getAttr(asSectionToken.attrs, "mode");
 
-  // Add main section wrapper is section is a custom section and mode is not present
+  // Add main section wrapper if section is a custom section and mode is not present
   if (as && !mode) {
     finalTokens.splice(sectionStartIndex + 2, 1); // Remove main section inline token
     finalTokens.slice(sectionStartIndex + 3).forEach((finalToken) => {

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -137,7 +137,10 @@ function curlyAttrs(state) {
   }
 
   // Close opened sections and step section tags if opened
-  if (sectionStart) pushClosingTag(finalTokens, sectionStartIndex, state);
+  if (sectionStart) {
+    parseAsSectionWrapper(finalTokens, sectionStartIndex);
+    pushClosingTag(finalTokens, sectionStartIndex, state);
+  }
   if (sectionSteps) pushClosingTag(finalTokens, sectionStepsIndex, state);
 
   generateCustomAttrsAndSectionMetaList(finalTokens, state.md);
@@ -327,9 +330,9 @@ function parseInlineContent(
  * @param {Array<Object>} tokens - List of markdown tokens
  * @param {Array<Object>} finalTokens - Processed final set of markdown token
  * @param {Boolean} sectionStart - Section started or not
- * @param {Boolean} sectionStartIndex - Section start index
+ * @param {Number} sectionStartIndex - Section start index
  * @param {Boolean} sectionSteps - Step Section started or not
- * @param {Boolean} sectionStepsIndex - Step Section start index
+ * @param {Number} sectionStepsIndex - Step Section start index
  * @param {{tokens: Array<Object>}} state - Token state
  * @param {Object} stack
  * @return {Object} - Final list of updated states
@@ -365,6 +368,8 @@ function parseSection(
       }
 
       const tag = finalTokens[sectionStartIndex].tag;
+      parseAsSectionWrapper(finalTokens, sectionStartIndex);
+
       finalTokens.push(addNewHTMLSection(state, tag, -1, -1, "html_close"));
       sectionStart = false;
       sectionStartIndex = -1;
@@ -400,9 +405,9 @@ function parseSection(
  * @param {Array<Object>} tokens - List of markdown tokens
  * @param {Array<Object>} finalTokens - Processed final set of markdown token
  * @param {Boolean} sectionStart - Section started or not
- * @param {Boolean} sectionStartIndex - Section start index
+ * @param {Number} sectionStartIndex - Section start index
  * @param {Boolean} sectionSteps - Step Section started or not
- * @param {Boolean} sectionStepsIndex - Step Section start index
+ * @param {Number} sectionStepsIndex - Step Section start index
  * @param {{tokens: Array<Object>}} state - Token state
  * @param {Object} stack
  * @return {Object} - Final list of updated states
@@ -478,6 +483,29 @@ function parseHeroSection(finalTokens, state, stack) {
   finalTokens.push(addNewHTMLSection(state, "h1", 1, -1, "html_close", null));
 
   return finalTokens;
+}
+
+/**
+ * Process and parse `as` section wrapper if mode is not present
+ *
+ * @param {Array<Object>} finalTokens - Processed final set of markdown token
+ * @param {Number} sectionStartIndex - Section start index
+ */
+function parseAsSectionWrapper(finalTokens, sectionStartIndex) {
+  const asSectionToken = finalTokens[sectionStartIndex + 1];
+
+  const as = getAttr(asSectionToken.attrs, "as");
+  const mode = getAttr(asSectionToken.attrs, "mode");
+
+  // Add main section wrapper is section is a custom section and mode is not present
+  if (as && !mode) {
+    finalTokens.splice(sectionStartIndex + 2, 1); // Remove main section inline token
+    finalTokens.slice(sectionStartIndex + 3).forEach((finalToken) => {
+      finalToken.level = 1; // Increase one level of each token which goes inside as child
+    });
+    finalTokens.push(finalTokens[sectionStartIndex + 2]); // Push main section closing tag towards end
+    finalTokens.splice(sectionStartIndex + 2, 1); // Removing duplicate main section's closing tag
+  }
 }
 
 /**


### PR DESCRIPTION
## Implemented Changes
- The custom section DOM was disrupted following the release of `StoryTelling` version `0.4.0` due to the introduction of the `hero section`.
- Wrapped section content, which has `as` and without a `mode` attribute, under the custom section specified by the `as` value.

### From (Wrong structure)
```markdown
<div class="section-wrap">
  <eox-main-section></eox-main-section>
  <h4>Some content</h4>
  <p>some content</p>
</div>
```

### To (Correct structure)
```html
<div class="section-wrap">
  <eox-main-section>
    <h4>Some content</h4>
    <p>some content</p>
  </eox-main-section>
</div>
```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos 
### Old > New
<img width="49%" alt="image" src="https://github.com/EOX-A/EOxElements/assets/10809211/f276d7d5-3b61-47c4-a614-594fc4343530"> <img width="49%" alt="image" src="https://github.com/EOX-A/EOxElements/assets/10809211/aaff3929-c93f-4db8-a0ae-a488a251570c">


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
