### PR TITLE
fix: add support for exclusive groups

### DIFF
--- a/elements/layercontrol/src/methods/layer/input-click.js
+++ b/elements/layercontrol/src/methods/layer/input-click.js
@@ -15,10 +15,9 @@ const inputClickMethod = (evt, EOxLayerControlLayer) => {
     /**
      * @type NodeListOf<Element & {layer: any, requestUpdate: function}>
      */
-    const siblings =
-      EOxLayerControlLayer.parentNode.parentNode.querySelectorAll(
-        "li > eox-layercontrol-layer"
-      );
+    const siblings = EOxLayerControlLayer.closest(
+      ".layers > ul"
+    ).querySelectorAll("eox-layercontrol-layer");
 
     // Loop through the sibling layers to handle exclusive visibility.
     siblings.forEach((sibling) => {

--- a/elements/layercontrol/test/cases/general/exclusive-layers.js
+++ b/elements/layercontrol/test/cases/general/exclusive-layers.js
@@ -1,0 +1,35 @@
+// Function to simulate exclusive layers and groups within the LayerControl
+const exclusiveLayers = () => {
+  // Set up the layers in the mock map
+  cy.get("mock-map").then(($el) => {
+    const mockMap = $el[0]; // Accessing the mock map element
+
+    // Setting layers and a group with layerControlExclusive
+    mockMap.setLayers([
+      { properties: { id: "a", layerControlExclusive: true }, visible: true },
+      { properties: { id: "b", layerControlExclusive: true }, visible: false },
+      {
+        type: "Group",
+        properties: {
+          id: "c",
+          layerControlExclusive: true,
+          layerControlExpand: true,
+        },
+        layers: [{ properties: { id: "d", visible: true } }],
+        visible: false,
+      },
+    ]);
+  });
+
+  // Verify the effect on the LayerControl
+  cy.get("eox-layercontrol")
+    .shadow()
+    .within(() => {
+      // Checking the number of checked radio inputs in the LayerControl
+      cy.get("ul").find("input[type=radio]:checked").should("have.length", 1);
+      cy.get("ul").find("input[type=radio]:not(:checked)").last().click();
+      cy.get("ul").find("input[type=radio]:checked").should("have.length", 1);
+    });
+};
+
+export default exclusiveLayers;

--- a/elements/layercontrol/test/cases/general/index.js
+++ b/elements/layercontrol/test/cases/general/index.js
@@ -2,6 +2,7 @@ export { default as checkLayerSize } from "./check-layer-size";
 export { default as checkPreOpenLayerTools } from "./check-pre-open-layer-tools";
 export { default as checkPreOpenSection } from "./check-pre-open-section";
 export { default as disableDrag } from "./disable-drag";
+export { default as exclusiveLayers } from "./exclusive-layers";
 export { default as hideLayers } from "./hide-layers";
 export { default as emptyGroup } from "./empty-groups";
 export { default as renderOptionalLayer } from "./render-optional-layer";

--- a/elements/layercontrol/test/general.cy.js
+++ b/elements/layercontrol/test/general.cy.js
@@ -6,6 +6,7 @@ import {
   checkPreOpenLayerTools,
   checkPreOpenSection,
   disableDrag,
+  exclusiveLayers,
   hideLayers,
   emptyGroup,
   renderOptionalLayer,
@@ -30,6 +31,9 @@ describe("LayerControl", () => {
 
   // Test to validate the hiding of layers
   it("hides layers correctly", () => hideLayers());
+
+  // Test to verify that layers with `layerContorlExclusive` are shown/hidden exclusively
+  it("supports exclusive layers", () => exclusiveLayers());
 
   // Test if groups with no layers are shown as not expandable
   it("shows groups with no layers as not expandable", () => emptyGroup());


### PR DESCRIPTION
## Implemented changes
This includes layer groups in the exclusive layer visibility check; it allows to mix layers and groups and have all of them exclusive (by setting teh `layerControlExclusive` property).

## Screenshots/Videos

![image](https://github.com/EOX-A/EOxElements/assets/26576876/2eb2ab6a-27cb-4966-8710-3c100a587736)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
