### PR TITLE
Fix: Closing editor was causing markdown getting reset

### DIFF
--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -275,7 +275,7 @@ export class EOxStoryTelling extends LitElement {
               .storyId=${this.id}
               show-editor=${this.showEditor}
               @change=${this.#debounceUpdateMarkdown}
-              }
+              .markdown=${this.markdown}
             ></eox-storytelling-editor>
           `
         )}


### PR DESCRIPTION
## Implemented changes
- missing `.markdown` property was causing the markdown to reset every time any user closes the editor.  

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
