### PR TITLE
fix(style): highlight on hover and primary color on select

### DIFF
--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -10,6 +10,7 @@ export const styleEOX = `
     var(--secondary-color) 30%,
     transparent
   );
+  --item-select-color: var(--primary-color);
   --inline-bg-color: color-mix(
     in srgb,
     var(--secondary-color) 10%,
@@ -377,10 +378,14 @@ button.icon {
   flex-wrap: nowrap;
   gap: 4px;
 }
-li.highlighted,
-.select-container li:hover,
-.highlight-item {
+.select li:hover,
+.multiselect li:hover,
+eox-itemfilter-results li:hover {
   background: var(--item-hover-color);
+}
+eox-itemfilter-results li.highlighted {
+  color: var(--background-color);
+  background: var(--item-select-color);
 }
 .selected-item span {
   margin-right: 8px;


### PR DESCRIPTION
## Implemented changes

This PR fixes the highlighting on hover for the result items and adds a visually more prominent highlighting for selected items (introducing a new CSS variable called `--item-select-color`).

## Screenshots/Videos

[Screencast from 2024-08-05 11:38:00.webm](https://github.com/user-attachments/assets/0e5b76f8-d975-4ac5-9075-fffabc742dcc)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
