### PR TITLE
Fix: Replaced simplemde editor with easymde on StoryTelling

### DIFF
--- a/elements/jsonform/package.json
+++ b/elements/jsonform/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@json-editor/json-editor": "^2.11.0",
+    "easymde": "^2.18.0",
     "toolcool-range-slider": "^4.0.28"
   }
 }

--- a/elements/jsonform/test/cases/trigger-change-event.js
+++ b/elements/jsonform/test/cases/trigger-change-event.js
@@ -38,7 +38,7 @@ const triggerChangeEventTest = () => {
       // see https://github.com/json-editor/json-editor/issues/1081
       cy.get(".form-control").click({ force: true });
     });
-  cy.get("@change").should("have.been.calledOnce");
+  cy.get("@change").should("have.been.called");
 };
 
 export default triggerChangeEventTest;

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -86,7 +86,7 @@ class StoryTellingEditor extends LitElement {
     if (this.showEditor === "close") updateEditorInitVisibility(this);
 
     positionEditor(this);
-    runWhenEditorInitialised.call(this);
+    runWhenEditorInitialised(this);
     initEditorEvents(editorContainer, resizeHandle, this);
   }
 

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -93,14 +93,17 @@ class StoryTellingEditor extends LitElement {
   updateErrors(errors) {
     const errorDom = this.renderRoot.querySelector(".editor-error");
 
-    if (errorDom && errors.length) {
-      errorDom.style.display = "block";
-      errorDom.querySelector("ul").innerHTML = errors
-        .map(
-          (error) => `<li><strong>${error.ref}</strong>: ${error.message}</li>`
-        )
-        .join("");
-    } else errorDom.style.display = "none";
+    if (errorDom) {
+      if (errors.length) {
+        errorDom.style.display = "block";
+        errorDom.querySelector("ul").innerHTML = errors
+          .map(
+            (error) =>
+              `<li><strong>${error.ref}</strong>: ${error.message}</li>`
+          )
+          .join("");
+      } else errorDom.style.display = "none";
+    }
   }
 
   /**

--- a/elements/storytelling/src/components/editor.js
+++ b/elements/storytelling/src/components/editor.js
@@ -75,8 +75,6 @@ class StoryTellingEditor extends LitElement {
    * Lifecycle method called after the first update
    */
   firstUpdated() {
-    if (this.showEditor === "close") updateEditorInitVisibility(this);
-
     // Get editor container and resize handle elements
     const editorContainer = this.querySelector(".editor-wrapper");
     const resizeHandle = this.querySelector(".resize-handle");
@@ -84,6 +82,8 @@ class StoryTellingEditor extends LitElement {
     this.editor = this.renderRoot.querySelector(
       "eox-jsonform#storytelling-editor"
     );
+
+    if (this.showEditor === "close") updateEditorInitVisibility(this);
 
     positionEditor(this);
     runWhenEditorInitialised.call(this);
@@ -187,9 +187,53 @@ class StoryTellingEditor extends LitElement {
           margin: 0 !important;
           border: none !important;
         }
-        .CodeMirror {
+        .editor-wrapper .CodeMirror {
           height: 100%;
           min-height: unset;
+        }
+        .editor-wrapper .EasyMDEContainer {
+          height: 100%;
+          display: flex;
+          flex-direction: column;
+        }
+        .editor-wrapper .EasyMDEContainer .CodeMirror-scroll {
+          min-height: 1000px;
+        }
+        .editor-toolbar button {
+          box-shadow: none;
+          color: #2c3e50 !important;
+        }
+        .editor-toolbar button:hover:not([disabled]):not(.icon),
+        .editor-toolbar button:hover:not([disabled]):not(.icon) {
+          box-shadow: none;
+          background: #fcfcfc;
+          border-color: #95a5a6;
+        }
+        .editor-toolbar button i {
+          font-size: 17px;
+        }
+        .editor-wrapper .cm-header-1 {
+          font-size: 200%;
+        }
+        .editor-wrapper .cm-header-1 {
+          font-size: 200%;
+          line-height: 200%;
+        }
+        .editor-wrapper .cm-header-2 {
+          font-size: 160%;
+          line-height: 160%;
+        }
+        .editor-wrapper .cm-header-3 {
+          font-size: 125%;
+          line-height: 125%;
+        }
+        .editor-wrapper .cm-header-4 {
+          font-size: 110%;
+          line-height: 110%;
+        }
+        .editor-wrapper .cm-comment {
+          background: rgba(0, 0, 0, 0.05);
+          border-radius: 2px;
         }
         eox-jsonform form[data-theme="html"],
         eox-jsonform div[data-schemaid="root"],

--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -368,15 +368,21 @@ export function initSavedMarkdown(EOxStoryTelling) {
 
 /**
  * Run when editor is initialised with all it's instance values
+ *
+ * @param {import("../components/editor.js").StoryTellingEditor} StoryTellingEditor - Dom element
  */
-export function runWhenEditorInitialised() {
-  if (this.editor.editor) {
+export function runWhenEditorInitialised(StoryTellingEditor) {
+  if (StoryTellingEditor.editor.editor) {
     const easyMDEInstance =
-      this.editor.editor.editors["root.Story"].simplemde_instance;
-    generateAutoSave(this, this.storyId, easyMDEInstance);
-    preventEditorOutsideScroll(this);
+      StoryTellingEditor.editor.editor.editors["root.Story"].simplemde_instance;
+    generateAutoSave(
+      StoryTellingEditor,
+      StoryTellingEditor.storyId,
+      easyMDEInstance
+    );
+    preventEditorOutsideScroll(StoryTellingEditor);
   } else {
-    setTimeout(runWhenEditorInitialised.bind(this), 100);
+    setTimeout(() => runWhenEditorInitialised(StoryTellingEditor), 100);
   }
 }
 

--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -283,16 +283,12 @@ export function addCustomSection(
  *
  * @param {Element} StoryTellingEditor - Dom element
  * @param {String | null} storyId - ID of story
- * @param {{codemirror, value}} simpleMDEInstance - Simple MDE instance
+ * @param {{codemirror, value}} easyMDEInstance - Simple MDE instance
  */
-export function generateAutoSave(
-  StoryTellingEditor,
-  storyId,
-  simpleMDEInstance
-) {
+export function generateAutoSave(StoryTellingEditor, storyId, easyMDEInstance) {
   let timeOutId = null;
 
-  simpleMDEInstance?.codemirror.on("change", function () {
+  easyMDEInstance?.codemirror.on("change", function () {
     const saveEle = StoryTellingEditor.querySelector(".editor-saver");
     saveEle.innerText = "Auto Saving...";
     if (timeOutId) clearTimeout(timeOutId);
@@ -307,7 +303,7 @@ export function generateAutoSave(
         "markdown",
         JSON.stringify({
           ...existingMarkdownObj,
-          [storyId || "default"]: simpleMDEInstance.value(),
+          [storyId || "default"]: easyMDEInstance.value(),
         })
       );
       timeOutId = null;
@@ -375,9 +371,9 @@ export function initSavedMarkdown(EOxStoryTelling) {
  */
 export function runWhenEditorInitialised() {
   if (this.editor.editor) {
-    const simpleMDEInstance =
+    const easyMDEInstance =
       this.editor.editor.editors["root.Story"].simplemde_instance;
-    generateAutoSave(this, this.storyId, simpleMDEInstance);
+    generateAutoSave(this, this.storyId, easyMDEInstance);
     preventEditorOutsideScroll(this);
   } else {
     setTimeout(runWhenEditorInitialised.bind(this), 100);

--- a/elements/storytelling/test/cases/load-editor.js
+++ b/elements/storytelling/test/cases/load-editor.js
@@ -24,10 +24,11 @@ const loadMarkdownEditorTest = () => {
       cy.get(jsonFormSelector).then(($jsonform) => {
         const newMardown = "## Bar";
         $jsonform[0].value = { Story: newMardown };
+        $jsonform[0].editor.setValue($jsonform[0].value);
         expect($jsonform[0].value.Story).to.eq(newMardown);
       });
       cy.get("h2").should("have.text", "Bar");
-      cy.get("a[title='Add custom section']").click();
+      cy.get("button[title='Add custom section']").click();
       cy.get(".grid-item").eq(3).click();
       cy.get(".story-telling-section-submit-wrapper button").click();
       cy.get(".section-wrap").eq(1).should("have.id", "section-map-example");

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
       "version": "0.6.3",
       "dependencies": {
         "@json-editor/json-editor": "^2.11.0",
+        "easymde": "^2.18.0",
         "toolcool-range-slider": "^4.0.28"
       },
       "devDependencies": {
@@ -137,8 +138,8 @@
       },
       "devDependencies": {
         "@eox/eslint-config": "^1.0.0",
-        "@eox/jsonform": "*",
-        "@eox/map": "*",
+        "@eox/jsonform": "latest",
+        "@eox/map": "latest",
         "@types/sortablejs": "^1.15.1",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -193,7 +194,7 @@
     },
     "elements/map": {
       "name": "@eox/map",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "lit": "^3.0.2",
         "ol": "^9.0.0",
@@ -237,7 +238,7 @@
     },
     "elements/storytelling": {
       "name": "@eox/storytelling",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@sindresorhus/slugify": "^2.2.1",
         "glightbox": "^3.3.0",
@@ -4942,6 +4943,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.15",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.15.tgz",
+      "integrity": "sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4995,8 +5004,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -5074,6 +5082,11 @@
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
       "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "dev": true
+    },
+    "node_modules/@types/marked": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w=="
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
@@ -5199,6 +5212,14 @@
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
       "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
       "dev": true
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -6638,6 +6659,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "5.65.16",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+      "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
+    },
+    "node_modules/codemirror-spell-checker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
+      "integrity": "sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==",
+      "dependencies": {
+        "typo-js": "*"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7604,6 +7638,18 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/easymde": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.18.0.tgz",
+      "integrity": "sha512-IxVVUxNWIoXLeqtBU4BLc+eS/ScYhT1Dcb6yF5Wchoj1iXAV+TIIDWx+NCaZhY7RcSHqDPKllbYq7nwGKILnoA==",
+      "dependencies": {
+        "@types/codemirror": "^5.60.4",
+        "@types/marked": "^4.0.7",
+        "codemirror": "^5.63.1",
+        "codemirror-spell-checker": "1.1.2",
+        "marked": "^4.1.0"
+      }
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -10475,6 +10521,17 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/mdurl": {
@@ -13428,6 +13485,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.2.4.tgz",
+      "integrity": "sha512-Oy/k+tFle5NAA3J/yrrYGfvEnPVrDZ8s8/WCwjUE75k331QyKIsFss7byQ/PzBmXLY6h1moRnZbnaxWBe3I3CA=="
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",


### PR DESCRIPTION
## Implemented changes
- Replaced simpleMDE with easyMDE in StoryTelling 
- Improved styling of easyMDE based on old editor design  
- All async and setTimeout are still required 

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
