### PR TITLE
feat: allow passing an eox-map DOM element to `sync` property

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -399,11 +399,32 @@ export class EOxMap extends LitElement {
     }
   }
 
+  private _sync: string | EOxMap | undefined;
   /**
-   * Sync map with another map view by providing its query selector
+   * Sync map with another map view by providing its query selector or an eox-map DOM element
    */
   @property()
-  sync: string;
+  set sync(sync: string | EOxMap | undefined) {
+    this._sync = sync;
+    if (sync) {
+      let originMap: EOxMap;
+      // Wait for next render tick
+      setTimeout(() => {
+        if (typeof sync === "string") {
+          originMap = document.querySelector(sync);
+        } else {
+          originMap = sync;
+        }
+        if (originMap) {
+          this.map.setView(originMap.map.getView());
+        }
+      });
+    }
+  }
+
+  get sync() {
+    return this._sync;
+  }
 
   /**
    * The native OpenLayers map object.
@@ -590,13 +611,6 @@ export class EOxMap extends LitElement {
   }
 
   firstUpdated() {
-    if (this.sync) {
-      const originMap: EOxMap = document.querySelector(this.sync);
-      if (originMap) {
-        this.map.setView(originMap.map.getView());
-      }
-    }
-
     this.map.once("change:target", (e) => {
       // set center again after target, as y-coordinate might be 0 otherwise
       e.target.getView().setCenter(this.center);

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -40,6 +40,7 @@ import {
   get as getProjection,
 } from "ol/proj";
 import { Coordinate } from "ol/coordinate";
+import { getElement } from "../../utils";
 
 type EOxAnimationOptions = import("ol/View").AnimationOptions &
   import("ol/View").FitOptions;
@@ -407,14 +408,9 @@ export class EOxMap extends LitElement {
   set sync(sync: string | EOxMap | undefined) {
     this._sync = sync;
     if (sync) {
-      let originMap: EOxMap;
       // Wait for next render tick
       setTimeout(() => {
-        if (typeof sync === "string") {
-          originMap = document.querySelector(sync);
-        } else {
-          originMap = sync;
-        }
+        const originMap = getElement(sync) as EOxMap;
         if (originMap) {
           this.map.setView(originMap.map.getView());
         }

--- a/elements/map/test/sync.cy.ts
+++ b/elements/map/test/sync.cy.ts
@@ -19,4 +19,21 @@ describe("map syncing", () => {
       expect(olMapView.getCenter()).to.deep.eq(center);
     });
   });
+  it("supports passing an eox-map to the sync property", () => {
+    const zoom = 7;
+    const center = [10, 10];
+    cy.mount(html`<eox-map id="a"></eox-map> <eox-map id="b"></eox-map>`);
+    cy.get("eox-map#a").and(($el) => {
+      const olMapView = (<EOxMap>$el[0]).map.getView();
+      olMapView.setZoom(zoom);
+      olMapView.setCenter(center);
+    });
+    cy.get("eox-map#b").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.sync = <EOxMap>document.querySelector("eox-map#a");
+      const olMapView = eoxMap.map.getView();
+      expect(olMapView.getZoom()).to.be.equal(zoom);
+      expect(olMapView.getCenter()).to.deep.eq(center);
+    });
+  });
 });

--- a/elements/map/tsconfig.json
+++ b/elements/map/tsconfig.json
@@ -15,7 +15,8 @@
     "noImplicitReturns": true,
     "skipLibCheck": true,
     "experimentalDecorators": true,
-    "types": ["cypress"]
+    "types": ["cypress"],
+    "allowJs": true
   },
   "include": ["**/*.ts", "../../cypress/cypress.d.ts"]
 }

--- a/utils/getElement.js
+++ b/utils/getElement.js
@@ -1,0 +1,15 @@
+/**
+ * Return a DOM element from either a query selector or from directly passing a DOM element
+ *
+ * @param {string | HTMLElement | undefined} stringOrElement query selector string or DOM element
+ * @returns {HTMLElement | undefined} the DOM element
+ */
+export const getElement = (stringOrElement) => {
+  let domElement;
+  if (typeof stringOrElement === "string") {
+    domElement = document.querySelector(stringOrElement);
+  } else {
+    domElement = stringOrElement;
+  }
+  return domElement;
+};

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,1 @@
+export { getElement } from "./getElement";


### PR DESCRIPTION
## Implemented changes

This PR adds the functionality to pass an `eox-map` directly to the `sync` property. Previously it only took a `string` and internally did a `document.querySelector`, but if the `eox-map` is used within another shadow root, then this query selector didn't work.

Now there are two options:
- pass a `string` as attribute or property, e.g. `<eox-map sync="#other-map">`
- pass a DOM element as property, e.g. `eoxMapB.sync = document.querySelector("#other-map")` 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
