### PR TITLE
Fix: Styling stacking issue when range value become bigger

### DIFF
--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -18,6 +18,10 @@ export const styleEOX = `
     border-bottom: 1px solid #0002;
     padding: 0.5rem 0;
   }
+  .je-range-control {
+    display: flex;
+    align-items: center;
+  }
   .je-indented-panel span {
     display: flex;
     align-items: center;

--- a/elements/storytelling/CHANGELOG.md
+++ b/elements/storytelling/CHANGELOG.md
@@ -2,125 +2,144 @@
 
 ## [1.0.3](https://github.com/EOX-A/EOxElements/compare/storytelling-v1.0.2...storytelling-v1.0.3) (2024-05-22)
 
+
 ### Bug Fixes
 
-- Debounce editor updates ([#965](https://github.com/EOX-A/EOxElements/issues/965)) ([83f9df7](https://github.com/EOX-A/EOxElements/commit/83f9df793a751a4650ec24ac6357d049b731d588))
-- Wheel event listener error when querySelector is null ([#976](https://github.com/EOX-A/EOxElements/issues/976)) ([03da42e](https://github.com/EOX-A/EOxElements/commit/03da42ed641c701a1045e753f62abf5b268e8979))
+* Debounce editor updates  ([#965](https://github.com/EOX-A/EOxElements/issues/965)) ([83f9df7](https://github.com/EOX-A/EOxElements/commit/83f9df793a751a4650ec24ac6357d049b731d588))
+* Wheel event listener error when querySelector is null ([#976](https://github.com/EOX-A/EOxElements/issues/976)) ([03da42e](https://github.com/EOX-A/EOxElements/commit/03da42ed641c701a1045e753f62abf5b268e8979))
 
 ## [1.0.2](https://github.com/EOX-A/EOxElements/compare/storytelling-v1.0.1...storytelling-v1.0.2) (2024-05-16)
 
+
 ### Bug Fixes
 
-- Adaptations to new eox-jsonform md editor ([#957](https://github.com/EOX-A/EOxElements/issues/957)) ([4a644ca](https://github.com/EOX-A/EOxElements/commit/4a644ca1fa81ad0981761b7f92469198950bfed2))
+* Adaptations to new eox-jsonform md editor ([#957](https://github.com/EOX-A/EOxElements/issues/957)) ([4a644ca](https://github.com/EOX-A/EOxElements/commit/4a644ca1fa81ad0981761b7f92469198950bfed2))
 
 ## [1.0.1](https://github.com/EOX-A/EOxElements/compare/storytelling-v1.0.0...storytelling-v1.0.1) (2024-05-15)
 
+
 ### Bug Fixes
 
-- Editor loading race condition ([#945](https://github.com/EOX-A/EOxElements/issues/945)) ([513d952](https://github.com/EOX-A/EOxElements/commit/513d9526ad8eaf0498b3fe5e68e3e00359892fae))
-- Validation schema for layer groups ([#946](https://github.com/EOX-A/EOxElements/issues/946)) ([841f6b1](https://github.com/EOX-A/EOxElements/commit/841f6b10916677a7d1e51e91ac61899db1ca3d2a))
+* Editor loading race condition ([#945](https://github.com/EOX-A/EOxElements/issues/945)) ([513d952](https://github.com/EOX-A/EOxElements/commit/513d9526ad8eaf0498b3fe5e68e3e00359892fae))
+* Validation schema for layer groups ([#946](https://github.com/EOX-A/EOxElements/issues/946)) ([841f6b1](https://github.com/EOX-A/EOxElements/commit/841f6b10916677a7d1e51e91ac61899db1ca3d2a))
 
 ## [1.0.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.6.0...storytelling-v1.0.0) (2024-05-08)
 
+
 ### Bug Fixes
 
-- Editor autofocus ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-- Json-form hidden issue ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-- Opening all links in new tabs ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-- Story saving issues ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-- Using html code in a story ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-- Various bug fixes ([#932](https://github.com/EOX-A/EOxElements/issues/932)) ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+* Editor autofocus ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+* Json-form hidden issue ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+* Opening all links in new tabs ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+* Story saving issues ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+* Using html code in a story ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+* Various bug fixes ([#932](https://github.com/EOX-A/EOxElements/issues/932)) ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+
 
 ### Miscellaneous Chores
 
-- Update readme ([8d73a62](https://github.com/EOX-A/EOxElements/commit/8d73a6251368c53c0374185f029cd054f8684e4a))
+* Update readme ([8d73a62](https://github.com/EOX-A/EOxElements/commit/8d73a6251368c53c0374185f029cd054f8684e4a))
 
 ## [0.6.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.5.0...storytelling-v0.6.0) (2024-05-07)
 
+
 ### Features
 
-- Autosave to localstorage ([#892](https://github.com/EOX-A/EOxElements/issues/892)) ([ea30ac8](https://github.com/EOX-A/EOxElements/commit/ea30ac84b4a596eae69536c61ae993206638fcd2))
-- Parallax effect on hero section ([#877](https://github.com/EOX-A/EOxElements/issues/877)) ([833bbc3](https://github.com/EOX-A/EOxElements/commit/833bbc3dfe97fb9ff9f391bdb598903a1fa170ac))
-- Section adding popup ([#889](https://github.com/EOX-A/EOxElements/issues/889)) ([f2f492b](https://github.com/EOX-A/EOxElements/commit/f2f492b81abec2f8d0b37e0aaf23894d19106f85))
-- Syntax versioning, validation and error handling ([#867](https://github.com/EOX-A/EOxElements/issues/867)) ([a950cc6](https://github.com/EOX-A/EOxElements/commit/a950cc6c0581eb2379ba8116272cb6b5735eedaf))
+* Autosave to localstorage ([#892](https://github.com/EOX-A/EOxElements/issues/892)) ([ea30ac8](https://github.com/EOX-A/EOxElements/commit/ea30ac84b4a596eae69536c61ae993206638fcd2))
+* Parallax effect on hero section  ([#877](https://github.com/EOX-A/EOxElements/issues/877)) ([833bbc3](https://github.com/EOX-A/EOxElements/commit/833bbc3dfe97fb9ff9f391bdb598903a1fa170ac))
+* Section adding popup ([#889](https://github.com/EOX-A/EOxElements/issues/889)) ([f2f492b](https://github.com/EOX-A/EOxElements/commit/f2f492b81abec2f8d0b37e0aaf23894d19106f85))
+* Syntax versioning, validation and error handling ([#867](https://github.com/EOX-A/EOxElements/issues/867)) ([a950cc6](https://github.com/EOX-A/EOxElements/commit/a950cc6c0581eb2379ba8116272cb6b5735eedaf))
+
 
 ### Bug Fixes
 
-- Custom section DOM structure ([#888](https://github.com/EOX-A/EOxElements/issues/888)) ([e33e542](https://github.com/EOX-A/EOxElements/commit/e33e54284ccc1d14e63a7b1f201a7c822b3b6c07))
-- Prevent repetitive prompt to load saved markdown ([#906](https://github.com/EOX-A/EOxElements/issues/906)) ([9de8730](https://github.com/EOX-A/EOxElements/commit/9de8730e02d60b4928527b36353c4f370fea9bcf))
-- Prevent scroll-through editor ([#923](https://github.com/EOX-A/EOxElements/issues/923)) ([78f61be](https://github.com/EOX-A/EOxElements/commit/78f61be7e5ff9abf2ded03f3882e5d808d3f5128))
+* Custom section DOM structure ([#888](https://github.com/EOX-A/EOxElements/issues/888)) ([e33e542](https://github.com/EOX-A/EOxElements/commit/e33e54284ccc1d14e63a7b1f201a7c822b3b6c07))
+* Prevent repetitive prompt to load saved markdown  ([#906](https://github.com/EOX-A/EOxElements/issues/906)) ([9de8730](https://github.com/EOX-A/EOxElements/commit/9de8730e02d60b4928527b36353c4f370fea9bcf))
+* Prevent scroll-through editor ([#923](https://github.com/EOX-A/EOxElements/issues/923)) ([78f61be](https://github.com/EOX-A/EOxElements/commit/78f61be7e5ff9abf2ded03f3882e5d808d3f5128))
 
 ## [0.5.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.4.0...storytelling-v0.5.0) (2024-04-16)
 
+
 ### Features
 
-- Dedicated fallback mode ([#847](https://github.com/EOX-A/EOxElements/issues/847)) ([005b06d](https://github.com/EOX-A/EOxElements/commit/005b06d60f2ecf25f4a81338c373218848c5d6fc))
-- Lightbox for images ([#858](https://github.com/EOX-A/EOxElements/issues/858)) ([3226751](https://github.com/EOX-A/EOxElements/commit/3226751684e4d8e7e715f6d1ec70d337e9bd0291))
-- Sticky navigation after hero ([#837](https://github.com/EOX-A/EOxElements/issues/837)) ([8bf25a3](https://github.com/EOX-A/EOxElements/commit/8bf25a3cfb3d428c0bc5f91c6adce6c6d95626c8))
+* Dedicated fallback mode ([#847](https://github.com/EOX-A/EOxElements/issues/847)) ([005b06d](https://github.com/EOX-A/EOxElements/commit/005b06d60f2ecf25f4a81338c373218848c5d6fc))
+* Lightbox for images ([#858](https://github.com/EOX-A/EOxElements/issues/858)) ([3226751](https://github.com/EOX-A/EOxElements/commit/3226751684e4d8e7e715f6d1ec70d337e9bd0291))
+* Sticky navigation after hero ([#837](https://github.com/EOX-A/EOxElements/issues/837)) ([8bf25a3](https://github.com/EOX-A/EOxElements/commit/8bf25a3cfb3d428c0bc5f91c6adce6c6d95626c8))
+
 
 ### Bug Fixes
 
-- StoryTelling styling and highlight active nav item ([#842](https://github.com/EOX-A/EOxElements/issues/842)) ([ec1b7cf](https://github.com/EOX-A/EOxElements/commit/ec1b7cf9c2b3f03dfc8dfca92a6f29ad64b5b8c1))
-- **style:** Navigation z-index ([#848](https://github.com/EOX-A/EOxElements/issues/848)) ([ec425c6](https://github.com/EOX-A/EOxElements/commit/ec425c655201c7b6c23af27b859d42e1a4b6f304))
+* StoryTelling styling and highlight active nav item ([#842](https://github.com/EOX-A/EOxElements/issues/842)) ([ec1b7cf](https://github.com/EOX-A/EOxElements/commit/ec1b7cf9c2b3f03dfc8dfca92a6f29ad64b5b8c1))
+* **style:** Navigation z-index ([#848](https://github.com/EOX-A/EOxElements/issues/848)) ([ec425c6](https://github.com/EOX-A/EOxElements/commit/ec425c655201c7b6c23af27b859d42e1a4b6f304))
 
 ## [0.4.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.3.1...storytelling-v0.4.0) (2024-04-09)
 
+
 ### Features
 
-- Added image/video based hero section to StoryTelling ([#808](https://github.com/EOX-A/EOxElements/issues/808)) ([03e99a0](https://github.com/EOX-A/EOxElements/commit/03e99a0f6889331b2bf74116eae746a657bc1b2b))
-- Export/Import for storytelling editor ([#809](https://github.com/EOX-A/EOxElements/issues/809)) ([40aee95](https://github.com/EOX-A/EOxElements/commit/40aee95039c7a2604be2819e1c535d3c4eae76f6))
-- StoryTelling with Editor Mode ([#788](https://github.com/EOX-A/EOxElements/issues/788)) ([5ed4599](https://github.com/EOX-A/EOxElements/commit/5ed45995624c11dc403bde3d641ca1b58d6c0015))
-- Use eox-jsonform instead of monaco editor ([#791](https://github.com/EOX-A/EOxElements/issues/791)) ([91a6ba9](https://github.com/EOX-A/EOxElements/commit/91a6ba95e25487d09125b0c9a6ce3ac0f68d005c))
+* Added image/video based hero section to StoryTelling ([#808](https://github.com/EOX-A/EOxElements/issues/808)) ([03e99a0](https://github.com/EOX-A/EOxElements/commit/03e99a0f6889331b2bf74116eae746a657bc1b2b))
+* Export/Import for storytelling editor  ([#809](https://github.com/EOX-A/EOxElements/issues/809)) ([40aee95](https://github.com/EOX-A/EOxElements/commit/40aee95039c7a2604be2819e1c535d3c4eae76f6))
+* StoryTelling with Editor Mode ([#788](https://github.com/EOX-A/EOxElements/issues/788)) ([5ed4599](https://github.com/EOX-A/EOxElements/commit/5ed45995624c11dc403bde3d641ca1b58d6c0015))
+* Use eox-jsonform instead of monaco editor ([#791](https://github.com/EOX-A/EOxElements/issues/791)) ([91a6ba9](https://github.com/EOX-A/EOxElements/commit/91a6ba95e25487d09125b0c9a6ce3ac0f68d005c))
+
 
 ### Bug Fixes
 
-- **style:** Adapt styling to new editor ([#813](https://github.com/EOX-A/EOxElements/issues/813)) ([03d61f9](https://github.com/EOX-A/EOxElements/commit/03d61f9a73e93ab1c790f79563f55997404da11c))
+* **style:** Adapt styling to new editor ([#813](https://github.com/EOX-A/EOxElements/issues/813)) ([03d61f9](https://github.com/EOX-A/EOxElements/commit/03d61f9a73e93ab1c790f79563f55997404da11c))
 
 ## [0.3.1](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.3.0...storytelling-v0.3.1) (2024-03-25)
 
+
 ### Bug Fixes
 
-- Add default sensitive tag like iframe ([#773](https://github.com/EOX-A/EOxElements/issues/773)) ([b6f867e](https://github.com/EOX-A/EOxElements/commit/b6f867edacf2581c11ce717461c541a967e2d294))
+* Add default sensitive tag like iframe ([#773](https://github.com/EOX-A/EOxElements/issues/773)) ([b6f867e](https://github.com/EOX-A/EOxElements/commit/b6f867edacf2581c11ce717461c541a967e2d294))
 
 ## [0.3.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.2.0...storytelling-v0.3.0) (2024-03-25)
 
+
 ### Features
 
-- Map tour mode ([#766](https://github.com/EOX-A/EOxElements/issues/766)) ([9fe659e](https://github.com/EOX-A/EOxElements/commit/9fe659e8a2336c8374b20fa5a97959bf9f18050d))
-- Replace `h2` tags via `as` attr ([#748](https://github.com/EOX-A/EOxElements/issues/748)) ([214a2b9](https://github.com/EOX-A/EOxElements/commit/214a2b96a0c40a5f0615f02e66bd4c3fe9acdade))
-- Storytelling map section powered by @eox/map ([#761](https://github.com/EOX-A/EOxElements/issues/761)) ([a0f96c4](https://github.com/EOX-A/EOxElements/commit/a0f96c4b759113e1ece715a35d5e862032baa0eb))
-- Storytelling sections ([#755](https://github.com/EOX-A/EOxElements/issues/755)) ([bf8a706](https://github.com/EOX-A/EOxElements/commit/bf8a706f2657bed4cace8a29fe187e450963819c))
+* Map tour mode ([#766](https://github.com/EOX-A/EOxElements/issues/766)) ([9fe659e](https://github.com/EOX-A/EOxElements/commit/9fe659e8a2336c8374b20fa5a97959bf9f18050d))
+* Replace `h2` tags via `as` attr ([#748](https://github.com/EOX-A/EOxElements/issues/748)) ([214a2b9](https://github.com/EOX-A/EOxElements/commit/214a2b96a0c40a5f0615f02e66bd4c3fe9acdade))
+* Storytelling map section powered by @eox/map ([#761](https://github.com/EOX-A/EOxElements/issues/761)) ([a0f96c4](https://github.com/EOX-A/EOxElements/commit/a0f96c4b759113e1ece715a35d5e862032baa0eb))
+* Storytelling sections ([#755](https://github.com/EOX-A/EOxElements/issues/755)) ([bf8a706](https://github.com/EOX-A/EOxElements/commit/bf8a706f2657bed4cace8a29fe187e450963819c))
+
 
 ### Bug Fixes
 
-- Allow empty section titles ([#760](https://github.com/EOX-A/EOxElements/issues/760)) ([62234a6](https://github.com/EOX-A/EOxElements/commit/62234a67b5f9fd056c610f5fb732e99926637031))
+* Allow empty section titles ([#760](https://github.com/EOX-A/EOxElements/issues/760)) ([62234a6](https://github.com/EOX-A/EOxElements/commit/62234a67b5f9fd056c610f5fb732e99926637031))
 
 ## [0.2.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.1.0...storytelling-v0.2.0) (2024-03-07)
 
+
 ### Features
 
-- Automated navigation from headings ([#703](https://github.com/EOX-A/EOxElements/issues/703)) ([0610749](https://github.com/EOX-A/EOxElements/commit/0610749fcc38b2ec3410a22e4f3978613d84d258))
-- Basic frontmatter config ([#725](https://github.com/EOX-A/EOxElements/issues/725)) ([68f7a36](https://github.com/EOX-A/EOxElements/commit/68f7a366a97bf4972e9d6e787f941dcd2c3e5a0d))
-- Basic styling for storytelling ([#729](https://github.com/EOX-A/EOxElements/issues/729)) ([aca2ca3](https://github.com/EOX-A/EOxElements/commit/aca2ca3854cd4e960bba7faad566525ea18bca86))
-- Render attributes via comment tags ([#700](https://github.com/EOX-A/EOxElements/issues/700)) ([83c2139](https://github.com/EOX-A/EOxElements/commit/83c2139fcd5abdc6cb5d2ba8de7e782546b94bd2))
+* Automated navigation from headings ([#703](https://github.com/EOX-A/EOxElements/issues/703)) ([0610749](https://github.com/EOX-A/EOxElements/commit/0610749fcc38b2ec3410a22e4f3978613d84d258))
+* Basic frontmatter config ([#725](https://github.com/EOX-A/EOxElements/issues/725)) ([68f7a36](https://github.com/EOX-A/EOxElements/commit/68f7a366a97bf4972e9d6e787f941dcd2c3e5a0d))
+* Basic styling for storytelling ([#729](https://github.com/EOX-A/EOxElements/issues/729)) ([aca2ca3](https://github.com/EOX-A/EOxElements/commit/aca2ca3854cd4e960bba7faad566525ea18bca86))
+* Render attributes via comment tags  ([#700](https://github.com/EOX-A/EOxElements/issues/700)) ([83c2139](https://github.com/EOX-A/EOxElements/commit/83c2139fcd5abdc6cb5d2ba8de7e782546b94bd2))
+
 
 ### Bug Fixes
 
-- **style:** Restrict iframe, img, video max width by default ([#705](https://github.com/EOX-A/EOxElements/issues/705)) ([53a3cf7](https://github.com/EOX-A/EOxElements/commit/53a3cf720e59ccde42e6b65c62ad2aba4658cb7d))
+* **style:** Restrict iframe, img, video max width by default ([#705](https://github.com/EOX-A/EOxElements/issues/705)) ([53a3cf7](https://github.com/EOX-A/EOxElements/commit/53a3cf720e59ccde42e6b65c62ad2aba4658cb7d))
 
 ## [0.1.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.0.0...storytelling-v0.1.0) (2024-02-27)
 
+
 ### Features
 
-- Add markdown rendering via `markdown-it` as string and URL ([#690](https://github.com/EOX-A/EOxElements/issues/690)) ([42154a3](https://github.com/EOX-A/EOxElements/commit/42154a3c133ee29bfdfedc8816730ea859039419))
-- Render markdown from default slot ([#696](https://github.com/EOX-A/EOxElements/issues/696)) ([cfef85a](https://github.com/EOX-A/EOxElements/commit/cfef85a6675a58e9637e684c2edd48e8c42f9f39))
+* Add markdown rendering via `markdown-it` as string and URL ([#690](https://github.com/EOX-A/EOxElements/issues/690)) ([42154a3](https://github.com/EOX-A/EOxElements/commit/42154a3c133ee29bfdfedc8816730ea859039419))
+* Render markdown from default slot ([#696](https://github.com/EOX-A/EOxElements/issues/696)) ([cfef85a](https://github.com/EOX-A/EOxElements/commit/cfef85a6675a58e9637e684c2edd48e8c42f9f39))
+
 
 ### Bug Fixes
 
-- **docs:** MarkdownURL pattern ([#697](https://github.com/EOX-A/EOxElements/issues/697)) ([edbc1ca](https://github.com/EOX-A/EOxElements/commit/edbc1ca21c5bd3d8fe0a2b4d918566a72fbc40d3))
+* **docs:** MarkdownURL pattern ([#697](https://github.com/EOX-A/EOxElements/issues/697)) ([edbc1ca](https://github.com/EOX-A/EOxElements/commit/edbc1ca21c5bd3d8fe0a2b4d918566a72fbc40d3))
 
 ## 0.0.0 (2024-02-22)
 
+
 ### Features
 
-- Initial storytelling element setup ([#669](https://github.com/EOX-A/EOxElements/issues/669)) ([509a579](https://github.com/EOX-A/EOxElements/commit/509a579032a704660f6b23b34371a12f2d27eb86))
+* Initial storytelling element setup ([#669](https://github.com/EOX-A/EOxElements/issues/669)) ([509a579](https://github.com/EOX-A/EOxElements/commit/509a579032a704660f6b23b34371a12f2d27eb86))

--- a/elements/storytelling/CHANGELOG.md
+++ b/elements/storytelling/CHANGELOG.md
@@ -2,144 +2,125 @@
 
 ## [1.0.3](https://github.com/EOX-A/EOxElements/compare/storytelling-v1.0.2...storytelling-v1.0.3) (2024-05-22)
 
-
 ### Bug Fixes
 
-* Debounce editor updates  ([#965](https://github.com/EOX-A/EOxElements/issues/965)) ([83f9df7](https://github.com/EOX-A/EOxElements/commit/83f9df793a751a4650ec24ac6357d049b731d588))
-* Wheel event listener error when querySelector is null ([#976](https://github.com/EOX-A/EOxElements/issues/976)) ([03da42e](https://github.com/EOX-A/EOxElements/commit/03da42ed641c701a1045e753f62abf5b268e8979))
+- Debounce editor updates ([#965](https://github.com/EOX-A/EOxElements/issues/965)) ([83f9df7](https://github.com/EOX-A/EOxElements/commit/83f9df793a751a4650ec24ac6357d049b731d588))
+- Wheel event listener error when querySelector is null ([#976](https://github.com/EOX-A/EOxElements/issues/976)) ([03da42e](https://github.com/EOX-A/EOxElements/commit/03da42ed641c701a1045e753f62abf5b268e8979))
 
 ## [1.0.2](https://github.com/EOX-A/EOxElements/compare/storytelling-v1.0.1...storytelling-v1.0.2) (2024-05-16)
 
-
 ### Bug Fixes
 
-* Adaptations to new eox-jsonform md editor ([#957](https://github.com/EOX-A/EOxElements/issues/957)) ([4a644ca](https://github.com/EOX-A/EOxElements/commit/4a644ca1fa81ad0981761b7f92469198950bfed2))
+- Adaptations to new eox-jsonform md editor ([#957](https://github.com/EOX-A/EOxElements/issues/957)) ([4a644ca](https://github.com/EOX-A/EOxElements/commit/4a644ca1fa81ad0981761b7f92469198950bfed2))
 
 ## [1.0.1](https://github.com/EOX-A/EOxElements/compare/storytelling-v1.0.0...storytelling-v1.0.1) (2024-05-15)
 
-
 ### Bug Fixes
 
-* Editor loading race condition ([#945](https://github.com/EOX-A/EOxElements/issues/945)) ([513d952](https://github.com/EOX-A/EOxElements/commit/513d9526ad8eaf0498b3fe5e68e3e00359892fae))
-* Validation schema for layer groups ([#946](https://github.com/EOX-A/EOxElements/issues/946)) ([841f6b1](https://github.com/EOX-A/EOxElements/commit/841f6b10916677a7d1e51e91ac61899db1ca3d2a))
+- Editor loading race condition ([#945](https://github.com/EOX-A/EOxElements/issues/945)) ([513d952](https://github.com/EOX-A/EOxElements/commit/513d9526ad8eaf0498b3fe5e68e3e00359892fae))
+- Validation schema for layer groups ([#946](https://github.com/EOX-A/EOxElements/issues/946)) ([841f6b1](https://github.com/EOX-A/EOxElements/commit/841f6b10916677a7d1e51e91ac61899db1ca3d2a))
 
 ## [1.0.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.6.0...storytelling-v1.0.0) (2024-05-08)
 
-
 ### Bug Fixes
 
-* Editor autofocus ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-* Json-form hidden issue ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-* Opening all links in new tabs ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-* Story saving issues ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-* Using html code in a story ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-* Various bug fixes ([#932](https://github.com/EOX-A/EOxElements/issues/932)) ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
-
+- Editor autofocus ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+- Json-form hidden issue ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+- Opening all links in new tabs ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+- Story saving issues ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+- Using html code in a story ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
+- Various bug fixes ([#932](https://github.com/EOX-A/EOxElements/issues/932)) ([c474eef](https://github.com/EOX-A/EOxElements/commit/c474eefba55082657f03ee291ec13ff55016ac3a))
 
 ### Miscellaneous Chores
 
-* Update readme ([8d73a62](https://github.com/EOX-A/EOxElements/commit/8d73a6251368c53c0374185f029cd054f8684e4a))
+- Update readme ([8d73a62](https://github.com/EOX-A/EOxElements/commit/8d73a6251368c53c0374185f029cd054f8684e4a))
 
 ## [0.6.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.5.0...storytelling-v0.6.0) (2024-05-07)
 
-
 ### Features
 
-* Autosave to localstorage ([#892](https://github.com/EOX-A/EOxElements/issues/892)) ([ea30ac8](https://github.com/EOX-A/EOxElements/commit/ea30ac84b4a596eae69536c61ae993206638fcd2))
-* Parallax effect on hero section  ([#877](https://github.com/EOX-A/EOxElements/issues/877)) ([833bbc3](https://github.com/EOX-A/EOxElements/commit/833bbc3dfe97fb9ff9f391bdb598903a1fa170ac))
-* Section adding popup ([#889](https://github.com/EOX-A/EOxElements/issues/889)) ([f2f492b](https://github.com/EOX-A/EOxElements/commit/f2f492b81abec2f8d0b37e0aaf23894d19106f85))
-* Syntax versioning, validation and error handling ([#867](https://github.com/EOX-A/EOxElements/issues/867)) ([a950cc6](https://github.com/EOX-A/EOxElements/commit/a950cc6c0581eb2379ba8116272cb6b5735eedaf))
-
+- Autosave to localstorage ([#892](https://github.com/EOX-A/EOxElements/issues/892)) ([ea30ac8](https://github.com/EOX-A/EOxElements/commit/ea30ac84b4a596eae69536c61ae993206638fcd2))
+- Parallax effect on hero section ([#877](https://github.com/EOX-A/EOxElements/issues/877)) ([833bbc3](https://github.com/EOX-A/EOxElements/commit/833bbc3dfe97fb9ff9f391bdb598903a1fa170ac))
+- Section adding popup ([#889](https://github.com/EOX-A/EOxElements/issues/889)) ([f2f492b](https://github.com/EOX-A/EOxElements/commit/f2f492b81abec2f8d0b37e0aaf23894d19106f85))
+- Syntax versioning, validation and error handling ([#867](https://github.com/EOX-A/EOxElements/issues/867)) ([a950cc6](https://github.com/EOX-A/EOxElements/commit/a950cc6c0581eb2379ba8116272cb6b5735eedaf))
 
 ### Bug Fixes
 
-* Custom section DOM structure ([#888](https://github.com/EOX-A/EOxElements/issues/888)) ([e33e542](https://github.com/EOX-A/EOxElements/commit/e33e54284ccc1d14e63a7b1f201a7c822b3b6c07))
-* Prevent repetitive prompt to load saved markdown  ([#906](https://github.com/EOX-A/EOxElements/issues/906)) ([9de8730](https://github.com/EOX-A/EOxElements/commit/9de8730e02d60b4928527b36353c4f370fea9bcf))
-* Prevent scroll-through editor ([#923](https://github.com/EOX-A/EOxElements/issues/923)) ([78f61be](https://github.com/EOX-A/EOxElements/commit/78f61be7e5ff9abf2ded03f3882e5d808d3f5128))
+- Custom section DOM structure ([#888](https://github.com/EOX-A/EOxElements/issues/888)) ([e33e542](https://github.com/EOX-A/EOxElements/commit/e33e54284ccc1d14e63a7b1f201a7c822b3b6c07))
+- Prevent repetitive prompt to load saved markdown ([#906](https://github.com/EOX-A/EOxElements/issues/906)) ([9de8730](https://github.com/EOX-A/EOxElements/commit/9de8730e02d60b4928527b36353c4f370fea9bcf))
+- Prevent scroll-through editor ([#923](https://github.com/EOX-A/EOxElements/issues/923)) ([78f61be](https://github.com/EOX-A/EOxElements/commit/78f61be7e5ff9abf2ded03f3882e5d808d3f5128))
 
 ## [0.5.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.4.0...storytelling-v0.5.0) (2024-04-16)
 
-
 ### Features
 
-* Dedicated fallback mode ([#847](https://github.com/EOX-A/EOxElements/issues/847)) ([005b06d](https://github.com/EOX-A/EOxElements/commit/005b06d60f2ecf25f4a81338c373218848c5d6fc))
-* Lightbox for images ([#858](https://github.com/EOX-A/EOxElements/issues/858)) ([3226751](https://github.com/EOX-A/EOxElements/commit/3226751684e4d8e7e715f6d1ec70d337e9bd0291))
-* Sticky navigation after hero ([#837](https://github.com/EOX-A/EOxElements/issues/837)) ([8bf25a3](https://github.com/EOX-A/EOxElements/commit/8bf25a3cfb3d428c0bc5f91c6adce6c6d95626c8))
-
+- Dedicated fallback mode ([#847](https://github.com/EOX-A/EOxElements/issues/847)) ([005b06d](https://github.com/EOX-A/EOxElements/commit/005b06d60f2ecf25f4a81338c373218848c5d6fc))
+- Lightbox for images ([#858](https://github.com/EOX-A/EOxElements/issues/858)) ([3226751](https://github.com/EOX-A/EOxElements/commit/3226751684e4d8e7e715f6d1ec70d337e9bd0291))
+- Sticky navigation after hero ([#837](https://github.com/EOX-A/EOxElements/issues/837)) ([8bf25a3](https://github.com/EOX-A/EOxElements/commit/8bf25a3cfb3d428c0bc5f91c6adce6c6d95626c8))
 
 ### Bug Fixes
 
-* StoryTelling styling and highlight active nav item ([#842](https://github.com/EOX-A/EOxElements/issues/842)) ([ec1b7cf](https://github.com/EOX-A/EOxElements/commit/ec1b7cf9c2b3f03dfc8dfca92a6f29ad64b5b8c1))
-* **style:** Navigation z-index ([#848](https://github.com/EOX-A/EOxElements/issues/848)) ([ec425c6](https://github.com/EOX-A/EOxElements/commit/ec425c655201c7b6c23af27b859d42e1a4b6f304))
+- StoryTelling styling and highlight active nav item ([#842](https://github.com/EOX-A/EOxElements/issues/842)) ([ec1b7cf](https://github.com/EOX-A/EOxElements/commit/ec1b7cf9c2b3f03dfc8dfca92a6f29ad64b5b8c1))
+- **style:** Navigation z-index ([#848](https://github.com/EOX-A/EOxElements/issues/848)) ([ec425c6](https://github.com/EOX-A/EOxElements/commit/ec425c655201c7b6c23af27b859d42e1a4b6f304))
 
 ## [0.4.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.3.1...storytelling-v0.4.0) (2024-04-09)
 
-
 ### Features
 
-* Added image/video based hero section to StoryTelling ([#808](https://github.com/EOX-A/EOxElements/issues/808)) ([03e99a0](https://github.com/EOX-A/EOxElements/commit/03e99a0f6889331b2bf74116eae746a657bc1b2b))
-* Export/Import for storytelling editor  ([#809](https://github.com/EOX-A/EOxElements/issues/809)) ([40aee95](https://github.com/EOX-A/EOxElements/commit/40aee95039c7a2604be2819e1c535d3c4eae76f6))
-* StoryTelling with Editor Mode ([#788](https://github.com/EOX-A/EOxElements/issues/788)) ([5ed4599](https://github.com/EOX-A/EOxElements/commit/5ed45995624c11dc403bde3d641ca1b58d6c0015))
-* Use eox-jsonform instead of monaco editor ([#791](https://github.com/EOX-A/EOxElements/issues/791)) ([91a6ba9](https://github.com/EOX-A/EOxElements/commit/91a6ba95e25487d09125b0c9a6ce3ac0f68d005c))
-
+- Added image/video based hero section to StoryTelling ([#808](https://github.com/EOX-A/EOxElements/issues/808)) ([03e99a0](https://github.com/EOX-A/EOxElements/commit/03e99a0f6889331b2bf74116eae746a657bc1b2b))
+- Export/Import for storytelling editor ([#809](https://github.com/EOX-A/EOxElements/issues/809)) ([40aee95](https://github.com/EOX-A/EOxElements/commit/40aee95039c7a2604be2819e1c535d3c4eae76f6))
+- StoryTelling with Editor Mode ([#788](https://github.com/EOX-A/EOxElements/issues/788)) ([5ed4599](https://github.com/EOX-A/EOxElements/commit/5ed45995624c11dc403bde3d641ca1b58d6c0015))
+- Use eox-jsonform instead of monaco editor ([#791](https://github.com/EOX-A/EOxElements/issues/791)) ([91a6ba9](https://github.com/EOX-A/EOxElements/commit/91a6ba95e25487d09125b0c9a6ce3ac0f68d005c))
 
 ### Bug Fixes
 
-* **style:** Adapt styling to new editor ([#813](https://github.com/EOX-A/EOxElements/issues/813)) ([03d61f9](https://github.com/EOX-A/EOxElements/commit/03d61f9a73e93ab1c790f79563f55997404da11c))
+- **style:** Adapt styling to new editor ([#813](https://github.com/EOX-A/EOxElements/issues/813)) ([03d61f9](https://github.com/EOX-A/EOxElements/commit/03d61f9a73e93ab1c790f79563f55997404da11c))
 
 ## [0.3.1](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.3.0...storytelling-v0.3.1) (2024-03-25)
 
-
 ### Bug Fixes
 
-* Add default sensitive tag like iframe ([#773](https://github.com/EOX-A/EOxElements/issues/773)) ([b6f867e](https://github.com/EOX-A/EOxElements/commit/b6f867edacf2581c11ce717461c541a967e2d294))
+- Add default sensitive tag like iframe ([#773](https://github.com/EOX-A/EOxElements/issues/773)) ([b6f867e](https://github.com/EOX-A/EOxElements/commit/b6f867edacf2581c11ce717461c541a967e2d294))
 
 ## [0.3.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.2.0...storytelling-v0.3.0) (2024-03-25)
 
-
 ### Features
 
-* Map tour mode ([#766](https://github.com/EOX-A/EOxElements/issues/766)) ([9fe659e](https://github.com/EOX-A/EOxElements/commit/9fe659e8a2336c8374b20fa5a97959bf9f18050d))
-* Replace `h2` tags via `as` attr ([#748](https://github.com/EOX-A/EOxElements/issues/748)) ([214a2b9](https://github.com/EOX-A/EOxElements/commit/214a2b96a0c40a5f0615f02e66bd4c3fe9acdade))
-* Storytelling map section powered by @eox/map ([#761](https://github.com/EOX-A/EOxElements/issues/761)) ([a0f96c4](https://github.com/EOX-A/EOxElements/commit/a0f96c4b759113e1ece715a35d5e862032baa0eb))
-* Storytelling sections ([#755](https://github.com/EOX-A/EOxElements/issues/755)) ([bf8a706](https://github.com/EOX-A/EOxElements/commit/bf8a706f2657bed4cace8a29fe187e450963819c))
-
+- Map tour mode ([#766](https://github.com/EOX-A/EOxElements/issues/766)) ([9fe659e](https://github.com/EOX-A/EOxElements/commit/9fe659e8a2336c8374b20fa5a97959bf9f18050d))
+- Replace `h2` tags via `as` attr ([#748](https://github.com/EOX-A/EOxElements/issues/748)) ([214a2b9](https://github.com/EOX-A/EOxElements/commit/214a2b96a0c40a5f0615f02e66bd4c3fe9acdade))
+- Storytelling map section powered by @eox/map ([#761](https://github.com/EOX-A/EOxElements/issues/761)) ([a0f96c4](https://github.com/EOX-A/EOxElements/commit/a0f96c4b759113e1ece715a35d5e862032baa0eb))
+- Storytelling sections ([#755](https://github.com/EOX-A/EOxElements/issues/755)) ([bf8a706](https://github.com/EOX-A/EOxElements/commit/bf8a706f2657bed4cace8a29fe187e450963819c))
 
 ### Bug Fixes
 
-* Allow empty section titles ([#760](https://github.com/EOX-A/EOxElements/issues/760)) ([62234a6](https://github.com/EOX-A/EOxElements/commit/62234a67b5f9fd056c610f5fb732e99926637031))
+- Allow empty section titles ([#760](https://github.com/EOX-A/EOxElements/issues/760)) ([62234a6](https://github.com/EOX-A/EOxElements/commit/62234a67b5f9fd056c610f5fb732e99926637031))
 
 ## [0.2.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.1.0...storytelling-v0.2.0) (2024-03-07)
 
-
 ### Features
 
-* Automated navigation from headings ([#703](https://github.com/EOX-A/EOxElements/issues/703)) ([0610749](https://github.com/EOX-A/EOxElements/commit/0610749fcc38b2ec3410a22e4f3978613d84d258))
-* Basic frontmatter config ([#725](https://github.com/EOX-A/EOxElements/issues/725)) ([68f7a36](https://github.com/EOX-A/EOxElements/commit/68f7a366a97bf4972e9d6e787f941dcd2c3e5a0d))
-* Basic styling for storytelling ([#729](https://github.com/EOX-A/EOxElements/issues/729)) ([aca2ca3](https://github.com/EOX-A/EOxElements/commit/aca2ca3854cd4e960bba7faad566525ea18bca86))
-* Render attributes via comment tags  ([#700](https://github.com/EOX-A/EOxElements/issues/700)) ([83c2139](https://github.com/EOX-A/EOxElements/commit/83c2139fcd5abdc6cb5d2ba8de7e782546b94bd2))
-
+- Automated navigation from headings ([#703](https://github.com/EOX-A/EOxElements/issues/703)) ([0610749](https://github.com/EOX-A/EOxElements/commit/0610749fcc38b2ec3410a22e4f3978613d84d258))
+- Basic frontmatter config ([#725](https://github.com/EOX-A/EOxElements/issues/725)) ([68f7a36](https://github.com/EOX-A/EOxElements/commit/68f7a366a97bf4972e9d6e787f941dcd2c3e5a0d))
+- Basic styling for storytelling ([#729](https://github.com/EOX-A/EOxElements/issues/729)) ([aca2ca3](https://github.com/EOX-A/EOxElements/commit/aca2ca3854cd4e960bba7faad566525ea18bca86))
+- Render attributes via comment tags ([#700](https://github.com/EOX-A/EOxElements/issues/700)) ([83c2139](https://github.com/EOX-A/EOxElements/commit/83c2139fcd5abdc6cb5d2ba8de7e782546b94bd2))
 
 ### Bug Fixes
 
-* **style:** Restrict iframe, img, video max width by default ([#705](https://github.com/EOX-A/EOxElements/issues/705)) ([53a3cf7](https://github.com/EOX-A/EOxElements/commit/53a3cf720e59ccde42e6b65c62ad2aba4658cb7d))
+- **style:** Restrict iframe, img, video max width by default ([#705](https://github.com/EOX-A/EOxElements/issues/705)) ([53a3cf7](https://github.com/EOX-A/EOxElements/commit/53a3cf720e59ccde42e6b65c62ad2aba4658cb7d))
 
 ## [0.1.0](https://github.com/EOX-A/EOxElements/compare/storytelling-v0.0.0...storytelling-v0.1.0) (2024-02-27)
 
-
 ### Features
 
-* Add markdown rendering via `markdown-it` as string and URL ([#690](https://github.com/EOX-A/EOxElements/issues/690)) ([42154a3](https://github.com/EOX-A/EOxElements/commit/42154a3c133ee29bfdfedc8816730ea859039419))
-* Render markdown from default slot ([#696](https://github.com/EOX-A/EOxElements/issues/696)) ([cfef85a](https://github.com/EOX-A/EOxElements/commit/cfef85a6675a58e9637e684c2edd48e8c42f9f39))
-
+- Add markdown rendering via `markdown-it` as string and URL ([#690](https://github.com/EOX-A/EOxElements/issues/690)) ([42154a3](https://github.com/EOX-A/EOxElements/commit/42154a3c133ee29bfdfedc8816730ea859039419))
+- Render markdown from default slot ([#696](https://github.com/EOX-A/EOxElements/issues/696)) ([cfef85a](https://github.com/EOX-A/EOxElements/commit/cfef85a6675a58e9637e684c2edd48e8c42f9f39))
 
 ### Bug Fixes
 
-* **docs:** MarkdownURL pattern ([#697](https://github.com/EOX-A/EOxElements/issues/697)) ([edbc1ca](https://github.com/EOX-A/EOxElements/commit/edbc1ca21c5bd3d8fe0a2b4d918566a72fbc40d3))
+- **docs:** MarkdownURL pattern ([#697](https://github.com/EOX-A/EOxElements/issues/697)) ([edbc1ca](https://github.com/EOX-A/EOxElements/commit/edbc1ca21c5bd3d8fe0a2b4d918566a72fbc40d3))
 
 ## 0.0.0 (2024-02-22)
 
-
 ### Features
 
-* Initial storytelling element setup ([#669](https://github.com/EOX-A/EOxElements/issues/669)) ([509a579](https://github.com/EOX-A/EOxElements/commit/509a579032a704660f6b23b34371a12f2d27eb86))
+- Initial storytelling element setup ([#669](https://github.com/EOX-A/EOxElements/issues/669)) ([509a579](https://github.com/EOX-A/EOxElements/commit/509a579032a704660f6b23b34371a12f2d27eb86))


### PR DESCRIPTION
## Implemented changes
- Small styling issue when the value of range goes double or more. 

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
From > To
<img width="49%" alt="Screenshot 2024-05-24 at 6 52 58 PM" src="https://github.com/EOX-A/EOxElements/assets/10809211/bade31ec-5edf-405d-953a-9c5bff51397c"> <img width="49%" alt="Screenshot 2024-05-24 at 6 52 58 PM" src="https://github.com/EOX-A/EOxElements/assets/10809211/58cc18ac-d3c8-48dc-9505-2ff2f3b92a69"> 



<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
