### PR TITLE
Fix: unmanaged Styles

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -213,6 +213,16 @@ export class EOxMap extends LitElement {
           )
         ) {
           const layerToBeRemoved = getLayerById(this, l.properties?.id);
+          const jsonDefinition = layerToBeRemoved.get("_jsonDefinition");
+          jsonDefinition.interactions?.forEach(
+            (interaction: import("./src/generate").EOxInteraction) => {
+              if (interaction.type === "select") {
+                this.removeSelect(interaction.options.id);
+              } else {
+                this.removeInteraction(interaction.options.id);
+              }
+            }
+          );
           this.map.removeLayer(layerToBeRemoved);
         }
       });

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -498,7 +498,7 @@ export class EOxMap extends LitElement {
    * Removes a given EOxSelectInteraction from the map.
    * @param id id of the interaction
    */
-  removeSelect = (id: string) => {
+  removeSelect = (id: string | number) => {
     this.selectInteractions[id].remove();
     delete this.selectInteractions[id];
   };

--- a/elements/map/src/select.ts
+++ b/elements/map/src/select.ts
@@ -37,7 +37,6 @@ export class EOxSelectInteraction {
   selectLayer: SelectLayer;
   selectStyleLayer: SelectLayer;
   changeSourceListener: () => void;
-  removeListener: () => void;
 
   constructor(
     eoxMap: EOxMap,
@@ -167,7 +166,6 @@ export class EOxSelectInteraction {
           const newSelectFids = feature ? [this.getId(feature)] : [];
           const idChanged = this.selectedFids[0] !== newSelectFids[0];
           this.selectedFids = newSelectFids;
-
           if (idChanged) {
             this.selectStyleLayer.changed();
             if (feature) panIntoFeature(feature);
@@ -215,18 +213,19 @@ export class EOxSelectInteraction {
 
     this.selectLayer.on("change:source", this.changeSourceListener);
 
-    this.removeListener = () => {
-      //
-    };
-    this.eoxMap.map.getLayers().on("remove", this.removeListener);
-
-    const removeLayerListener = () => {
-      if (!eoxMap.getLayerById(selectLayer.get("id"))) {
-        eoxMap.selectInteractions[options.id].remove();
-        eoxMap.map.getLayerGroup().un("change", removeLayerListener);
+    const changeLayerListener = () => {
+      if (eoxMap.getLayerById(selectLayer.get("id"))) {
+        eoxMap.selectInteractions[options.id]?.setActive(true);
+        this.selectStyleLayer?.setMap(this.eoxMap.map);
+        overlay?.setMap(this.eoxMap.map);
+      } else {
+        // remove the baselayer and the interaction if vector layer is removed
+        eoxMap.selectInteractions[options.id]?.setActive(false);
+        this.selectStyleLayer?.setMap(null);
+        overlay?.setMap(null);
       }
     };
-    eoxMap.map.getLayerGroup().on("change", removeLayerListener);
+    eoxMap.map.getLayerGroup().on("change", changeLayerListener);
   }
 
   setActive(active: boolean) {
@@ -242,11 +241,14 @@ export class EOxSelectInteraction {
     this.selectStyleLayer.changed(); // force rerender to highlight selected fids
   }
 
+  /**
+   * removes this interaction and the connected unmanaged layer from the map
+   */
   remove() {
     this.selectStyleLayer.setMap(null);
     delete this.eoxMap.selectInteractions[this.options.id];
     this.selectLayer.un("change:source", this.changeSourceListener);
-    this.eoxMap.map.getLayers().un("remove", this.removeListener);
+    //this.eoxMap.map.getLayers().un("remove", this.removeListener);
   }
 
   /**

--- a/elements/map/test/hoverInteraction.cy.ts
+++ b/elements/map/test/hoverInteraction.cy.ts
@@ -41,4 +41,60 @@ describe("select interaction with hover", () => {
       });
     });
   });
+
+  it("working selection after re-arranging layers", () => {
+    cy.intercept(/^.*openstreetmap.*$/, {
+      fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
+    });
+    cy.intercept(
+      "https://openlayers.org/data/vector/ecoregions.json",
+      (req) => {
+        req.reply(ecoRegionsFixture);
+      }
+    );
+    (vectorLayerStyleJson as Array<import("../src/generate").EoxLayer>).push({
+      type: "Tile",
+      properties: {
+        id: "osm",
+      },
+      source: {
+        type: "OSM",
+      },
+    });
+
+    cy.mount(
+      html`<eox-map .layers=${vectorLayerStyleJson}>
+        <eox-map-tooltip></eox-map-tooltip>
+      </eox-map>`
+    ).as("eox-map");
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      let selectCounter = 0;
+      let featureSelectCounter = 0;
+      eoxMap.addEventListener("select", (evt) => {
+        selectCounter++;
+        // @ts-ignore
+        if (evt.detail.feature) {
+          featureSelectCounter++;
+        }
+        if (selectCounter === 3) {
+          // moving the cursor to a feature, moving it off the feature, and onto the feature again
+          expect(featureSelectCounter).to.be.equal(2);
+        }
+      });
+
+      eoxMap.map.on("loadend", () => {
+        const layers = eoxMap.map.getLayers();
+        let first = layers.getArray()[0];
+        layers.removeAt(0);
+        layers.insertAt(1, first);
+        first = layers.getArray()[0];
+        layers.removeAt(0);
+        layers.insertAt(1, first);
+        simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
+        simulateEvent(eoxMap.map, "pointermove", 0, -140); // no feature here
+        simulateEvent(eoxMap.map, "pointermove", 120, -140); // a feature here
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Implemented changes

This PR handles the issue described in  #587. The idea is that sorting the ol layers by removing and re-adding them will not actually remove the connected interactions.

@silvester-pari is this how the desired behaviour? 

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
