### PR TITLE
Feat: The widget hook initialize based on the @init event 

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -325,11 +325,7 @@ export class EOxMap extends LitElement {
   @property({ attribute: "projection", type: String })
   set projection(projection: ProjectionLike) {
     const oldView = this.map.getView();
-    if (
-      projection &&
-      getProjection(projection) &&
-      projection !== oldView.getProjection().getCode()
-    ) {
+    if (projection && projection !== oldView.getProjection().getCode()) {
       const newCenter = transform(
         oldView.getCenter(),
         oldView.getProjection().getCode(),

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -325,7 +325,11 @@ export class EOxMap extends LitElement {
   @property({ attribute: "projection", type: String })
   set projection(projection: ProjectionLike) {
     const oldView = this.map.getView();
-    if (projection && projection !== oldView.getProjection().getCode()) {
+    if (
+      projection &&
+      getProjection(projection) &&
+      projection !== oldView.getProjection().getCode()
+    ) {
       const newCenter = transform(
         oldView.getCenter(),
         oldView.getProjection().getCode(),

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -152,13 +152,13 @@ function assignNewAttrValue(section, index, elementSelector, parent) {
  * @returns {Element} The processed DOM node.
  */
 function processNode(node, initDispatchFunc) {
-  if (
-    node.nodeType === Node.ELEMENT_NODE &&
-    node.classList.contains("section-custom")
-  ) {
+  if (node.nodeType === Node.ELEMENT_NODE) {
     const childElements = node.querySelectorAll("*");
     childElements.forEach((element) => {
-      if (/^[a-z]+(-[a-z0-9]+)*$/.test(element.tagName.toLowerCase())) {
+      if (
+        /^[a-z]+(-[a-z0-9]+)*$/.test(element.tagName.toLowerCase()) &&
+        node.classList.contains("section-custom")
+      ) {
         Array.from(element.attributes).forEach(
           // Update the attribute with its converted value
           (attr) =>
@@ -167,8 +167,8 @@ function processNode(node, initDispatchFunc) {
               attr.name
             ))
         );
-        setTimeout(() => initDispatchFunc(element), 100);
       }
+      setTimeout(() => initDispatchFunc(element), 100);
     });
   }
 

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -9,10 +9,11 @@ let stepSectionObservers = [];
  *
  * @param {string} htmlString - The HTML string to be rendered.
  * @param {Object} sections - List of sections meta
+ * @param {Function} initDispatchFunc - Init dispatch event
  * @param {import("lit").LitElement} that - The LitElement instance.
  * @returns {Element[]} An array of processed DOM nodes.
  */
-export function renderHtmlString(htmlString, sections, that) {
+export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
   // Parse the HTML string into a document
   const parser = new DOMParser();
   const doc = parser.parseFromString(htmlString, "text/html");
@@ -122,7 +123,9 @@ export function renderHtmlString(htmlString, sections, that) {
   window.addEventListener("scroll", generateParallaxEffect);
 
   // Process child nodes of the document body
-  return Array.from(doc.body.childNodes).map(processNode);
+  return Array.from(doc.body.childNodes).map((node) =>
+    processNode(node, initDispatchFunc)
+  );
 }
 
 /**
@@ -145,9 +148,10 @@ function assignNewAttrValue(section, index, elementSelector, parent) {
  * Processes a DOM node by potentially modifying its attributes value based on it's datatype
  *
  * @param {Element} node - The DOM node to process.
+ * @param {Function} initDispatchFunc - Init dispatch event
  * @returns {Element} The processed DOM node.
  */
-function processNode(node) {
+function processNode(node, initDispatchFunc) {
   if (
     node.nodeType === Node.ELEMENT_NODE &&
     node.classList.contains("section-custom")
@@ -163,6 +167,7 @@ function processNode(node) {
               attr.name
             ))
         );
+        setTimeout(() => initDispatchFunc(element), 100);
       }
     });
   }

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -131,6 +131,18 @@ export class EOxStoryTelling extends LitElement {
   }
 
   /**
+   * @param {Element} element - Dom element
+   * @private
+   */
+  #dispatchInitEvent(element) {
+    this.dispatchEvent(
+      new CustomEvent("init", {
+        detail: element,
+      })
+    );
+  }
+
+  /**
    * @param {Map} changedProperties - A map of changed properties.
    */
   async updated(changedProperties) {
@@ -160,6 +172,7 @@ export class EOxStoryTelling extends LitElement {
           ADD_TAGS: DEFAULT_SENSITIVE_TAGS,
         }),
         md.sections,
+        this.#dispatchInitEvent.bind(this),
         this
       );
 

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -4,3 +4,4 @@ export { default as PrimaryStory } from "./primary"; // StoryTelling with markdo
 export { default as MarkdownAsURLStory } from "./markdown-url"; // StoryTelling with markdown URL
 export { default as MarkdownSlotStory } from "./markdown-slot"; // StoryTelling with markdown from the slot
 export { default as MarkdownEditorStory } from "./markdown-editor"; // StoryTelling with editor
+export { default as MarkdownInitEventStory } from "./markdown-init-event"; // StoryTelling with init event

--- a/elements/storytelling/stories/markdown-init-event.js
+++ b/elements/storytelling/stories/markdown-init-event.js
@@ -1,0 +1,43 @@
+/**
+ * Renders storytelling with @init event.
+ */
+import { html } from "lit";
+
+function initEventFunc(element) {
+  if (element?.tagName === "EOX-MAP") {
+    element.registerProjection(
+      "ESRI:53009",
+      "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
+        "+b=6371000 +units=m +no_defs"
+    );
+    const projection = element.getAttribute("projection");
+    if (projection) element.setAttribute("projection", projection);
+  }
+}
+
+export const MarkdownInitEvent = {
+  args: {
+    markdown: `## Map section <!--{as="eox-map" projection="ESRI:53009" style="width: 100%; height: 500px;" config='{ "controls": { "Zoom": {}, "Attribution": {}, "FullScreen": {}, "OverviewMap": { "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "OSM" } } ] } }, "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ], "view": { "center": [15,48], "zoom": 1 } }'}-->
+
+## Map Tour section <!--{ projection="ESRI:53009" as="eox-map" zoom="9" center=[12.46,41.89] mode="tour" layers='[{"type":"Tile","properties":{"id":"osm"},"source":{"type":"OSM"}}]' }-->
+
+### <!--{ projection="ESRI:53009" animationOptions="{duration:500}" }-->
+#### ESRI:53009
+
+### <!--{ projection="EPSG:3857" animationOptions="{duration:500}" }-->
+#### EPSG:3857
+
+### <!--{ projection="EPSG:4326" animationOptions="{duration:500}" }-->
+#### EPSG:4326
+`,
+  },
+  render: (args) => html`
+    <eox-storytelling
+      id="markdown-editor"
+      markdown=${args.markdown}
+      @init=${({ detail }) => initEventFunc(detail)}
+    ></eox-storytelling>
+  `,
+};
+
+export default MarkdownInitEvent;

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -7,6 +7,7 @@ import {
   MarkdownAsURLStory,
   MarkdownSlotStory,
   MarkdownEditorStory,
+  MarkdownInitEventStory,
 } from "./index";
 import { html } from "lit";
 
@@ -46,3 +47,8 @@ export const MarkdownInsideSlot = MarkdownSlotStory;
  * StoryTelling with editor
  */
 export const MarkdownWithEditor = MarkdownEditorStory;
+
+/**
+ * StoryTelling with @init event
+ */
+export const MarkdownInitEvent = MarkdownInitEventStory;


### PR DESCRIPTION
## Implemented changes
Introducing `@init` event to update the elements when markdown is initialised or changed. 

```vue
<eox-storytelling
  markdown="## Welcome to the story editor "
  @init=${({ detail }) => {
  if (detail?.tagName === "EOX-MAP") {
    detail.registerProjection(
      "EPSG:3035",
      PROJDICT["EPSG:3035"].def
    );
  }
}}
></eox-storytelling>
```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
