### PR TITLE
feat: enable/disable compare

### DIFF
--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -512,6 +512,9 @@ export const TooltipWithPropertyTransform = {
   `,
 };
 
+/**
+ * Sync the views of two maps using the `sync` attribute (e.g. `sync="eox-map#a"`).
+ */
 export const MapSync = {
   args: {
     layers: [
@@ -543,6 +546,14 @@ export const MapSync = {
   `,
 };
 
+/**
+ * To compare two maps, wrap them in an `<eox-map-compare>` element and assign them to the slot `first` and `second`.
+ * Also use the `sync` attribute so both move their view together.
+ *
+ * `eox-map-compare` also takes a `value` property (0 - 100) which determines the position of the comparison slider;
+ * and an `enabled` attribute, which can be either `"first"` (only left map visible), `"second"` (only second map visible)
+ * or `undefined` (default, both visible).
+ */
 export const ABCompare = {
   args: {
     layersA: [{ type: "Tile", source: { type: "OSM" } }],

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -575,6 +575,14 @@ export const ABCompare = {
         .layers=${args.layersB}
       ></eox-map>
     </eox-map-compare>
+    <button
+      @click=${() => {
+        const compareContainer = document.querySelector("eox-map-compare");
+        compareContainer.disabled = !compareContainer.disabled;
+      }}
+    >
+      toggle
+    </button>
   `,
 };
 

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -576,12 +576,26 @@ export const ABCompare = {
       ></eox-map>
     </eox-map-compare>
     <button
-      @click=${() => {
-        const compareContainer = document.querySelector("eox-map-compare");
-        compareContainer.disabled = !compareContainer.disabled;
-      }}
+      @click=${() =>
+        document
+          .querySelector("eox-map-compare")
+          .setAttribute("enabled", "first")}
     >
-      toggle
+      First
+    </button>
+    <button
+      @click=${() =>
+        document
+          .querySelector("eox-map-compare")
+          .setAttribute("enabled", "second")}
+    >
+      Second
+    </button>
+    <button
+      @click=${() =>
+        document.querySelector("eox-map-compare").removeAttribute("enabled")}
+    >
+      Both (default)
     </button>
   `,
 };

--- a/elements/map/src/compare.ts
+++ b/elements/map/src/compare.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { when } from "lit/directives/when.js";
 import { property } from "lit/decorators.js";
 import { TemplateElement } from "../../../utils/templateElement";
 
@@ -8,6 +9,9 @@ type HTMLElementEvent<T extends HTMLElement> = Event & {
 export class EOxMapCompare extends TemplateElement {
   @property()
   value = 50;
+
+  @property()
+  disabled = true;
 
   render() {
     return html`
@@ -101,23 +105,29 @@ export class EOxMapCompare extends TemplateElement {
           appearance: none;
         }
       </style>
-      <div class="eox-map-compare">
-        <div class="eox-map-compare__first">
-          <slot name="first"></slot>
-        </div>
-        <div class="eox-map-compare__second">
-          <slot name="second"></slot>
-        </div>
-        <input
-          type="range"
-          class="eox-map-compare__range"
-          min="0"
-          max="100"
-          value=${this.value}
-          @input=${(evt: HTMLElementEvent<HTMLInputElement>) =>
-            (this.value = parseInt(evt.target.value))}
-        />
-      </div>
+      ${when(
+        this.disabled,
+        () => html` <slot name="first"></slot> `,
+        () => html`
+          <div class="eox-map-compare">
+            <div class="eox-map-compare__first">
+              <slot name="first"></slot>
+            </div>
+            <div class="eox-map-compare__second">
+              <slot name="second"></slot>
+            </div>
+            <input
+              type="range"
+              class="eox-map-compare__range"
+              min="0"
+              max="100"
+              value=${this.value}
+              @input=${(evt: HTMLElementEvent<HTMLInputElement>) =>
+                (this.value = parseInt(evt.target.value))}
+            />
+          </div>
+        `
+      )}
     `;
   }
 }

--- a/elements/map/src/compare.ts
+++ b/elements/map/src/compare.ts
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { when } from "lit/directives/when.js";
+import { choose } from "lit/directives/choose.js";
 import { property } from "lit/decorators.js";
 import { TemplateElement } from "../../../utils/templateElement";
 
@@ -10,8 +10,8 @@ export class EOxMapCompare extends TemplateElement {
   @property()
   value = 50;
 
-  @property()
-  disabled = true;
+  @property({ type: String })
+  enabled = "true";
 
   render() {
     return html`
@@ -105,9 +105,12 @@ export class EOxMapCompare extends TemplateElement {
           appearance: none;
         }
       </style>
-      ${when(
-        this.disabled,
-        () => html` <slot name="first"></slot> `,
+      ${choose(
+        this.enabled,
+        [
+          ["first", () => html`<slot name="first"></slot>`],
+          ["second", () => html`<slot name="second"></slot>`],
+        ],
         () => html`
           <div class="eox-map-compare">
             <div class="eox-map-compare__first">

--- a/elements/map/test/compare.cy.ts
+++ b/elements/map/test/compare.cy.ts
@@ -1,0 +1,91 @@
+import { html } from "lit";
+import "../main";
+import imageWmsLayerStyleJson from "./imageWmsLayer.json";
+
+describe("comparison", () => {
+  beforeEach(() => {
+    cy.intercept(/^.*openstreetmap.*$/, {
+      fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
+    });
+    cy.intercept(/^.*geoserver.*$/, {
+      fixture: "./map/test/fixtures/tiles/wms/wms0.png",
+    });
+  });
+  it("allows shows two maps", () => {
+    cy.mount(
+      html` <eox-map-compare style="height: 300px">
+        <eox-map
+          slot="first"
+          .layers=${[
+            {
+              type: "Tile",
+              properties: { id: "osm" },
+              source: { type: "OSM" },
+            },
+          ]}
+          style="height: 300px"
+        ></eox-map>
+        <eox-map
+          slot="second"
+          sync="eox-map[slot=first]"
+          .layers=${imageWmsLayerStyleJson}
+          style="height: 300px"
+        ></eox-map>
+      </eox-map-compare>`
+    ).as("eox-map-compare");
+    cy.get("eox-map[slot=first]").should("be.visible");
+    cy.get("eox-map[slot=second]").should("be.visible");
+  });
+  it("shows only the first map", () => {
+    cy.mount(
+      html` <eox-map-compare enabled="first" style="height: 300px">
+        <eox-map
+          slot="first"
+          .layers=${[
+            {
+              type: "Tile",
+              properties: { id: "osm" },
+              source: { type: "OSM" },
+            },
+          ]}
+          style="height: 300px"
+        ></eox-map>
+        <eox-map
+          slot="second"
+          sync="eox-map[slot=first]"
+          .layers=${imageWmsLayerStyleJson}
+          style="height: 300px"
+        ></eox-map>
+      </eox-map-compare>`
+    ).as("eox-map-compare");
+    cy.get("eox-map[slot=first]").should("be.visible");
+    cy.get("eox-map[slot=second]").should("not.be.visible");
+    cy.get("eox-map[slot=second]").should("exist");
+  });
+  it("shows only the second map", () => {
+    cy.mount(
+      html` <eox-map-compare enabled="second" style="height: 300px">
+        <eox-map
+          slot="first"
+          .layers=${[
+            {
+              type: "Tile",
+              properties: { id: "osm" },
+              source: { type: "OSM" },
+            },
+          ]}
+          style="height: 300px"
+        ></eox-map>
+        <eox-map
+          slot="second"
+          sync="eox-map[slot=first]"
+          .layers=${imageWmsLayerStyleJson}
+          style="height: 300px"
+        ></eox-map>
+      </eox-map-compare>`
+    ).as("eox-map-compare");
+    cy.get("eox-map[slot=first]").should("not.be.visible");
+    cy.get("eox-map[slot=first]").should("exist");
+    cy.get("eox-map[slot=second]").should("be.visible");
+  });
+});


### PR DESCRIPTION
## Implemented changes

This PR adds a new functionality to the `eox-map-compare` and allows to toggle the comparison mode via the new `enabled` attribute:
- `enabled="first"` only shows the first map
- `enabled="second"` only shows the second map
- `enabled` (`undefined` or any other truthy value; default) shows both maps

This effectively allows enabling/disabling the comparison in a flexible way.

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
