### PR TITLE
Fix: Repetative prompt to load saved markdown 

### DIFF
--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -7,6 +7,7 @@ class StoryTellingEditor extends LitElement {
   // Define static properties for LitElement
   static properties = {
     markdown: { attribute: "markdown", type: String },
+    storyId: { attribute: "story-id", type: String },
     isNavigation: { attribute: "markdown", type: Boolean },
   };
 
@@ -17,6 +18,11 @@ class StoryTellingEditor extends LitElement {
      * @type {String} - Markdown Content
      */
     this.markdown = "";
+
+    /**
+     * @type {String | null} - id of eox-storytelling
+     */
+    this.storyId = null;
 
     /**
      * @type {Boolean} - is navigation enabled or not
@@ -67,7 +73,7 @@ class StoryTellingEditor extends LitElement {
     setTimeout(() => {
       const simpleMDEInstance =
         this.editor.editor.editors["root.Story"].simplemde_instance;
-      generateAutoSave(this, simpleMDEInstance);
+      generateAutoSave(this, this.storyId, simpleMDEInstance);
     }, 1000);
     initEditorEvents(editorContainer, resizeHandle, this);
   }

--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -282,9 +282,14 @@ export function addCustomSection(
  * Generate auto save functionality when markdown changes
  *
  * @param {Element} StoryTellingEditor - Dom element
+ * @param {String | null} storyId - ID of story
  * @param {{codemirror, value}} simpleMDEInstance - Simple MDE instance
  */
-export function generateAutoSave(StoryTellingEditor, simpleMDEInstance) {
+export function generateAutoSave(
+  StoryTellingEditor,
+  storyId,
+  simpleMDEInstance
+) {
   let timeOutId = null;
 
   simpleMDEInstance?.codemirror.on("change", function () {
@@ -294,8 +299,48 @@ export function generateAutoSave(StoryTellingEditor, simpleMDEInstance) {
 
     timeOutId = setTimeout(() => {
       saveEle.innerText = "Saved";
-      localStorage.setItem("markdown", simpleMDEInstance.value());
+      const existingMarkdownObj = JSON.parse(
+        localStorage.getItem("markdown") || "{}"
+      );
+
+      localStorage.setItem(
+        "markdown",
+        JSON.stringify({
+          ...existingMarkdownObj,
+          [storyId || "default"]: simpleMDEInstance.value(),
+        })
+      );
       timeOutId = null;
     }, 2500);
   });
+}
+
+/**
+ * Init saved markdown if it is present
+ *
+ * @param {import("../main.js").EOxStoryTelling} EOxStoryTelling - EOxStoryTelling instance.
+ */
+export function initSavedMarkdown(EOxStoryTelling) {
+  if (EOxStoryTelling.showEditor) {
+    let existingMarkdownObj = JSON.parse(
+      localStorage.getItem("markdown") || "{}"
+    );
+    const storyId = EOxStoryTelling.id || "default";
+    const prevMarkdown = existingMarkdownObj[storyId];
+
+    // Check previous markdown exist and not similar to new one
+    if (prevMarkdown && prevMarkdown !== EOxStoryTelling.markdown) {
+      // Prompt whether to recover previous markdown
+      const updatePrevMarkdown = confirm(
+        "Recover your Story from the last time you edited?"
+      );
+
+      // update markdown if previous markdown to be recovered, otherwise just delete the previous one
+      if (updatePrevMarkdown) EOxStoryTelling.markdown = prevMarkdown;
+      else {
+        delete existingMarkdownObj[storyId];
+        localStorage.setItem("markdown", JSON.stringify(existingMarkdownObj));
+      }
+    }
+  }
 }

--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -55,11 +55,12 @@ function handleMouseMove(e, editorContainer, StoryTellingEditor) {
   if (StoryTellingEditor.dragging || StoryTellingEditor.resizing) {
     let dx = StoryTellingEditor.lastX - e.clientX;
     let dy = e.clientY - StoryTellingEditor.lastY;
-    let { width, height, left } = editorContainer.getBoundingClientRect();
+    let { width, height, left, top } = editorContainer.getBoundingClientRect();
 
     if (StoryTellingEditor.resizing) {
       editorContainer.style.width = `${width + dx}px`;
       editorContainer.style.height = `${height + dy}px`;
+      editorContainer.style.top = `${top}px`;
     }
     editorContainer.style.left = `${left - dx}px`;
 

--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -14,5 +14,6 @@ export {
   getSectionIndexes,
   generateAutoSave,
   positionEditor,
+  initSavedMarkdown,
 } from "./editor";
 export { validateMarkdownAttrs } from "./validator";

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -11,6 +11,7 @@ import {
   validateMarkdownAttrs,
   addLightBoxScript,
   addCustomSection,
+  initSavedMarkdown,
 } from "./helpers";
 import mainStyle from "../../../utils/styles/dist/main.style";
 import DOMPurify from "isomorphic-dompurify";
@@ -197,16 +198,7 @@ export class EOxStoryTelling extends LitElement {
   }
 
   async firstUpdated() {
-    if (this.showEditor) {
-      const prevMarkdown = localStorage.getItem("markdown");
-      if (prevMarkdown && prevMarkdown !== this.markdown) {
-        const updatePrevMarkdown = confirm(
-          "Recover your Story from the last time you edited?"
-        );
-        if (updatePrevMarkdown) this.markdown = prevMarkdown;
-        else localStorage.removeItem("markdown");
-      } else localStorage.removeItem("markdown");
-    }
+    initSavedMarkdown(this);
     addLightBoxScript(this);
 
     // Check if this.#html is initialized, if not, wait for it
@@ -244,6 +236,7 @@ export class EOxStoryTelling extends LitElement {
           () => html`
             <eox-storytelling-editor
               .isNavigation=${Boolean(this.showNav)}
+              .storyId=${this.id}
               @change=${(e) => {
                 if (e.detail) {
                   this.markdown = e.detail.Story;

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -204,8 +204,8 @@ export class EOxStoryTelling extends LitElement {
           "Recover your Story from the last time you edited?"
         );
         if (updatePrevMarkdown) this.markdown = prevMarkdown;
-        else localStorage.setItem("markdown", this.markdown);
-      }
+        else localStorage.removeItem("markdown");
+      } else localStorage.removeItem("markdown");
     }
     addLightBoxScript(this);
 


### PR DESCRIPTION
## Implemented Changes
- Markdown will only be saved in local storage if it has been modified either in the editor or through the "Add Section" popup.
- Markdown is saved under the `id` provided to `eox-storytelling`; otherwise, it is stored using the `default` key. This ensures that markdown is loaded only for the respective `ids`, preventing conflicts inside storytelling or even if using multiple storytellings inside an app.
- When a prompt is cancelled, the markdown associated with that particular `id` will be removed from local storage.

#### Markdown list structure inside localstorage 
```json 
{
  "default": "## Markdown for default without any id",
  "id1": "## Markdown for id storytelling 1",
  "id2": "## Markdown for id storytelling 2"
}
```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/EOX-A/EOxElements/assets/10809211/7c1a901f-9015-4d07-8c1d-b984d8144619



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
