### PR TITLE
Chore: Create dev release action

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,55 @@
+name: Create dev release
+
+on:
+ workflow_dispatch:
+     inputs:
+       branch_name:
+         description: 'name of the branch to be released'
+         required: true
+         type: string
+       element:
+           description: 'name of the element to be released'
+           required: true
+           type: string
+       preid:
+           description: 'optional postfix of the released version, defaults to "dev"'
+           required: false
+           default: dev
+           type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:  
+      - name: Release Please! 🤖
+        uses: google-github-actions/release-please-action@v4
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+         ref: ${{ inputs.branch_name }}
+        # these if statements ensure that a publication only occurs when
+        # a new release is created:
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
+      - name: Set up NPM 🔧
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
+      - name: Install dependencies 🔧
+        run: npm ci
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
+      - name: Build and publish package 🚀
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          ELEMENT_DIR: ${{ steps.release.outputs.paths_released }}
+        run: |
+          npm run styles && \
+          cd `echo ${ELEMENT_DIR} | tr -d '[]"'` && \
+          npm run build && \
+          npm version prerelease --preid ${{ inputs.preid }} && \
+          npm publish --access=public
+        if: ${{ fromJSON(steps.release.outputs.releases_created) }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,7 +21,7 @@ permissions:
   contents: write
 
 jobs:
-  release-please:
+  dev-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,21 +1,21 @@
 name: Create dev release
 
 on:
- workflow_dispatch:
-     inputs:
-       branch_name:
-         description: 'name of the branch to be released'
-         required: true
-         type: string
-       element:
-           description: 'name of the element to be released'
-           required: true
-           type: string
-       preid:
-           description: 'optional postfix of the released version, defaults to "dev"'
-           required: false
-           default: dev
-           type: string
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "name of the branch to be released"
+        required: true
+        type: string
+      element:
+        description: "name of the element to be released"
+        required: true
+        type: string
+      preid:
+        description: 'optional postfix of the released version, defaults to "dev"'
+        required: false
+        default: dev
+        type: string
 
 permissions:
   contents: write
@@ -23,13 +23,13 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    steps:  
+    steps:
       - name: Release Please! 🤖
         uses: google-github-actions/release-please-action@v4
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:
-         ref: ${{ inputs.branch_name }}
+          ref: ${{ inputs.branch_name }}
         # these if statements ensure that a publication only occurs when
         # a new release is created:
         if: ${{ fromJSON(steps.release.outputs.releases_created) }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       element:
-        description: "name of the element to be released"
+        description: "name of the element folder to be released"
         required: true
         type: string
       preid:
@@ -24,32 +24,24 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Release Please! 🤖
-        uses: google-github-actions/release-please-action@v4
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch_name }}
-        # these if statements ensure that a publication only occurs when
-        # a new release is created:
-        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
       - name: Set up NPM 🔧
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
-        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
       - name: Install dependencies 🔧
         run: npm ci
-        if: ${{ fromJSON(steps.release.outputs.releases_created) }}
       - name: Build and publish package 🚀
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          ELEMENT_DIR: ${{ steps.release.outputs.paths_released }}
+          ELEMENT_DIR: ${{ inputs.element }}
         run: |
           npm run styles && \
           cd `echo ${ELEMENT_DIR} | tr -d '[]"'` && \
           npm run build && \
           npm version prerelease --preid ${{ inputs.preid }} && \
           npm publish --access=public
-        if: ${{ fromJSON(steps.release.outputs.releases_created) }}


### PR DESCRIPTION
## Implemented changes
Created a dev release github action that can be triggered manually and takes an input of the branch name to be deployed and an optional postfix of the released version that defaults to `dev`. This implementation has not been tested yet; [the workflow must be in default branch of the repo to be triggered](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch).

Related to #530. 

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
