### PR TITLE
fix: improve incorrect selection highlighting

### DIFF
--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -344,9 +344,7 @@ export class EOxItemFilter extends TemplateElement {
                   class="result-radio"
                   name="result"
                   id="${<string>item.id}"
-                  ?checked=${this.selectedResult?.[
-                    this._config.titleProperty
-                  ] === item[this._config.titleProperty] || (nothing as null)}
+                  ?checked=${this.selectedResult?.id === item.id || (nothing as null)}
                   @click=${() => {
                     this.selectedResult = item;
                     this._config.onSelect(item);

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -344,7 +344,8 @@ export class EOxItemFilter extends TemplateElement {
                   class="result-radio"
                   name="result"
                   id="${<string>item.id}"
-                  ?checked=${this.selectedResult?.id === item.id || (nothing as null)}
+                  ?checked=${this.selectedResult?.id === item.id ||
+                  (nothing as null)}
                   @click=${() => {
                     this.selectedResult = item;
                     this._config.onSelect(item);

--- a/elements/itemfilter/src/main.ts
+++ b/elements/itemfilter/src/main.ts
@@ -333,8 +333,7 @@ export class EOxItemFilter extends TemplateElement {
           (item: Item) => item.id,
           (item: Item) => html`
             <li
-              class=${this.selectedResult?.[this._config.titleProperty] ===
-              item[this._config.titleProperty]
+              class=${this.selectedResult?.id === item.id
                 ? "highlighted"
                 : (nothing as null)}
             >


### PR DESCRIPTION
## Implemented changes
As described by Lubo in #835, with certain indicators, the selection in the Item Filter renders incorrect additional highlightings at other positions than the active radio button.

This is because the comparison responsible for the highlighting only compared the titles of the items, resulting in additional highlightings for any others that had the same title. This PR changes the comparison to use the item IDs directly, which is definitely an improvement, however this does still result in collisions if an indicator happens to be present in more than a single theme – highlighting the same indicator in multiple theme dropdowns.

For Lubo, that behavior is fine, but I am a bit uncomfortable about the fact that our code generates two objects with identical ID fields. Is this possibly something to investigate, and to implement a fix for that enables properly unique IDs?


## Screenshots/Videos


https://github.com/EOX-A/EOxElements/assets/94269527/8a1551a6-a1fc-4b04-a3e0-69c63e59c8e6



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
