### PR TITLE
Feat: WMTS Tile Grid & Source Projections

### DIFF
--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -121,6 +121,35 @@ export const WMTSCapabilitiesLayer = {
   },
 };
 
+/**
+ * `WMTS` data can also be accessed directly without the need of fetching the capabilities.
+ * A TileGrid can be defined via the `tileGrid`-property of the Source
+ */
+export const WMTSTileGrid = {
+  args: {
+    center: [20, 40],
+    layers: [
+      {
+        type: "Tile",
+        properties: {
+          id: "customId",
+        },
+        source: {
+          type: "WMTS",
+          url: "https://tiles.maps.eox.at/wmts",
+          layer: "s2cloudless-2017_3857",
+          style: "default",
+          matrixSet: "GoogleMapsCompatible",
+          tileGrid: {
+            tileSize: [128, 128],
+          },
+        },
+      },
+    ],
+    zoom: 5,
+  },
+};
+
 export const STACLayer = {
   args: {
     center: [-122.38, 46.1],

--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -21,7 +21,6 @@ import {
 
 import { FlatStyleLike } from "ol/style/flat";
 import { Collection } from "ol";
-import { createXYZ } from "ol/tilegrid";
 import { DrawOptions, addDraw } from "./draw";
 import { EOxMap } from "../main";
 import {
@@ -129,13 +128,20 @@ export type EoxLayer = {
   maxResolution?: number;
   opacity?: number;
   visible?: boolean;
-  source?: { type: sourceType; format?: string | formatWithOptions };
+  source?: {
+    type: sourceType;
+    format?: string | formatWithOptions;
+    tileGrid?: object;
+    projection?: import("ol/proj").ProjectionLike;
+  };
   layers?: Array<EoxLayer>;
   style?: FlatStyleLike;
   interactions?: Array<EOxInteraction>;
   zIndex?: number;
   renderMode?: "vector" | "vectorImage";
 };
+import { get as getProjection } from "ol/proj.js";
+import { generateTileGrid } from "./tileGrid";
 
 /**
  * creates an ol-layer from a given EoxLayer definition object
@@ -187,32 +193,34 @@ export function createLayer(
     }
   }
 
+  const tileGrid = generateTileGrid(layer);
+
   const olLayer = new newLayer({
     ...layer,
     ...(layer.source && {
       source: new newSource({
         ...layer.source,
         // @ts-ignore
-        ...(layer.source.format && {
-          // @ts-ignore
-          format: new availableFormats[
-            typeof layer.source.format === "object"
-              ? layer.source.format.type
-              : layer.source.format
-          ]({
+        ...(layer.source.format &&
+          layer.source.type !== "WMTS" && {
             // @ts-ignore
-            ...(typeof layer.source.format === "object" && {
+            format: new availableFormats[
+              typeof layer.source.format === "object"
+                ? layer.source.format.type
+                : layer.source.format
+            ]({
               // @ts-ignore
-              ...layer.source.format,
+              ...(typeof layer.source.format === "object" && {
+                // @ts-ignore
+                ...layer.source.format,
+              }),
             }),
           }),
-        }),
-        // @ts-ignore
         ...(layer.source.tileGrid && {
-          tileGrid: createXYZ({
-            // @ts-ignore
-            ...layer.source.tileGrid,
-          }),
+          tileGrid,
+        }),
+        ...(layer.source.projection && {
+          projection: getProjection(layer.source.projection),
         }),
       }),
     }),

--- a/elements/map/src/tileGrid.ts
+++ b/elements/map/src/tileGrid.ts
@@ -28,12 +28,12 @@ export function generateTileGrid(layer: import("./generate").EoxLayer) {
       }
 
       tileGrid = new WMTSTileGrid({
-        ...layer.source.tileGrid,
         resolutions: resolutions,
         origin: getTopLeft(projectionExtent),
         // @ts-ignore
         projection: layer.source.tileGrid.projection || "EPSG:3857",
         matrixIds: matrixIds,
+        ...layer.source.tileGrid,
       });
     } else {
       tileGrid = createXYZ({

--- a/elements/map/src/tileGrid.ts
+++ b/elements/map/src/tileGrid.ts
@@ -1,0 +1,45 @@
+import { createXYZ } from "ol/tilegrid";
+import WMTSTileGrid from "ol/tilegrid/WMTS";
+import { getTopLeft, getWidth } from "ol/extent.js";
+import { get as getProjection } from "ol/proj.js";
+
+/**
+ * generates a WMTS tile grid for WMTS layers or else an XYZ tile grid, if defined.
+ * @param layer
+ * @returns
+ */
+export function generateTileGrid(layer: import("./generate").EoxLayer) {
+  let tileGrid;
+  if (!layer.source?.tileGrid) {
+    return undefined;
+  }
+
+  if (layer.source.tileGrid) {
+    if (layer.source.type === "WMTS") {
+      const projection = getProjection("EPSG:3857");
+      const projectionExtent = projection.getExtent();
+      const size = getWidth(projectionExtent) / 128;
+      const resolutions = new Array(19);
+      const matrixIds = new Array(19);
+      for (let z = 0; z < 19; ++z) {
+        // generate resolutions and matrixIds arrays for this WMTS
+        resolutions[z] = size / Math.pow(2, z);
+        matrixIds[z] = z;
+      }
+
+      tileGrid = new WMTSTileGrid({
+        ...layer.source.tileGrid,
+        resolutions: resolutions,
+        origin: getTopLeft(projectionExtent),
+        // @ts-ignore
+        projection: layer.source.tileGrid.projection || "EPSG:3857",
+        matrixIds: matrixIds,
+      });
+    } else {
+      tileGrid = createXYZ({
+        ...layer.source.tileGrid,
+      });
+    }
+  }
+  return tileGrid;
+}

--- a/elements/map/src/tileGrid.ts
+++ b/elements/map/src/tileGrid.ts
@@ -6,7 +6,7 @@ import { get as getProjection } from "ol/proj.js";
 /**
  * generates a WMTS tile grid for WMTS layers or else an XYZ tile grid, if defined.
  * @param layer
- * @returns
+ * @returns {WMTSTileGrid | import("ol/tilegrid/TileGrid").default | undefined}
  */
 export function generateTileGrid(layer: import("./generate").EoxLayer) {
   let tileGrid;

--- a/elements/map/test/fixtures/eoxCapabilities.xml
+++ b/elements/map/test/fixtures/eoxCapabilities.xml
@@ -86,6 +86,201 @@
 </ows:OperationsMetadata>
 <Contents>
 <Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2018 by EOX - 3857</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2017 &amp; 2018) released under <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. For commercial usage please see <a href="https://cloudless.eox.at">https://cloudless.eox.at</a></ows:Abstract>
+<ows:Identifier>s2cloudless-2018_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2018_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Coastline overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Coastline overlay</a> { Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>coastline</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/coastline/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2020 by EOX - 4326</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2020) released under <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. For commercial usage please see <a href="https://cloudless.eox.at">https://cloudless.eox.at</a></ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>s2cloudless-2020</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2020/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>OpenStreetMap background layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">OpenStreetMap</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:Identifier>osm_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/osm_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2016 by EOX - 3857</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2016 &amp; 2017) released under <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</ows:Abstract>
+<ows:Identifier>s2cloudless_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Terrain background layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Terrain</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors and <a href="https://maps.eox.at/#data">others</a>, Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:Identifier>terrain_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/terrain_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Bright overlay layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay bright</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:Identifier>overlay_base_bright_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay_base_bright_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Hydrography overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Hydrography overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>hydrography</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/hydrography/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Graticules overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Graticules</a> { Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>graticules</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/graticules/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Overlay layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:Identifier>overlay_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Blue marble background layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Blue Marble</a> { &copy; <a href="http://nasa.gov">NASA</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>bluemarble</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/bluemarble/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Black coastline overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Black coastline overlay</a> { Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>coastline_black</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/coastline_black/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
 <ows:Title>Sentinel-2 cloudless layer for 2017 by EOX - 3857</ows:Title>
 <ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2017) released under <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</ows:Abstract>
 <ows:Identifier>s2cloudless-2017_3857</ows:Identifier>
@@ -100,6 +295,408 @@
 <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
 </TileMatrixSetLink>
 <ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2017_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Streets overlay layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Streets overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:Identifier>streets_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/streets_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Bright overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay bright</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>overlay_bright</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay_bright/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2019 by EOX - 3857</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2019) released under <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. For commercial usage please see <a href="https://cloudless.eox.at">https://cloudless.eox.at</a></ows:Abstract>
+<ows:Identifier>s2cloudless-2019_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2019_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>overlay</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Black marble background layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Black Marble</a> { &copy; <a href="http://nasa.gov">NASA</a> }</ows:Abstract>
+<ows:Identifier>blackmarble_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/blackmarble_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Hydrography overlay layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Hydrography overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:Identifier>hydrography_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/hydrography_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2017 by EOX - 4326</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2017) released under <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>s2cloudless-2017</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2017/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Streets overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Streets overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>streets</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/streets/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2018 by EOX - 4326</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2017 &amp; 2018) released under <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. For commercial usage please see <a href="https://cloudless.eox.at">https://cloudless.eox.at</a></ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>s2cloudless-2018</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2018/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2019 by EOX - 4326</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2019) released under <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. For commercial usage please see <a href="https://cloudless.eox.at">https://cloudless.eox.at</a></ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>s2cloudless-2019</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2019/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>OpenStreetMap background layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">OpenStreetMap</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>osm</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/osm/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Black marble background layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Black Marble</a> { &copy; <a href="http://nasa.gov">NASA</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>blackmarble</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/blackmarble/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Terrain Light background layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Terrain Light</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors and <a href="https://maps.eox.at/#data">others</a>, Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:Identifier>terrain-light_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/terrain-light_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2020 by EOX - 3857</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2020) released under <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. For commercial usage please see <a href="https://cloudless.eox.at">https://cloudless.eox.at</a></ows:Abstract>
+<ows:Identifier>s2cloudless-2020_3857_512</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible_512</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2020_3857_512/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Blue marble background layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Blue Marble</a> { &copy; <a href="http://nasa.gov">NASA</a> }</ows:Abstract>
+<ows:Identifier>bluemarble_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/bluemarble_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Overlay layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:Identifier>overlay_base_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay_base_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2016 by EOX - 4326</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2016 &amp; 2017) released under <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>s2cloudless</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Terrain background layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Terrain</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors and <a href="https://maps.eox.at/#data">others</a>, Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>terrain</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/terrain/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Bright overlay layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay bright</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:Identifier>overlay_bright_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay_bright_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Coastline overlay layer by EOX - 3857</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Coastline overlay</a> { Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:Identifier>coastline_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/coastline_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Sentinel-2 cloudless layer for 2020 by EOX - 3857</ows:Title>
+<ows:Abstract><a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title">Sentinel-2 cloudless - https://s2maps.eu</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2020) released under <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. For commercial usage please see <a href="https://cloudless.eox.at">https://cloudless.eox.at</a></ows:Abstract>
+<ows:Identifier>s2cloudless-2020_3857</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>g</TileMatrixSet>
+</TileMatrixSetLink>
+<TileMatrixSetLink>
+<TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2020_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Magnetic Graticules overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Magnetic Graticules</a> { Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>magnetic_graticules</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/magnetic_graticules/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Terrain Light background layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Terrain Light</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors and <a href="https://maps.eox.at/#data">others</a>, Rendering &copy; <a href="https://eox.at">EOX</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>terrain-light</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/jpeg</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/jpeg" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/terrain-light/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+</Layer>
+<Layer>
+<ows:Title>Bright overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay bright</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>overlay_base_bright</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay_base_bright/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+</Layer>
+<Layer>
+<ows:Title>Overlay layer by EOX - 4326</ows:Title>
+<ows:Abstract><a href="https://maps.eox.at">Overlay</a> { Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Rendering &copy; <a href="https://eox.at">EOX</a> and <a href="https://github.com/mapserver/basemaps">MapServer</a> }</ows:Abstract>
+<ows:WGS84BoundingBox>
+<ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+<ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+</ows:WGS84BoundingBox>
+<ows:Identifier>overlay_base</ows:Identifier>
+<Style isDefault="true">
+<ows:Identifier>default</ows:Identifier>
+</Style>
+<Format>image/png</Format>
+<TileMatrixSetLink>
+<TileMatrixSet>WGS84</TileMatrixSet>
+</TileMatrixSetLink>
+<ResourceURL format="image/png" resourceType="tile" template="https://tiles.maps.eox.at/wmts/1.0.0/overlay_base/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
 </Layer>
 <TileMatrixSet>
 <ows:Identifier>GoogleMapsCompatible_512</ows:Identifier>
@@ -804,5 +1401,4 @@
 </TileMatrix>
 </TileMatrixSet>
 </Contents>
-<script id="bw-fido2-page-script"/>
 </Capabilities>

--- a/elements/map/test/wmts.cy.ts
+++ b/elements/map/test/wmts.cy.ts
@@ -1,0 +1,42 @@
+import { html } from "lit";
+import "../main";
+
+describe("layers", () => {
+  it("create wmts with tile grid", () => {
+    cy.intercept("*Request=GetTile*", {
+      fixture: "./map/test/fixtures/tiles/wms/eox_cloudless.jpeg",
+    });
+
+    const layer = {
+      type: "Tile",
+      properties: {
+        id: "customId",
+      },
+      source: {
+        type: "WMTS",
+        url: "https://tiles.maps.eox.at/wmts",
+        layer: "s2cloudless-2017_3857",
+        style: "default",
+        matrixSet: "GoogleMapsCompatible",
+        tileGrid: {
+          tileSize: [128, 128],
+        },
+      },
+    };
+
+    cy.mount(html`<eox-map .layers=${[layer]}></eox-map>`).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const layer = (<EOxMap>$el[0]).map
+        .getLayers()
+        .getArray()[0] as import("../src/generate").AnyLayerWithSource;
+      expect(layer).to.exist;
+      expect(layer.get("id")).to.be.equal("customId");
+
+      const source = layer.getSource() as import("ol/source/WMTS").default;
+      expect(
+        source.getTileGrid().getTileSize(0),
+        "use tileGrid options"
+      ).to.be.deep.equal([128, 128]);
+    });
+  });
+});


### PR DESCRIPTION
## Implemented changes

This PR brings the possibility to defined tile grids for WMTS sources as well as projections for sources, which could be relevant in this context.

To keep it simple, WMTS tile grid generation has been simplified to the bare minimum. Resolutions are created for all zoom levels, extent has to be defined on the layer level. XYZ tilegrid generation remains unchanged.

For now, this has only been tested for 3857 data, though other projections should work, as long as the projection is registered on the map.

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
