### PR TITLE
fix: layer update of group layers

### DIFF
--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -396,7 +396,7 @@ export function updateLayer(
     const layerCollection = (
       existingLayer as unknown as import("ol/layer/Group").default
     ).getLayers();
-    layerCollection.forEach((l: Layer) => {
+    layerCollection.getArray().forEach((l: Layer) => {
       if (!newLayerIds.includes(l.get("id"))) {
         layerCollection.remove(l);
       }

--- a/elements/map/test/groupLayer.cy.ts
+++ b/elements/map/test/groupLayer.cy.ts
@@ -315,5 +315,58 @@ describe("layers", () => {
         "correctly updates a layer inside group"
       ).to.be.equal(0.5);
     });
+
+    it("update tile layer inside group ", () => {
+      cy.intercept(/^.*s2maps-tiles.*$/, {
+        fixture: "./map/test/fixtures/tiles/wms/wms0.png",
+      });
+
+      let groupLayer = {
+        type: "Group",
+        properties: { id: "BASELAYERS", title: "Base Layers" },
+        layers: [
+          {
+            type: "Tile",
+            properties: {
+              id: "cloudless-2022",
+              name: "original layer",
+            },
+            source: {
+              type: "XYZ",
+              url: "//s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2022_3857/default/g/{z}/{y}/{x}.jpeg",
+            },
+          },
+        ],
+      };
+
+      cy.mount(html`<eox-map .layers=${[groupLayer]}></eox-map>`).as("eox-map");
+      cy.get("eox-map").and(($el) => {
+        const eoxMap = <EOxMap>$el[0];
+        groupLayer = {
+          type: "Group",
+          properties: { id: "BASELAYERS", title: "Base Layers" },
+          layers: [
+            {
+              type: "Tile",
+              properties: {
+                id: "cloudless-2022",
+                name: "updated layer",
+              },
+              source: {
+                type: "XYZ",
+                url: "//s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2022_3857/default/g/{z}/{y}/{x}.jpeg",
+              },
+            },
+          ],
+        };
+        eoxMap.layers = [groupLayer] as Array<EoxLayer>;
+        const layer = eoxMap.getLayerById("cloudless-2022");
+
+        expect(
+          layer.get("name"),
+          "update layer inside group in realistic setting (testing instanceof checks)"
+        ).to.be.equal("updated layer");
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR fixes a bug when updating layers inside layer groups.

Additionally, this PR adds another test to more realistically simulate real-world situations when working with groups. This test also detects failing `instanceof`-checks that occured in the past when multiple instances of `ol` are installed in the project.

connected to https://github.com/EOX-A/EOxElements/issues/975 

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
