### PR TITLE
fix: wheel event listener error when querySelector is null

### DIFF
--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -319,7 +319,7 @@ export function generateAutoSave(StoryTellingEditor, storyId, easyMDEInstance) {
 export function preventEditorOutsideScroll(StoryTellingEditor) {
   (StoryTellingEditor.shadowRoot || StoryTellingEditor)
     .querySelector(".CodeMirror-scroll")
-    .addEventListener(
+    ?.addEventListener(
       "wheel",
       function (event) {
         const deltaY = event.deltaY;


### PR DESCRIPTION
## Implemented changes
In https://github.com/EOX-A/EOxElements/actions/runs/9175391835/job/25229841043 we noticed the `markdown-with-editor` story had an error (`> Cannot read properties of null (reading 'addEventListener')`).
This PR adds a conditional to the querySelector so that the event listener is only added if `.CodeMirror-scroll` is available
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
