### PR TITLE
Fix: Editor loading issue 

### DIFF
--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -3,6 +3,7 @@ import {
   initEditorEvents,
   positionEditor,
   runWhenEditorInitialised,
+  updateEditorInitVisibility,
 } from "../helpers";
 import { EDITOR_SCHEMA } from "../enums";
 
@@ -74,8 +75,7 @@ class StoryTellingEditor extends LitElement {
    * Lifecycle method called after the first update
    */
   firstUpdated() {
-    if (this.showEditor === "close")
-      this.querySelector(".switch-input").click();
+    if (this.showEditor === "close") updateEditorInitVisibility(this);
 
     // Get editor container and resize handle elements
     const editorContainer = this.querySelector(".editor-wrapper");
@@ -120,8 +120,7 @@ class StoryTellingEditor extends LitElement {
       `eox-storytelling${storyIdSelector}`
     );
     if (!evt.target.checked) {
-      wrapper.classList.add("editor-opacity-none");
-      setTimeout(() => wrapper.classList.add("editor-hide"), 500);
+      wrapper.classList.add("editor-hide");
       storyDOM.setAttribute("show-editor", "close");
     } else {
       wrapper.classList.remove("editor-opacity-none");

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -121,7 +121,7 @@ class StoryTellingEditor extends LitElement {
     );
     if (!evt.target.checked) {
       wrapper.classList.add("editor-opacity-none");
-      setTimeout(() => wrapper.classList.add("editor-hide"), 100);
+      setTimeout(() => wrapper.classList.add("editor-hide"), 500);
       storyDOM.setAttribute("show-editor", "close");
     } else {
       wrapper.classList.remove("editor-opacity-none");

--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -383,3 +383,23 @@ export function runWhenEditorInitialised() {
     setTimeout(runWhenEditorInitialised.bind(this), 100);
   }
 }
+
+/**
+ * Update initial editor visibility
+ *
+ * @param {import("../components/editor.js").StoryTellingEditor} StoryTellingEditor - Dom element
+ */
+export function updateEditorInitVisibility(StoryTellingEditor) {
+  const wrapper =
+    StoryTellingEditor.renderRoot.querySelector(".editor-wrapper");
+  wrapper.classList.add("editor-opacity-none");
+
+  if (
+    StoryTellingEditor.editor &&
+    StoryTellingEditor.editor.editor &&
+    StoryTellingEditor.editor.editor.ready &&
+    StoryTellingEditor.editor.editor?.editors["root.Story"].simplemde_instance
+  )
+    StoryTellingEditor.querySelector(".switch-input").click();
+  else setTimeout(() => updateEditorInitVisibility(StoryTellingEditor), 100);
+}

--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -17,5 +17,6 @@ export {
   initSavedMarkdown,
   preventEditorOutsideScroll,
   runWhenEditorInitialised,
+  updateEditorInitVisibility,
 } from "./editor";
 export { validateMarkdownAttrs } from "./validator";


### PR DESCRIPTION
## Implemented changes
- Validator was loading an empty screen due to delayed SimpleMDE package loading. Added a check to whether the SimpleMDE loaded or not. If loaded then only it hides the editor.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
