### PR TITLE
Feat: Auto save in StoryTelling

### DIFF
--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -63,6 +63,23 @@ class StoryTellingEditor extends LitElement {
     this.editor = this.renderRoot.querySelector(
       "eox-jsonform#storytelling-editor"
     );
+    setTimeout(() => {
+      const instance =
+        this.editor.editor.editors["root.Story"].simplemde_instance;
+      const that = this;
+      let timeOutId = null;
+      instance.codemirror.on("change", function () {
+        const saveEle = that.querySelector(".editor-saver");
+        saveEle.innerText = "Auto Saving...";
+        if (timeOutId) clearTimeout(timeOutId);
+
+        timeOutId = setTimeout(() => {
+          saveEle.innerText = "Saved";
+          localStorage.setItem("markdown", instance.value());
+          timeOutId = null;
+        }, 4000);
+      });
+    }, 2500);
     initEditorEvents(editorContainer, resizeHandle, this);
   }
 
@@ -116,7 +133,7 @@ class StoryTellingEditor extends LitElement {
           .value=${{ Story: this.markdown }}
         ></eox-jsonform>
         <div class="resize-handle"></div>
-        <span class="editor-saver"></span>
+        <span class="editor-saver">Saved</span>
         <div class="editor-error">
           <div class="editor-error-wrapper">
             <div class="overflow">

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -67,7 +67,7 @@ class StoryTellingEditor extends LitElement {
       const simpleMDEInstance =
         this.editor.editor.editors["root.Story"].simplemde_instance;
       generateAutoSave(this, simpleMDEInstance);
-    }, 2500);
+    }, 200);
     initEditorEvents(editorContainer, resizeHandle, this);
   }
 

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -67,7 +67,7 @@ class StoryTellingEditor extends LitElement {
       const simpleMDEInstance =
         this.editor.editor.editors["root.Story"].simplemde_instance;
       generateAutoSave(this, simpleMDEInstance);
-    }, 200);
+    }, 500);
     initEditorEvents(editorContainer, resizeHandle, this);
   }
 

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import { initEditorEvents } from "../helpers";
+import { generateAutoSave, initEditorEvents } from "../helpers";
 import { EDITOR_SCHEMA } from "../enums";
 
 // Define LitElement for the editor
@@ -64,21 +64,9 @@ class StoryTellingEditor extends LitElement {
       "eox-jsonform#storytelling-editor"
     );
     setTimeout(() => {
-      const instance =
+      const simpleMDEInstance =
         this.editor.editor.editors["root.Story"].simplemde_instance;
-      const that = this;
-      let timeOutId = null;
-      instance.codemirror.on("change", function () {
-        const saveEle = that.querySelector(".editor-saver");
-        saveEle.innerText = "Auto Saving...";
-        if (timeOutId) clearTimeout(timeOutId);
-
-        timeOutId = setTimeout(() => {
-          saveEle.innerText = "Saved";
-          localStorage.setItem("markdown", instance.value());
-          timeOutId = null;
-        }, 4000);
-      });
+      generateAutoSave(this, simpleMDEInstance);
     }, 2500);
     initEditorEvents(editorContainer, resizeHandle, this);
   }

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -67,7 +67,7 @@ class StoryTellingEditor extends LitElement {
       const simpleMDEInstance =
         this.editor.editor.editors["root.Story"].simplemde_instance;
       generateAutoSave(this, simpleMDEInstance);
-    }, 500);
+    }, 1000);
     initEditorEvents(editorContainer, resizeHandle, this);
   }
 

--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -161,3 +161,25 @@ export function exportMdFile(editor) {
   a.click();
   document.body.removeChild(a);
 }
+
+/**
+ * Generate auto save functionality when markdown changes
+ *
+ * @param {Element} StoryTellingEditor - Dom element
+ * @param {{codemirror, value}} simpleMDEInstance - Simple MDE instance
+ */
+export function generateAutoSave(StoryTellingEditor, simpleMDEInstance) {
+  let timeOutId = null;
+
+  simpleMDEInstance.codemirror.on("change", function () {
+    const saveEle = StoryTellingEditor.querySelector(".editor-saver");
+    saveEle.innerText = "Auto Saving...";
+    if (timeOutId) clearTimeout(timeOutId);
+
+    timeOutId = setTimeout(() => {
+      saveEle.innerText = "Saved";
+      localStorage.setItem("markdown", simpleMDEInstance.value());
+      timeOutId = null;
+    }, 2500);
+  });
+}

--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -263,7 +263,7 @@ export function addCustomSection(
 export function generateAutoSave(StoryTellingEditor, simpleMDEInstance) {
   let timeOutId = null;
 
-  simpleMDEInstance.codemirror.on("change", function () {
+  simpleMDEInstance?.codemirror.on("change", function () {
     const saveEle = StoryTellingEditor.querySelector(".editor-saver");
     saveEle.innerText = "Auto Saving...";
     if (timeOutId) clearTimeout(timeOutId);

--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -8,5 +8,5 @@ export {
   versionToInteger,
   checkMarkdownVersion,
 } from "./misc";
-export { default as initEditorEvents } from "./editor";
+export { default as initEditorEvents, generateAutoSave } from "./editor";
 export { validateMarkdownAttrs } from "./validator";

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -174,6 +174,15 @@ export class EOxStoryTelling extends LitElement {
   }
 
   async firstUpdated() {
+    if (this.showEditor) {
+      const prevMarkdown = localStorage.getItem("markdown");
+      if (prevMarkdown) {
+        const updatePrevMarkdown = confirm(
+          "Recover your Story from the last time you edited?"
+        );
+        if (updatePrevMarkdown) this.markdown = prevMarkdown;
+      }
+    }
     addLightBoxScript(this);
 
     // Check if this.#html is initialized, if not, wait for it

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -199,7 +199,7 @@ export class EOxStoryTelling extends LitElement {
   async firstUpdated() {
     if (this.showEditor) {
       const prevMarkdown = localStorage.getItem("markdown");
-      if (prevMarkdown) {
+      if (prevMarkdown && prevMarkdown !== this.markdown) {
         const updatePrevMarkdown = confirm(
           "Recover your Story from the last time you edited?"
         );

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -311,23 +311,12 @@ const styleEOX = `
     margin-left: 0.2rem;
   }
   .editor-saver {
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    animation: rotate 1s linear infinite;
-    display: none;
-  }
-  .editor-saver::before {
-    content: "";
-    box-sizing: border-box;
-    position: absolute;
-    inset: 0px;
-    border-radius: 50%;
-    border: 5px solid #5b5b5b85;
-    animation: spin 2s linear infinite ;
+    position: absolute;    
+    bottom: 18px;
+    left: 17px;
+    font-size: 12px;
+    color: #959694;
+    text-align: right;
   }
   @keyframes rotate {
     100% {transform: rotate(360deg)}


### PR DESCRIPTION
## Implemented changes
- Auto saving added (Triggers every 2.5 seconds after editing editor)
- Stored inside `localstorage`
- Confirm prompt to load previous markdown again or not
- Works only when `editor` is enabled

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/EOX-A/EOxElements/assets/10809211/0cedaf54-006d-455c-b669-d6096476c048

## Checklist before requesting a review


- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
