### PR TITLE
chore: allow node versions 20.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "storybook": "^8.0.0"
       },
       "engines": {
-        "node": "20.15.1"
+        "node": ">=20.0.0 <21.0.0"
       }
     },
     "elements/chart": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "storybook": "^8.0.0"
   },
   "engines": {
-    "node": "20.15.1"
+    "node": ">=20.0.0 <21.0.0"
   },
   "dependencies": {
     "eslint-plugin-cypress": "^3.0.2",


### PR DESCRIPTION
## Implemented changes

As it turns out, the changes made in https://github.com/EOX-A/EOxElements/pull/1108 where not a smart idea. Pinning the exact version caused some troubles, e.g. in the Netlify pipeline (which only allows to specify `20.x` and now started using the new LTS `20.16.0`. In order to not have to adjust each time a new LTS is specified, `20.x` should be more robust.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
