### PR TITLE
fix: prevent reaction to undefined zoom

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -129,7 +129,7 @@ export class EOxMap extends LitElement {
   private _zoom: number = 0;
 
   set zoom(zoom: number) {
-    if (!zoom) return
+    if (zoom === undefined) return;
     this._zoom = zoom;
     this._animateToState();
   }

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -129,6 +129,7 @@ export class EOxMap extends LitElement {
   private _zoom: number = 0;
 
   set zoom(zoom: number) {
+    if (!zoom) return
     this._zoom = zoom;
     this._animateToState();
   }


### PR DESCRIPTION
## Implemented changes

This PR introduces a small check to the `zoom` setter if the value is actually defined, as setting `undefined` resulted in a blank map.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
