### PR TITLE
fix: height of compare container

### DIFF
--- a/elements/map/src/compare.ts
+++ b/elements/map/src/compare.ts
@@ -21,6 +21,7 @@ export class EOxMapCompare extends TemplateElement {
           --thumb-w: 0.2rem;
 
           position: relative;
+          height: 100%;
         }
         .eox-map-compare::after {
           content: "";

--- a/elements/map/src/compare.ts
+++ b/elements/map/src/compare.ts
@@ -26,7 +26,6 @@ export class EOxMapCompare extends TemplateElement {
         .eox-map-compare::after {
           content: "";
           display: block;
-          padding-bottom: 50%;
         }
         .eox-map-compare__first,
         .eox-map-compare__second {


### PR DESCRIPTION
## Implemented changes

This PR fixes the height of the comparison container, so it only takes up the space of the map(s).

## Screenshots/Videos
### Before:

![image](https://github.com/user-attachments/assets/b06a06ce-8c0f-4465-bfc6-0ef00fbb6dcd)


### After:

![image](https://github.com/user-attachments/assets/b34c8dfe-3b30-49af-94c6-f1c45a92101f)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
