### PR TITLE
chore: pin node version to current LTS (20.15.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "storybook": "^8.0.0"
       },
       "engines": {
-        "node": ">=20.9.0"
+        "node": "20.15.1"
       }
     },
     "elements/chart": {
@@ -159,8 +159,8 @@
       },
       "devDependencies": {
         "@eox/eslint-config": "^1.0.0",
-        "@eox/jsonform": "*",
-        "@eox/map": "*",
+        "@eox/jsonform": "latest",
+        "@eox/map": "latest",
         "@types/sortablejs": "^1.15.1",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -215,7 +215,7 @@
     },
     "elements/map": {
       "name": "@eox/map",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "dependencies": {
         "lit": "^3.0.2",
         "ol": "^9.2.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "storybook": "^8.0.0"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": "20.15.1"
   },
   "dependencies": {
     "eslint-plugin-cypress": "^3.0.2",


### PR DESCRIPTION
## Implemented changes

Pins the required Node version  to current LTS (`20.15.1`)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
