### PR TITLE
Fix: enable timecontrol to have no map

### DIFF
--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -149,7 +149,7 @@ export class EOxTimeControl extends LitElement {
    */
   _updateStep(step = 1) {
     if (!step) {
-      return
+      return;
     }
 
     this._newStepIndex = this._newStepIndex + step;

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -156,9 +156,11 @@ export class EOxTimeControl extends LitElement {
       this._newStepIndex = this.controlValues.length - 1;
     }
 
-    this._controlSource?.updateParams({
-      [this.controlProperty]: this.controlValues[this._newStepIndex],
-    });
+    if (this.layer && this.for) {
+      this._controlSource?.updateParams({
+        [this.controlProperty]: this.controlValues[this._newStepIndex],
+      });
+    }
     this.requestUpdate();
 
     /**
@@ -204,29 +206,33 @@ export class EOxTimeControl extends LitElement {
   }
 
   render() {
-    const foundElement = /** @type {import('../../map/main').EOxMap} */ (
-      getElement(this.for)
-    );
-    const olMap = foundElement.map;
+    if (this.layer && this.for) {
+      const foundElement = /** @type {import('../../map/main').EOxMap} */ (
+        getElement(this.for)
+      );
 
-    olMap.once("loadend", () => {
-      if (!this._originalParams) {
-        const flatLayers = this.getFlatLayersArray(
-          /** @type {import('ol/layer/Base').default[]} */ (
-            olMap.getLayers().getArray()
-          )
-        );
-        const animationLayer = /** @type {import('ol/layer/Layer').default} */ (
-          flatLayers.find((l) => l.get("id") === this.layer)
-        );
-        this._controlSource =
-          /** @type {import('ol/source/TileWMS').default} */ (
-            animationLayer.getSource()
+      const olMap = foundElement.map;
+
+      olMap.once("loadend", () => {
+        if (!this._originalParams) {
+          const flatLayers = this.getFlatLayersArray(
+            /** @type {import('ol/layer/Base').default[]} */ (
+              olMap.getLayers().getArray()
+            )
           );
+          const animationLayer =
+            /** @type {import('ol/layer/Layer').default} */ (
+              flatLayers.find((l) => l.get("id") === this.layer)
+            );
+          this._controlSource =
+            /** @type {import('ol/source/TileWMS').default} */ (
+              animationLayer.getSource()
+            );
 
-        this._originalParams = this._controlSource.getParams();
-      }
-    });
+          this._originalParams = this._controlSource.getParams();
+        }
+      });
+    }
 
     return html`
       <style>

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -148,6 +148,10 @@ export class EOxTimeControl extends LitElement {
    * @private
    */
   _updateStep(step = 1) {
+    if (!step) {
+      return
+    }
+
     this._newStepIndex = this._newStepIndex + step;
     if (this._newStepIndex > this.controlValues.length - 1) {
       this._newStepIndex = 0;

--- a/elements/timecontrol/stories/index.js
+++ b/elements/timecontrol/stories/index.js
@@ -5,3 +5,4 @@ export { default as PrimaryStory } from "./primary"; // Primary story
 export { default as SliderStory } from "./slider"; // Slider story
 export { default as ProgrammaticTimeSelectionStory } from "./programmatic-time-selection"; // Programmatic time selection story
 export { default as DisabledPlayButtonStory } from "./disabled-play-button"; // Disabled play button story
+export { default as NoMapStory } from "./no-map"; // No map provided story

--- a/elements/timecontrol/stories/no-map.js
+++ b/elements/timecontrol/stories/no-map.js
@@ -1,0 +1,29 @@
+import { html } from "lit";
+import { DEFAULT_ARGS } from "../src/enums/stories";
+
+const NoMap = {
+  args: {
+    ...DEFAULT_ARGS,
+    disablePlay: true,
+    layer: undefined,
+    for: undefined,
+    controlProperty: undefined,
+    slider: true,
+    onStepChange: (evt) => {
+      console.log("stepchange", evt.detail);
+    },
+  },
+  render: (args) => html`
+    <eox-timecontrol
+      .for=${args.for}
+      .layer=${args.layer}
+      .controlProperty=${args.controlProperty}
+      .controlValues=${args.controlValues}
+      .slider=${args.slider}
+      .disablePlay=${args.disablePlay}
+      @stepchange=${args.onStepChange}
+    ></eox-timecontrol>
+  `,
+};
+
+export default NoMap;

--- a/elements/timecontrol/stories/timecontrol.stories.js
+++ b/elements/timecontrol/stories/timecontrol.stories.js
@@ -4,6 +4,7 @@ import {
   SliderStory,
   ProgrammaticTimeSelectionStory,
   DisabledPlayButtonStory,
+  NoMapStory,
 } from "./index";
 
 export default {
@@ -19,3 +20,5 @@ export const Slider = SliderStory;
 export const ProgrammaticTimeSelection = ProgrammaticTimeSelectionStory;
 
 export const DisabledPlayButton = DisabledPlayButtonStory;
+
+export const NoMap = NoMapStory;


### PR DESCRIPTION
## Implemented changes
This enables the timecontrol to have no map associated to it and fixes the issue of multiple events being triggered when the slider is displayed.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
