### PR TITLE
feat: improved list style

### DIFF
--- a/elements/itemfilter/src/components/filters/selector.js
+++ b/elements/itemfilter/src/components/filters/selector.js
@@ -217,9 +217,6 @@ export class EOxSelector extends LitElement {
               <li
                 data-identifier="${suggestion.toString().toLowerCase()}"
                 data-title="${suggestion}"
-                class="${this.selectedItems.includes(suggestion)
-                  ? "highlight-item"
-                  : ""}"
               >
                 <label>
                   <input

--- a/elements/itemfilter/src/enums/config.js
+++ b/elements/itemfilter/src/enums/config.js
@@ -51,9 +51,19 @@ export const ELEMENT_CONFIG = Object.freeze({
   showResults: true,
 
   /**
+   * Unique id property of items
+   */
+  idProperty: "id",
+
+  /**
    * The property of the result items used for display
    */
   titleProperty: "title",
+
+  /**
+   * The property of the result items used for a subtitle
+   */
+  subTitleProperty: undefined,
 
   /**
    * Allow opening multiple filter accordions in parallel

--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -188,7 +188,7 @@ export class EOxItemFilter extends TemplateElement {
     };
     this.#items =
       this.items?.map((i, index) =>
-        Object.assign({ id: `item-${index}` }, i)
+        Object.assign({ id: i[this.config.idProperty] || `item-${index}` }, i)
       ) || [];
     this.apply();
   }

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -57,8 +57,8 @@ export function createItemListMethod(
   const config = EOxItemFilterResults.config;
 
   const className = (item) =>
-    EOxItemFilterResults.selectedResult?.[config.titleProperty] ===
-    item[config.titleProperty]
+    EOxItemFilterResults.selectedResult?.[config.idProperty] ===
+    item[config.idProperty]
       ? "highlighted"
       : nothing;
 
@@ -69,25 +69,21 @@ export function createItemListMethod(
         (item) => item.id,
         (item) => html`
           <li class=${className(item)}>
-            <label>
-              <input
-                data-cy="result-radio"
-                type="radio"
-                class="result-radio"
-                name="result"
-                id="${item.id}"
-                ?checked=${EOxItemFilterResults.selectedResult?.[
-                  config.titleProperty
-                ] === item[config.titleProperty] || nothing}
-                @click=${() => {
+            <span
+              id="${item.id}"
+              @click=${() => {
+                if (EOxItemFilterResults.selectedResult === item) {
+                  EOxItemFilterResults.selectedResult = null;
+                } else {
                   EOxItemFilterResults.selectedResult = item;
-                  EOxItemFilterResults.dispatchEvent(
-                    new CustomEvent("result", {
-                      detail: item,
-                    })
-                  );
-                }}
-              />
+                }
+                EOxItemFilterResults.dispatchEvent(
+                  new CustomEvent("result", {
+                    detail: EOxItemFilterResults.selectedResult,
+                  })
+                );
+              }}
+            >
               ${when(
                 EOxItemFilterResults.hasTemplate("result"),
                 () =>
@@ -97,12 +93,27 @@ export function createItemListMethod(
                     `result-${item.id}`
                   ),
                 () => html`
-                  <span class="title"
-                    >${unsafeHTML(item[config.titleProperty])}</span
-                  >
+                  ${when(
+                    config.subTitleProperty,
+                    () => html`
+                      <div class="title-container">
+                        <span class="title"
+                          >${unsafeHTML(item[config.titleProperty])}</span
+                        >
+                        <span class="subtitle"
+                          >${unsafeHTML(item[config.subTitleProperty])}</span
+                        >
+                      </div>
+                    `,
+                    () => html`
+                      <span class="title"
+                        >${unsafeHTML(item[config.titleProperty])}</span
+                      >
+                    `
+                  )}
                 `
               )}
-            </label>
+            </span>
           </li>
         `
       )}

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -55,9 +55,18 @@ details > summary::-webkit-details-marker {
 }
 
 .title {
-  font-size: small;
+  font-size: 13px;
   align-items: center;
   text-transform: capitalize;
+}
+.subtitle {
+  font-size: 11px;
+  opacity: .7;
+  margin-top: 6px;
+}
+.title-container {
+  display: flex;
+  flex-direction: column;
 }
 h6.main-heading {
   font-size: 1rem;
@@ -127,7 +136,7 @@ section:not(section:last-of-type) {
   display: flex;
   flex-direction: column;
 }
-ul li {
+ul:not(#filters) > li {
   padding: 5px 10px;
 }
 section {

--- a/elements/itemfilter/stories/primary.js
+++ b/elements/itemfilter/stories/primary.js
@@ -12,6 +12,7 @@ function PrimaryStory() {
       config: {
         inlineMode: false,
         titleProperty: "title",
+        subTitleProperty: "description",
         aggregateResults: "themes",
         enableHighlighting: true,
         filterProperties: [

--- a/elements/itemfilter/test/cases/general/external-filter.js
+++ b/elements/itemfilter/test/cases/general/external-filter.js
@@ -29,7 +29,7 @@ const externalFilterTest = () => {
       cy.get("eox-itemfilter-results summary .title")
         .first()
         .contains(testItems[5].themes[0]);
-      cy.get("eox-itemfilter-results label .title")
+      cy.get("eox-itemfilter-results li .title")
         .first()
         .contains(testItems[5].title);
     });

--- a/elements/itemfilter/test/cases/general/index.js
+++ b/elements/itemfilter/test/cases/general/index.js
@@ -9,3 +9,4 @@ export { default as accordionTest } from "./accordion";
 export { default as spatialFilterTest } from "./spatial-filter";
 export { default as externalFilterTest } from "./external-filter";
 export { default as nestedPropertyTest } from "./nested-property";
+export { default as subtitleTest } from "./subtitle";

--- a/elements/itemfilter/test/cases/general/subtitle.js
+++ b/elements/itemfilter/test/cases/general/subtitle.js
@@ -1,0 +1,15 @@
+/**
+ * Tests the subtitle functionality. If the confif option `subTitleProperty` is set,
+ * then an additional subtitle is rendered.
+ */
+const subtitleTest = (testItems) => {
+  cy.get("eox-itemfilter")
+    .shadow()
+    .within(() => {
+      cy.get("eox-itemfilter-results").within(() => {
+        cy.get(".title").siblings(".subtitle").should("exist");
+      });
+    });
+};
+
+export default subtitleTest;

--- a/elements/itemfilter/test/cases/general/subtitle.js
+++ b/elements/itemfilter/test/cases/general/subtitle.js
@@ -2,7 +2,7 @@
  * Tests the subtitle functionality. If the confif option `subTitleProperty` is set,
  * then an additional subtitle is rendered.
  */
-const subtitleTest = (testItems) => {
+const subtitleTest = () => {
   cy.get("eox-itemfilter")
     .shadow()
     .within(() => {

--- a/elements/itemfilter/test/cases/state/result-pre-checked.js
+++ b/elements/itemfilter/test/cases/state/result-pre-checked.js
@@ -1,6 +1,6 @@
 /**
  * Tests that the specified result is pre-checked in the eox-itemfilter-results component.
- * It verifies that the radio button at the specified index is checked and that only one radio button is checked.
+ * It verifies that the result at the specified index is selected and that only one result is selected.
  *
  * @param {number} selectedResultIndex - The index of the result that should be pre-checked.
  */
@@ -9,10 +9,10 @@ const resultPreCheckedTest = (selectedResultIndex) => {
     .shadow()
     .within(() => {
       cy.get("eox-itemfilter-results").within(() => {
-        cy.get("input[data-cy=result-radio]")
+        cy.get(".details-results li")
           .eq(selectedResultIndex)
-          .should("be.checked");
-        cy.get("input[data-cy=result-radio][checked]").should("have.length", 1);
+          .should("have.class", "highlighted");
+        cy.get(".details-results li.highlighted").should("have.length", 1);
       });
     });
 };

--- a/elements/itemfilter/test/general.cy.js
+++ b/elements/itemfilter/test/general.cy.js
@@ -11,6 +11,7 @@ import {
   spatialFilterTest,
   externalFilterTest,
   nestedPropertyTest,
+  subtitleTest,
 } from "./cases/general/";
 
 /**
@@ -29,6 +30,7 @@ describe("Item Filter Config", () => {
         Object.assign(eoxItemFilter, {
           config: {
             titleProperty: "title",
+            subTitleProperty: "description",
             filterProperties: [
               {
                 keys: ["title", "themes"],
@@ -92,4 +94,9 @@ describe("Item Filter Config", () => {
    * Test case to check whether nested properties work or not
    */
   it("should run with nested property", () => nestedPropertyTest());
+
+  /**
+   * Test case to check if subtitles are rendered correctly
+   */
+  it.only("should render subtitles", () => subtitleTest(testItems));
 });

--- a/elements/itemfilter/test/general.cy.js
+++ b/elements/itemfilter/test/general.cy.js
@@ -98,5 +98,5 @@ describe("Item Filter Config", () => {
   /**
    * Test case to check if subtitles are rendered correctly
    */
-  it.only("should render subtitles", () => subtitleTest(testItems));
+  it.only("should render subtitles", () => subtitleTest());
 });

--- a/elements/itemfilter/test/state.cy.js
+++ b/elements/itemfilter/test/state.cy.js
@@ -33,6 +33,7 @@ describe("Item Filter Config", () => {
         const eoxItemFilter = $el[0];
         Object.assign(eoxItemFilter, {
           config: {
+            idProperty: "title",
             titleProperty: "title",
             filterProperties: [
               {


### PR DESCRIPTION
## Implemented changes

This PR introduces a new style for result lists:

- [x] removed radio input
- [x] deselectable results by default (https://github.com/EOX-A/EOxElements/issues/713)
- [x] `idProperty` analogous to `titleProperty` and highlighting checks based on that (see https://github.com/EOX-A/EOxElements/issues/835 - if an item is really rendered two times because it is aggregated in two lists, then both instances are highlighted)
- [x] optional `subTitle` property

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/51791a99-c8b1-48fd-9656-103533aa76c1)
![image](https://github.com/user-attachments/assets/b21acc8d-8567-4582-9925-2c8873a93b49)
![image](https://github.com/user-attachments/assets/348df919-0ca0-4630-be29-e5742b9c1493)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
