### PR TITLE
fix: issue of layer groups not removing all previous layers

### DIFF
--- a/elements/map/src/generate.ts
+++ b/elements/map/src/generate.ts
@@ -396,7 +396,12 @@ export function updateLayer(
     const layerCollection = (
       existingLayer as unknown as import("ol/layer/Group").default
     ).getLayers();
-    layerCollection.getArray().forEach((l: Layer) => {
+    // We can't remove the layers of a collection while iterating on it,
+    // this fails in removing all layers as expected.
+    // One solution is to create a shallow copy which we iterate
+    // in order to remove the layers from the actual layer collection
+    const layerArray = layerCollection.getArray().slice();
+    layerArray.forEach((l: Layer) => {
       if (!newLayerIds.includes(l.get("id"))) {
         layerCollection.remove(l);
       }


### PR DESCRIPTION
## Implemented changes

This PR attempts once more to fix the layer group update by creating a shallow copy before iteration, so that removing an item from the original array doesn't affect the logic negatively.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
