### PR TITLE
feat: allow passing an eox-map DOM element to `for` property 

### DIFF
--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -69,7 +69,7 @@ export class EOxLayerControl extends LitElement {
     /**
      * Query selector of an eox-map or another DOM element containing an OL map proeprty
      *
-     * @type {String}
+     * @type {String|HTMLElement}
      */
     this.for = "eox-map";
 

--- a/elements/layercontrol/src/methods/layercontrol/first-update.js
+++ b/elements/layercontrol/src/methods/layercontrol/first-update.js
@@ -1,3 +1,5 @@
+import { getElement } from '../../../../../utils/getElement.js';
+
 /**
  * Retrieves the EOxMap element based on the provided selector in EOxLayerControl's 'for' property.
  * Updates the EOxLayerControl's map property based on the target element's map.
@@ -6,29 +8,15 @@
  * @returns {import("@eox/map/main").EOxMap | null} The EOxMap element or null if not found.
  */
 const firstUpdatedMethod = (EOxLayerControl) => {
-  const map = EOxLayerControl.for;
-  console.log(map);
+  const mapElement = getElement(EOxLayerControl.for);
 
-  if (map instanceof HTMLElement) {
-    // The provided `for` property is an `eox-map` element.
-    EOxLayerControl.map = map.map;
-
-    return map;
-  } else {
-    // The `for` property is a string selector targeting an `eox-map` element.
-
-    // Find the element specified in EOxLayerControl.for
-    /** * @type {Element & { map: import("ol").Map }} */
-    const foundElement = document.querySelector(map);
-
-    // Check if the element exists and its map property differs from EOxLayerControl.map
-    if (foundElement && foundElement.map !== EOxLayerControl.map) {
-      // Update the EOxLayerControl's map property
-      EOxLayerControl.map = foundElement.map;
-    }
-
-    return foundElement;
+  // Check if the element exists and its map property differs from EOxLayerControl.map
+  if (mapElement && mapElement.map !== EOxLayerControl.map) {
+    // Update the EOxLayerControl's map property
+    EOxLayerControl.map = mapElement.map;
   }
+
+  return mapElement.map;
 };
 
 export default firstUpdatedMethod;

--- a/elements/layercontrol/src/methods/layercontrol/first-update.js
+++ b/elements/layercontrol/src/methods/layercontrol/first-update.js
@@ -16,7 +16,7 @@ const firstUpdatedMethod = (EOxLayerControl) => {
     EOxLayerControl.map = foundElement.map;
   }
 
-  return foundElement.map;
+  return foundElement;
 };
 
 export default firstUpdatedMethod;

--- a/elements/layercontrol/src/methods/layercontrol/first-update.js
+++ b/elements/layercontrol/src/methods/layercontrol/first-update.js
@@ -1,4 +1,4 @@
-import { getElement } from '../../../../../utils/getElement.js';
+import { getElement } from '../../../../../utils';
 
 /**
  * Retrieves the EOxMap element based on the provided selector in EOxLayerControl's 'for' property.
@@ -8,15 +8,15 @@ import { getElement } from '../../../../../utils/getElement.js';
  * @returns {import("@eox/map/main").EOxMap | null} The EOxMap element or null if not found.
  */
 const firstUpdatedMethod = (EOxLayerControl) => {
-  const mapElement = getElement(EOxLayerControl.for);
+  const foundElement = getElement(EOxLayerControl.for);
 
   // Check if the element exists and its map property differs from EOxLayerControl.map
-  if (mapElement && mapElement.map !== EOxLayerControl.map) {
+  if (foundElement && foundElement.map !== EOxLayerControl.map) {
     // Update the EOxLayerControl's map property
-    EOxLayerControl.map = mapElement.map;
+    EOxLayerControl.map = foundElement.map;
   }
 
-  return mapElement.map;
+  return foundElement.map;
 };
 
 export default firstUpdatedMethod;

--- a/elements/layercontrol/src/methods/layercontrol/first-update.js
+++ b/elements/layercontrol/src/methods/layercontrol/first-update.js
@@ -1,4 +1,4 @@
-import { getElement } from '../../../../../utils';
+import { getElement } from "../../../../../utils";
 
 /**
  * Retrieves the EOxMap element based on the provided selector in EOxLayerControl's 'for' property.

--- a/elements/layercontrol/src/methods/layercontrol/first-update.js
+++ b/elements/layercontrol/src/methods/layercontrol/first-update.js
@@ -6,11 +6,36 @@
  * @returns {import("@eox/map/main").EOxMap | null} The EOxMap element or null if not found.
  */
 const firstUpdatedMethod = (EOxLayerControl) => {
-  const mapSelector = EOxLayerControl.for;
+  const map = EOxLayerControl.for;
+  console.log(map);
+
+  if (map instanceof HTMLElement) {
+    // The provided `for` property is an `eox-map` element.
+    console.log('got a html element');
+    console.log(map.map);
+    EOxLayerControl.map = map.map;
+
+    return map;
+  } else {
+    // The `for` property is a string selector targeting an `eox-map` element.
+    console.log('got a selector');
+
+    // Find the element specified in EOxLayerControl.for
+    /** * @type {Element & { map: import("ol").Map }} */
+    const foundElement = document.querySelector(map);
+
+    // Check if the element exists and its map property differs from EOxLayerControl.map
+    if (foundElement && foundElement.map !== EOxLayerControl.map) {
+      // Update the EOxLayerControl's map property
+      EOxLayerControl.map = foundElement.map;
+    }
+
+    return foundElement;
+  }
 
   // Find the element specified in EOxLayerControl.for
   /** * @type {Element & { map: import("ol").Map }} */
-  const foundElement = document.querySelector(mapSelector);
+  const foundElement = document.querySelector(map);
 
   // Check if the element exists and its map property differs from EOxLayerControl.map
   if (foundElement && foundElement.map !== EOxLayerControl.map) {

--- a/elements/layercontrol/src/methods/layercontrol/first-update.js
+++ b/elements/layercontrol/src/methods/layercontrol/first-update.js
@@ -11,14 +11,11 @@ const firstUpdatedMethod = (EOxLayerControl) => {
 
   if (map instanceof HTMLElement) {
     // The provided `for` property is an `eox-map` element.
-    console.log('got a html element');
-    console.log(map.map);
     EOxLayerControl.map = map.map;
 
     return map;
   } else {
     // The `for` property is a string selector targeting an `eox-map` element.
-    console.log('got a selector');
 
     // Find the element specified in EOxLayerControl.for
     /** * @type {Element & { map: import("ol").Map }} */
@@ -32,18 +29,6 @@ const firstUpdatedMethod = (EOxLayerControl) => {
 
     return foundElement;
   }
-
-  // Find the element specified in EOxLayerControl.for
-  /** * @type {Element & { map: import("ol").Map }} */
-  const foundElement = document.querySelector(map);
-
-  // Check if the element exists and its map property differs from EOxLayerControl.map
-  if (foundElement && foundElement.map !== EOxLayerControl.map) {
-    // Update the EOxLayerControl's map property
-    EOxLayerControl.map = foundElement.map;
-  }
-
-  return foundElement;
 };
 
 export default firstUpdatedMethod;


### PR DESCRIPTION
## Implemented changes

Enables the Layer Control to take both string selectors and HTML elements in its `for` attribute thanks to Silvester's new `getElement` function.

<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
