### PR TITLE
Fix: Hiding editor still shows button due to usage of opacity rather than display

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -292,7 +292,7 @@ ${slider}
     }
   }
   .editor-hide {
-    opacity: 0;
+    display: none;
   }
   .editor-error {
     display: none;


### PR DESCRIPTION
## Implemented changes
Changed CSS property for hiding editor to `display: none;` from `opacity: none;` (I don't know how this silly or funny thing happened 😅) 

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
