### PR TITLE
feat: improved standard ol map config export

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -343,7 +343,7 @@ export class EOxMap extends LitElement {
           source.urls = olsource.urls;
         } else if (olsource.constructor.name === "VectorSource") {
           source.url = olsource.getUrl();
-          source.format = olsource.getFormat().constructor.name;
+          source.format = olsource.getFormat()?.constructor.name;
         }
         // Extract possible other configuration options
         if (["TileWMS", "WMS"].includes(olsource.constructor.name)) {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -314,7 +314,7 @@ export class EOxMap extends LitElement {
   extractLayerConfig = (layerArray: Array<Layer>) => {
     const layers: Array<EoxLayer> = [];
     layerArray.map((l) => {
-      if (l.constructor.name.includes("LayerGroup")) {
+      if (["Group", "LayerGroup"].includes(l.constructor.name)) {
         layers.push({
           type: "Group",
           properties: {
@@ -331,16 +331,16 @@ export class EOxMap extends LitElement {
             id: l.get("id") ? l.get("id") : getUid(l),
           },
         };
-        // Extract source config
-        const source: any = {
-          type: <sourceType>(
-            l.getSource().constructor.name.replace("Source", "")
-          ),
-        };
         // Evaluate what other information we need to extract for different source types
         const olsource: any = l.getSource();
         // only export visible layers
         if (olsource && l.isVisible()) {
+          // Extract source config
+          const source: any = {
+            type: <sourceType>(
+              l.getSource().constructor.name.replace("Source", "")
+            ),
+          };
           if (["XYZ", "TileWMS", "WMS"].includes(olsource.constructor.name)) {
             if ("url" in olsource) {
               source.url = olsource.url;
@@ -360,9 +360,9 @@ export class EOxMap extends LitElement {
             // TODO: the getStyle function does not return the applied style as described in OL docs
             layerConfig.style = ""; // l.getStyle();
           }
+          layerConfig.source = source;
+          layers.push(layerConfig);
         }
-        layerConfig.source = source;
-        layers.push(layerConfig);
       }
     });
     return layers;

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -339,20 +339,27 @@ export class EOxMap extends LitElement {
         };
         // Evaluate what other information we need to extract for different source types
         const olsource: any = l.getSource();
-        if (["XYZ", "TileWMS", "WMS"].includes(olsource.constructor.name)) {
-          source.urls = olsource.urls;
-        } else if (olsource.constructor.name === "VectorSource") {
-          source.url = olsource.getUrl();
-          source.format = olsource.getFormat()?.constructor.name;
-        }
-        // Extract possible other configuration options
-        if (["TileWMS", "WMS"].includes(olsource.constructor.name)) {
-          source.params = olsource.getParams();
-          source.serverType = olsource.serverType_;
-        }
-        if (olsource.constructor.name === "VectorSource") {
-          // TODO: the getStyle function does not return the applied style as described in OL docs
-          layerConfig.style = ""; // l.getStyle();
+        // only export visible layers
+        if (olsource && l.isVisible()) {
+          if (["XYZ", "TileWMS", "WMS"].includes(olsource.constructor.name)) {
+            if ("url" in olsource) {
+              source.url = olsource.url;
+            } else if ("urls" in olsource) {
+              source.urls = olsource.urls;
+            }
+          } else if (olsource.constructor.name === "VectorSource") {
+            source.url = olsource.getUrl();
+            source.format = olsource.getFormat()?.constructor.name;
+          }
+          // Extract possible other configuration options
+          if (["TileWMS", "WMS"].includes(olsource.constructor.name)) {
+            source.params = olsource.getParams();
+            source.serverType = olsource.serverType_;
+          }
+          if (olsource.constructor.name === "VectorSource") {
+            // TODO: the getStyle function does not return the applied style as described in OL docs
+            layerConfig.style = ""; // l.getStyle();
+          }
         }
         layerConfig.source = source;
         layers.push(layerConfig);
@@ -383,7 +390,7 @@ export class EOxMap extends LitElement {
         layers,
         view,
         controls,
-        preventScroll: false,
+        preventScroll: true,
       };
     }
   }

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -325,20 +325,20 @@ export class EOxMap extends LitElement {
       } else if (l.constructor.name.includes("STACLayer")) {
         layers.push(l.get("_jsonDefinition"));
       } else {
-        const layerConfig = {
+        const layerConfig: any = {
           type: <EoxLayer["type"]>l.constructor.name.replace("Layer", ""),
           properties: {
             id: l.get("id") ? l.get("id") : getUid(l),
           },
         };
         // Extract source config
-        const source = {
+        const source: any = {
           type: <sourceType>(
             l.getSource().constructor.name.replace("Source", "")
           ),
         };
         // Evaluate what other information we need to extract for different source types
-        const olsource = l.getSource();
+        const olsource: any = l.getSource();
         if (["XYZ", "TileWMS", "WMS"].includes(olsource.constructor.name)) {
           source.urls = olsource.urls;
         } else if (olsource.constructor.name === "VectorSource") {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -314,7 +314,7 @@ export class EOxMap extends LitElement {
   extractLayerConfig = (layerArray: Array<Layer>) => {
     const layers: Array<EoxLayer> = [];
     layerArray.map((l) => {
-      if (["Group", "LayerGroup"].includes(l.constructor.name)) {
+      if (["Group", "_LayerGroup"].includes(l.constructor.name)) {
         layers.push({
           type: "Group",
           properties: {

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -5,7 +5,6 @@ import XYZ from "ol/source/XYZ.js";
 import VectorLayer from "ol/layer/Vector.js";
 import VectorSource from "ol/source/Vector.js";
 import GeoJSON from "ol/format/GeoJSON.js";
-import TileLayer from "ol/layer/Tile.js";
 import TileWMS from "ol/source/TileWMS.js";
 import chaiExclude from "chai-exclude";
 chai.use(chaiExclude);

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -7,8 +7,12 @@ import VectorSource from "ol/source/Vector.js";
 import GeoJSON from "ol/format/GeoJSON.js";
 import TileWMS from "ol/source/TileWMS.js";
 import chaiExclude from "chai-exclude";
-chai.use(chaiExclude);
 import "../main";
+
+// Use chaiExlude in order to make the deep.eq inside the
+// test work, since OL generates random layer ids
+// (see "excludingEvery("id")")
+chai.use(chaiExclude);
 
 describe("config property", () => {
   it("sets controls, layers and view using the config object", () => {
@@ -85,7 +89,7 @@ describe("config property", () => {
       expect(eoxMap.map.getView().getCenter()[1]).to.be.closeTo(2273030, 0.01);
     });
   });
-  it.only("returns a config object even if none was set initially", () => {
+  it("returns a config object even if none was set initially", () => {
     // cy.intercept(/^.*openstreetmap.*$/, {
     //   fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
     // });

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -1,6 +1,14 @@
 import { html } from "lit";
 import { Group as LayerGroup, Tile as TileLayer } from "ol/layer.js";
 import OSM from "ol/source/OSM";
+import XYZ from "ol/source/XYZ.js";
+import VectorLayer from "ol/layer/Vector.js";
+import VectorSource from "ol/source/Vector.js";
+import GeoJSON from "ol/format/GeoJSON.js";
+import TileLayer from "ol/layer/Tile.js";
+import TileWMS from "ol/source/TileWMS.js";
+import chaiExclude from "chai-exclude";
+chai.use(chaiExclude);
 import "../main";
 
 describe("config property", () => {
@@ -102,28 +110,82 @@ describe("config property", () => {
             }),
           ],
         }),
+        new TileLayer({
+          source: new XYZ({
+            url: "https://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2022_3857/default/g/{z}/{y}/{x}.jpg",
+          }),
+        }),
+        new VectorLayer({
+          background: "#1a2b39",
+          source: new VectorSource({
+            url: "https://openlayers.org/data/vector/ecoregions.json",
+            format: new GeoJSON(),
+          }),
+          style: {
+            "fill-color": ["string", ["get", "COLOR"], "#eee"],
+          },
+        }),
+        new TileLayer({
+          source: new TileWMS({
+            url: "https://ahocevar.com/geoserver/wms",
+            params: { LAYERS: "topp:states", TILED: true },
+            serverType: "geoserver",
+          }),
+        }),
       ]);
       const eoxMapconfig = eoxMap.config;
       expect(eoxMapconfig.view.center).to.deep.eq(testCenter);
       expect(eoxMapconfig.view.zoom).to.eq(testZoom);
-      expect(eoxMapconfig.layers).to.deep.eq([
-        {
-          type: "Tile",
-          properties: { id: "19" },
-          source: { type: "OSM" },
-        },
-        {
-          type: "Group",
-          properties: { id: "22" },
-          layers: [
-            {
-              type: "Tile",
-              properties: { id: "21" },
-              source: { type: "OSM" },
+      expect(eoxMapconfig.layers)
+        .excludingEvery("id")
+        .to.deep.eq([
+          {
+            type: "Tile",
+            properties: { id: "37089" },
+            source: { type: "OSM" },
+          },
+          {
+            type: "Group",
+            properties: { id: "37092" },
+            layers: [
+              {
+                type: "Tile",
+                properties: { id: "37091" },
+                source: { type: "OSM" },
+              },
+            ],
+          },
+          {
+            type: "Tile",
+            properties: { id: "37095" },
+            source: {
+              type: "XYZ",
+              urls: [
+                "https://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2022_3857/default/g/{z}/{y}/{x}.jpg",
+              ],
             },
-          ],
-        },
-      ]);
+          },
+          {
+            type: "Vector",
+            properties: { id: "37097" },
+            style: "",
+            source: {
+              type: "Vector",
+              url: "https://openlayers.org/data/vector/ecoregions.json",
+              format: "GeoJSON",
+            },
+          },
+          {
+            type: "Tile",
+            properties: { id: "37099" },
+            source: {
+              type: "TileWMS",
+              urls: ["https://ahocevar.com/geoserver/wms"],
+              params: { LAYERS: "topp:states", TILED: true },
+              serverType: "geoserver",
+            },
+          },
+        ]);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@storybook/theming": "^8.0.0",
         "@storybook/web-components": "^8.0.0",
         "@storybook/web-components-vite": "^8.0.0",
+        "chai-exclude": "^2.1.0",
         "concurrently": "^8.2.1",
         "custom-elements-manifest": "^2.0.0",
         "cypress": "^13.3.0",
@@ -106,7 +107,7 @@
     },
     "elements/jsonform": {
       "name": "@eox/jsonform",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@json-editor/json-editor": "^2.11.0",
         "toolcool-range-slider": "^4.0.28"
@@ -192,7 +193,7 @@
     },
     "elements/map": {
       "name": "@eox/map",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dependencies": {
         "lit": "^3.0.2",
         "ol": "^9.0.0",
@@ -236,7 +237,7 @@
     },
     "elements/storytelling": {
       "name": "@eox/storytelling",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "dependencies": {
         "@sindresorhus/slugify": "^2.2.1",
         "glightbox": "^3.3.0",
@@ -5895,6 +5896,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -6361,6 +6372,37 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
+    "node_modules/chai": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai-exclude": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chai-exclude/-/chai-exclude-2.1.0.tgz",
+      "integrity": "sha512-IBnm50Mvl3O1YhPpTgbU8MK0Gw7NHcb18WT2TxGdPKOMtdtZVKLHmQwdvOF7mTlHVQStbXuZKFwkevFtbHjpVg==",
+      "dev": true,
+      "dependencies": {
+        "fclone": "^1.0.11"
+      },
+      "peerDependencies": {
+        "chai": ">= 4.0.0 < 5"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6402,6 +6444,19 @@
       "integrity": "sha512-idA2l7vXF+CzgEIMHppL+8SNiNEWpt4Ooobt9m+UfYkXJfuuzmjySAVdy8VjTXhI7lZvJU02KyaVeqdBPPeLXA==",
       "peerDependencies": {
         "chart.js": "^4.1.0"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/check-more-types": {
@@ -7187,6 +7242,19 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -8272,6 +8340,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fclone": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
+      "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
+      "dev": true
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -8809,6 +8883,16 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -10287,6 +10371,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11422,6 +11516,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/pbf": {
       "version": "3.2.1",
@@ -13266,6 +13370,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@storybook/theming": "^8.0.0",
     "@storybook/web-components": "^8.0.0",
     "@storybook/web-components-vite": "^8.0.0",
+    "chai-exclude": "^2.1.0",
     "concurrently": "^8.2.1",
     "custom-elements-manifest": "^2.0.0",
     "cypress": "^13.3.0",


### PR DESCRIPTION
## Implemented changes

The previous config extraction was only considering type but was missing extraction of further properties, these have now been added for WMS, TiledWMS, XYZ config options.
For Vector sources it is not possible to retrieve the original style object (will possibly be fixed by OL)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
