### PR TITLE
fix: order of format, layer and source spread

### DIFF
--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -152,18 +152,18 @@ export function createLayer(
   layer = JSON.parse(JSON.stringify(layer));
 
   const availableFormats = {
-    ...basicOlFormats,
     ...window.eoxMapAdvancedOlFormats,
+    ...basicOlFormats,
   };
 
   const availableLayers = {
-    ...basicOlLayers,
     ...window.eoxMapAdvancedOlLayers,
+    ...basicOlLayers,
   };
 
   const availableSources = {
-    ...basicOlSources,
     ...window.eoxMapAdvancedOlSources,
+    ...basicOlSources,
   };
 
   const newLayer = availableLayers[layer.type];


### PR DESCRIPTION
## Implemented changes

This PR changes the order of spreading the formats, layers and sources from the "advanced" plugin to happen first, and then the basic ones afterwards, as there were some issues that the internal ones were modified but then overwritten by the plugin ones.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
