### PR TITLE
chore: revert non-working parts of config extraction

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -314,7 +314,7 @@ export class EOxMap extends LitElement {
   extractLayerConfig = (layerArray: Array<Layer>) => {
     const layers: Array<EoxLayer> = [];
     layerArray.map((l) => {
-      if (["Group", "_LayerGroup"].includes(l.constructor.name)) {
+      if (l.constructor.name.includes("LayerGroup")) {
         layers.push({
           type: "Group",
           properties: {
@@ -325,44 +325,17 @@ export class EOxMap extends LitElement {
       } else if (l.constructor.name.includes("STACLayer")) {
         layers.push(l.get("_jsonDefinition"));
       } else {
-        const layerConfig: any = {
+        layers.push({
           type: <EoxLayer["type"]>l.constructor.name.replace("Layer", ""),
           properties: {
             id: l.get("id") ? l.get("id") : getUid(l),
           },
-        };
-        // Evaluate what other information we need to extract for different source types
-        const olsource: any = l.getSource();
-        // only export visible layers
-        if (olsource && l.isVisible()) {
-          // Extract source config
-          const source: any = {
+          source: {
             type: <sourceType>(
               l.getSource().constructor.name.replace("Source", "")
             ),
-          };
-          if (["XYZ", "TileWMS", "WMS"].includes(olsource.constructor.name)) {
-            if ("url" in olsource) {
-              source.url = olsource.url;
-            } else if ("urls" in olsource) {
-              source.urls = olsource.urls;
-            }
-          } else if (olsource.constructor.name === "VectorSource") {
-            source.url = olsource.getUrl();
-            source.format = olsource.getFormat()?.constructor.name;
-          }
-          // Extract possible other configuration options
-          if (["TileWMS", "WMS"].includes(olsource.constructor.name)) {
-            source.params = olsource.getParams();
-            source.serverType = olsource.serverType_;
-          }
-          if (olsource.constructor.name === "VectorSource") {
-            // TODO: the getStyle function does not return the applied style as described in OL docs
-            layerConfig.style = ""; // l.getStyle();
-          }
-          layerConfig.source = source;
-          layers.push(layerConfig);
-        }
+          },
+        });
       }
     });
     return layers;
@@ -390,7 +363,7 @@ export class EOxMap extends LitElement {
         layers,
         view,
         controls,
-        preventScroll: true,
+        preventScroll: false,
       };
     }
   }

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -2,13 +2,12 @@ import { LitElement, PropertyValueMap, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import Map from "ol/Map.js";
 import View, { ViewObjectEventTypes } from "ol/View.js";
-import { getUid } from "ol/util";
 // @ts-ignore
 import olCss from "ol/ol.css?inline";
 // @ts-ignore
 import controlCss from "./src/controls/controls.css?inline";
 import { EOxSelectInteraction } from "./src/select";
-import { EoxLayer, createLayer, sourceType, updateLayer } from "./src/generate";
+import { EoxLayer, createLayer, updateLayer } from "./src/generate";
 import { Draw, Modify } from "ol/interaction";
 import Control from "ol/control/Control";
 import { getLayerById, getFlatLayersArray } from "./src/layer";
@@ -306,66 +305,12 @@ export class EOxMap extends LitElement {
   }
 
   /**
-   * Extracts current OL layer group state as
-   * EoxLayer array configuration
-   * @param layerArray OL Layer array
-   * @returns EoxLayer array JSON definition
-   */
-  extractLayerConfig = (layerArray: Array<Layer>) => {
-    const layers: Array<EoxLayer> = [];
-    layerArray.map((l) => {
-      if (l.constructor.name.includes("LayerGroup")) {
-        layers.push({
-          type: "Group",
-          properties: {
-            id: l.get("id") ? l.get("id") : getUid(l),
-          },
-          layers: this.extractLayerConfig(l.getLayersArray()),
-        });
-      } else if (l.constructor.name.includes("STACLayer")) {
-        layers.push(l.get("_jsonDefinition"));
-      } else {
-        layers.push({
-          type: <EoxLayer["type"]>l.constructor.name.replace("Layer", ""),
-          properties: {
-            id: l.get("id") ? l.get("id") : getUid(l),
-          },
-          source: {
-            type: <sourceType>(
-              l.getSource().constructor.name.replace("Source", "")
-            ),
-          },
-        });
-      }
-    });
-    return layers;
-  };
-
-  /**
    * Config object, including `controls`, `layers` and `view`.
    * Alternative way of defining the map config.
    */
   @property({ attribute: false, type: Object })
   get config() {
-    if (this._config) {
-      return this._config;
-    } else {
-      const olLayers = this.map.getLayers();
-      const layers = this.extractLayerConfig(<Array<Layer>>olLayers.getArray());
-      const olView = this.map.getView();
-      const view = {
-        center: olView.getCenter(),
-        zoom: olView.getZoom(),
-      };
-      const controls = <controlDictionary>{};
-      // TODO: we need to investigate if we can extract the controls somehow
-      return {
-        layers,
-        view,
-        controls,
-        preventScroll: false,
-      };
-    }
+    return this._config;
   }
 
   private _projection: ProjectionLike;

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -1,18 +1,7 @@
 import { html } from "lit";
 import { Group as LayerGroup, Tile as TileLayer } from "ol/layer.js";
 import OSM from "ol/source/OSM";
-import XYZ from "ol/source/XYZ.js";
-import VectorLayer from "ol/layer/Vector.js";
-import VectorSource from "ol/source/Vector.js";
-import GeoJSON from "ol/format/GeoJSON.js";
-import TileWMS from "ol/source/TileWMS.js";
-import chaiExclude from "chai-exclude";
 import "../main";
-
-// Use chaiExlude in order to make the deep.eq inside the
-// test work, since OL generates random layer ids
-// (see "excludingEvery("id")")
-chai.use(chaiExclude);
 
 describe("config property", () => {
   it("sets controls, layers and view using the config object", () => {
@@ -89,7 +78,7 @@ describe("config property", () => {
       expect(eoxMap.map.getView().getCenter()[1]).to.be.closeTo(2273030, 0.01);
     });
   });
-  it("returns a config object even if none was set initially", () => {
+  it.only("returns a config object even if none was set initially", () => {
     // cy.intercept(/^.*openstreetmap.*$/, {
     //   fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
     // });
@@ -113,82 +102,28 @@ describe("config property", () => {
             }),
           ],
         }),
-        new TileLayer({
-          source: new XYZ({
-            url: "https://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2022_3857/default/g/{z}/{y}/{x}.jpg",
-          }),
-        }),
-        new VectorLayer({
-          background: "#1a2b39",
-          source: new VectorSource({
-            url: "https://openlayers.org/data/vector/ecoregions.json",
-            format: new GeoJSON(),
-          }),
-          style: {
-            "fill-color": ["string", ["get", "COLOR"], "#eee"],
-          },
-        }),
-        new TileLayer({
-          source: new TileWMS({
-            url: "https://ahocevar.com/geoserver/wms",
-            params: { LAYERS: "topp:states", TILED: true },
-            serverType: "geoserver",
-          }),
-        }),
       ]);
       const eoxMapconfig = eoxMap.config;
       expect(eoxMapconfig.view.center).to.deep.eq(testCenter);
       expect(eoxMapconfig.view.zoom).to.eq(testZoom);
-      expect(eoxMapconfig.layers)
-        .excludingEvery("id")
-        .to.deep.eq([
-          {
-            type: "Tile",
-            properties: { id: "37089" },
-            source: { type: "OSM" },
-          },
-          {
-            type: "Group",
-            properties: { id: "37092" },
-            layers: [
-              {
-                type: "Tile",
-                properties: { id: "37091" },
-                source: { type: "OSM" },
-              },
-            ],
-          },
-          {
-            type: "Tile",
-            properties: { id: "37095" },
-            source: {
-              type: "XYZ",
-              urls: [
-                "https://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2022_3857/default/g/{z}/{y}/{x}.jpg",
-              ],
+      expect(eoxMapconfig.layers).to.deep.eq([
+        {
+          type: "Tile",
+          properties: { id: "19" },
+          source: { type: "OSM" },
+        },
+        {
+          type: "Group",
+          properties: { id: "22" },
+          layers: [
+            {
+              type: "Tile",
+              properties: { id: "21" },
+              source: { type: "OSM" },
             },
-          },
-          {
-            type: "Vector",
-            properties: { id: "37097" },
-            style: "",
-            source: {
-              type: "Vector",
-              url: "https://openlayers.org/data/vector/ecoregions.json",
-              format: "GeoJSON",
-            },
-          },
-          {
-            type: "Tile",
-            properties: { id: "37099" },
-            source: {
-              type: "TileWMS",
-              urls: ["https://ahocevar.com/geoserver/wms"],
-              params: { LAYERS: "topp:states", TILED: true },
-              serverType: "geoserver",
-            },
-          },
-        ]);
+          ],
+        },
+      ]);
     });
   });
 });

--- a/elements/map/test/configObject.cy.ts
+++ b/elements/map/test/configObject.cy.ts
@@ -1,6 +1,4 @@
 import { html } from "lit";
-import { Group as LayerGroup, Tile as TileLayer } from "ol/layer.js";
-import OSM from "ol/source/OSM";
 import "../main";
 
 describe("config property", () => {
@@ -76,54 +74,6 @@ describe("config property", () => {
       );
       expect(eoxMap.map.getView().getCenter()[0]).to.be.closeTo(1113194, 0.01);
       expect(eoxMap.map.getView().getCenter()[1]).to.be.closeTo(2273030, 0.01);
-    });
-  });
-  it.only("returns a config object even if none was set initially", () => {
-    // cy.intercept(/^.*openstreetmap.*$/, {
-    //   fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
-    // });
-    cy.mount(html`<eox-map></eox-map>`).as("eox-map");
-    cy.get("eox-map").and(async ($el) => {
-      const eoxMap = <EOxMap>$el[0];
-      const olMap = eoxMap.map;
-
-      const testCenter = [1000, 1000];
-      const testZoom = 2;
-      olMap.getView().setCenter(testCenter);
-      olMap.getView().setZoom(testZoom);
-      olMap.setLayers([
-        new TileLayer({
-          source: new OSM(),
-        }),
-        new LayerGroup({
-          layers: [
-            new TileLayer({
-              source: new OSM(),
-            }),
-          ],
-        }),
-      ]);
-      const eoxMapconfig = eoxMap.config;
-      expect(eoxMapconfig.view.center).to.deep.eq(testCenter);
-      expect(eoxMapconfig.view.zoom).to.eq(testZoom);
-      expect(eoxMapconfig.layers).to.deep.eq([
-        {
-          type: "Tile",
-          properties: { id: "19" },
-          source: { type: "OSM" },
-        },
-        {
-          type: "Group",
-          properties: { id: "22" },
-          layers: [
-            {
-              type: "Tile",
-              properties: { id: "21" },
-              source: { type: "OSM" },
-            },
-          ],
-        },
-      ]);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@storybook/theming": "^8.0.0",
         "@storybook/web-components": "^8.0.0",
         "@storybook/web-components-vite": "^8.0.0",
-        "chai-exclude": "^2.1.0",
         "concurrently": "^8.2.1",
         "custom-elements-manifest": "^2.0.0",
         "cypress": "^13.3.0",
@@ -5896,16 +5895,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -6372,37 +6361,6 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
-    "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chai-exclude": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chai-exclude/-/chai-exclude-2.1.0.tgz",
-      "integrity": "sha512-IBnm50Mvl3O1YhPpTgbU8MK0Gw7NHcb18WT2TxGdPKOMtdtZVKLHmQwdvOF7mTlHVQStbXuZKFwkevFtbHjpVg==",
-      "dev": true,
-      "dependencies": {
-        "fclone": "^1.0.11"
-      },
-      "peerDependencies": {
-        "chai": ">= 4.0.0 < 5"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6444,19 +6402,6 @@
       "integrity": "sha512-idA2l7vXF+CzgEIMHppL+8SNiNEWpt4Ooobt9m+UfYkXJfuuzmjySAVdy8VjTXhI7lZvJU02KyaVeqdBPPeLXA==",
       "peerDependencies": {
         "chart.js": "^4.1.0"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/check-more-types": {
@@ -7242,19 +7187,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -8340,12 +8272,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fclone": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
-      "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
-      "dev": true
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -8883,16 +8809,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -10371,16 +10287,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11516,16 +11422,6 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/pbf": {
       "version": "3.2.1",
@@ -13370,16 +13266,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@storybook/theming": "^8.0.0",
     "@storybook/web-components": "^8.0.0",
     "@storybook/web-components-vite": "^8.0.0",
-    "chai-exclude": "^2.1.0",
     "concurrently": "^8.2.1",
     "custom-elements-manifest": "^2.0.0",
     "cypress": "^13.3.0",


### PR DESCRIPTION
## Implemented changes

The previously implemented functionality relied on a JS feature which turns out not to be reliable. Since the previous version (1.8.0) can't be unpublished any longer, it will be marked as "deprecated", and this change will be released as 1.8.1 instead.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
