### PR TITLE
feat: lonLatCenter & lonLatExtent

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -125,6 +125,29 @@ export class EOxMap extends LitElement {
     return this._center;
   }
 
+  /**
+   * current center of the view in EPSG:4326
+   */
+  get lonLatCenter() {
+    if (this.projection === "EPSG:4326") {
+      return this.map.getView().getCenter();
+    }
+    return transform(this.map.getView().getCenter(), this.projection);
+  }
+
+  /**
+   * current extent
+   */
+  get lonLatExtent() {
+    const currentExtent = this.map
+      .getView()
+      .calculateExtent(this.map.getSize());
+    if (this.projection === "EPSG:4326") {
+      return currentExtent;
+    }
+    return transformExtent(currentExtent, this.projection);
+  }
+
   private _zoom: number = 0;
 
   set zoom(zoom: number) {
@@ -143,7 +166,7 @@ export class EOxMap extends LitElement {
 
   private _zoomExtent: import("ol/extent").Extent;
   /**
-   * extent to zoom to
+   * extent to zoom to (debounced)
    * @type {import("ol/extent").Extent}
    */
   set zoomExtent(extent: import("ol/extent").Extent) {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -581,7 +581,6 @@ export class EOxMap extends LitElement {
    * @param vectorLayer - The vector layer to which the parsed features will be added.
    * @param replaceFeatures - A boolean flag indicating whether to replace the existing features in the vector layer.
    */
-
   parseTextToFeature = (
     text: string,
     vectorLayer: VectorLayer,
@@ -590,8 +589,19 @@ export class EOxMap extends LitElement {
     parseText(text, vectorLayer, this, replaceFeatures);
   };
 
+  /**
+   * given a projection code, this fetches the definition from epsg.io
+   * and registers the projection using proj4
+   * @param code The EPSG code (e.g. 4326 or 'EPSG:4326').
+   *
+   */
   registerProjectionFromCode = registerProjectionFromCode;
 
+  /**
+   * registers a projection under a given name, defined via a proj4 definition
+   * @param name name of the projection (e.g. "EPSG:4326")
+   * @param projection proj4 projection definition string
+   */
   registerProjection = registerProjection;
 
   /**
@@ -600,8 +610,24 @@ export class EOxMap extends LitElement {
    */
   getFlatLayersArray = getFlatLayersArray;
 
+  /**
+   * Transforms coordinates to a given projection.
+   * If no `destination` is defined, the coordinate is transformed to EPSG:4326
+   * @param {import('ol/coordinate').Coordinate} coordinate
+   * @param {import('ol/proj').ProjectionLike} source
+   * @param {import('ol/proj').ProjectionLike=} destination
+   * @returns {import('ol/coordinate'.Coordinate)}
+   */
   transform = transform;
 
+  /**
+   * Transforms an extent to a given projection.
+   * If no `destination` is defined, the extent is transformed to EPSG:4326.
+   * @param {import('ol/extent').Extent} extent
+   * @param {import('ol/proj').ProjectionLike} source
+   * @param {import('ol/proj').ProjectionLike=} destination
+   * @returns {import('ol/extent').Extent}
+   */
   transformExtent = transformExtent;
 
   render() {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -129,25 +129,23 @@ export class EOxMap extends LitElement {
    * current center of the view in EPSG:4326
    */
   get lonLatCenter() {
-    const projection = this.projection || this.map.getView().getProjection();
-    if (projection === "EPSG:4326") {
+    if (this.projection === "EPSG:4326") {
       return this.map.getView().getCenter();
     }
-    return transform(this.map.getView().getCenter(), projection);
+    return transform(this.map.getView().getCenter(), this.projection);
   }
 
   /**
    * current extent
    */
   get lonLatExtent() {
-    const projection = this.projection || this.map.getView().getProjection();
     const currentExtent = this.map
       .getView()
       .calculateExtent(this.map.getSize());
-    if (projection === "EPSG:4326") {
+    if (this.projection === "EPSG:4326") {
       return currentExtent;
     }
-    return transformExtent(currentExtent, projection);
+    return transformExtent(currentExtent, this.projection);
   }
 
   private _zoom: number = 0;
@@ -354,7 +352,7 @@ export class EOxMap extends LitElement {
    * @type ProjectionLike
    */
   get projection() {
-    return this._projection;
+    return this._projection || "EPSG:3857";
   }
 
   /**

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -21,6 +21,8 @@ import {
   addScrollInteractions,
   coordinatesRoughlyEquals,
   removeDefaultScrollInteractions,
+  transform,
+  transformExtent,
 } from "./src/utils";
 import GeoJSON from "ol/format/GeoJSON";
 import {
@@ -35,7 +37,7 @@ import { Geometry } from "ol/geom";
 import VectorLayer from "ol/layer/Vector.js";
 import {
   ProjectionLike,
-  transform,
+  transform as olTransform,
   getPointResolution,
   get as getProjection,
 } from "ol/proj";
@@ -341,7 +343,7 @@ export class EOxMap extends LitElement {
       getProjection(projection) &&
       projection !== oldView.getProjection().getCode()
     ) {
-      const newCenter = transform(
+      const newCenter = olTransform(
         oldView.getCenter(),
         oldView.getProjection().getCode(),
         projection
@@ -574,6 +576,10 @@ export class EOxMap extends LitElement {
    * as flat array
    */
   getFlatLayersArray = getFlatLayersArray;
+
+  transform = transform;
+
+  transformExtent = transformExtent;
 
   render() {
     const shadowStyleFix = `

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -129,23 +129,25 @@ export class EOxMap extends LitElement {
    * current center of the view in EPSG:4326
    */
   get lonLatCenter() {
-    if (this.projection === "EPSG:4326") {
+    const projection = this.projection || this.map.getView().getProjection();
+    if (projection === "EPSG:4326") {
       return this.map.getView().getCenter();
     }
-    return transform(this.map.getView().getCenter(), this.projection);
+    return transform(this.map.getView().getCenter(), projection);
   }
 
   /**
    * current extent
    */
   get lonLatExtent() {
+    const projection = this.projection || this.map.getView().getProjection();
     const currentExtent = this.map
       .getView()
       .calculateExtent(this.map.getSize());
-    if (this.projection === "EPSG:4326") {
+    if (projection === "EPSG:4326") {
       return currentExtent;
     }
-    return transformExtent(currentExtent, this.projection);
+    return transformExtent(currentExtent, projection);
   }
 
   private _zoom: number = 0;
@@ -346,7 +348,7 @@ export class EOxMap extends LitElement {
     return this._config;
   }
 
-  private _projection: ProjectionLike;
+  private _projection: ProjectionLike = "EPSG:3857";
 
   /**
    * @type ProjectionLike

--- a/elements/map/map.stories.js
+++ b/elements/map/map.stories.js
@@ -688,6 +688,53 @@ export const Projection = {
 };
 
 /**
+ * With the convenience functions `transform` and `transformExtent` it is possible to transform coordinates
+ * and extents from any projection to EPSG.4326 (default) or any other projection.
+ * Basically, these methods are the `ol/proj` [transform](https://openlayers.org/en/latest/apidoc/module-ol_proj.html#.transform)
+ * and [transformExtent](https://openlayers.org/en/latest/apidoc/module-ol_proj.html#.transformExtent) functions,
+ * with the small adaptation that the destination defaults to EPSG:4326 if not defined.
+ */
+export const ProjectionTransform = {
+  args: {
+    layers: [
+      {
+        type: "Tile",
+        properties: {
+          id: "osm",
+          title: "Background",
+        },
+        source: { type: "OSM" },
+      },
+    ],
+    center: [16.8, 48.2],
+    zoom: 7,
+  },
+  render: (args) => html`
+    <eox-map
+      id="transformMap"
+      style="width: 100%; height: 300px; display: none"
+      .center=${args.center}
+      .controls=${args.controls}
+      .zoom=${args.zoom}
+    >
+    </eox-map>
+    <button
+      @click=${() => {
+        const eoxMap = document.querySelector("#transformMap");
+        eoxMap.registerProjection(
+          "ESRI:53009",
+          "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
+            "+b=6371000 +units=m +no_defs"
+        );
+        alert(eoxMap.transform([991693, 1232660], "ESRI:53009"));
+      }}
+    >
+      Transform [991693, 1232660] ("ESRI:53009")
+    </button>
+  `,
+};
+
+/**
  * changing the properties `zoom`, `center` or `zoomExtent` will trigger animations, if the
  * `animationOptions`-property is set.
  * animation options for `zoom` or `center`: https://openlayers.org/en/latest/apidoc/module-ol_View.html#~AnimationOptions

--- a/elements/map/src/utils.ts
+++ b/elements/map/src/utils.ts
@@ -1,5 +1,9 @@
 import { DragPan, MouseWheelZoom } from "ol/interaction";
 import { platformModifierKeyOnly } from "ol/events/condition";
+import {
+  transform as olTransform,
+  transformExtent as olTransformExtent,
+} from "ol/proj";
 
 /**
  * a helper function to determin approximate equality between 2 coordinates.
@@ -92,4 +96,42 @@ export function removeDefaultScrollInteractions(map: import("ol").Map) {
       )
         map.removeInteraction(interaction);
     });
+}
+
+/**
+ * Transforms coordinates to a given projection.
+ * If no `destination` is defined, the coordinate is transformed to EPSG:4326
+ * @param {import('ol/coordinate').Coordinate} coordinate
+ * @param {import('ol/proj').ProjectionLike} source
+ * @param {import('ol/proj').ProjectionLike=} destination
+ * @returns {import('ol/coordinate'.Coordinate)}
+ */
+export function transform(
+  coordinate: import("ol/coordinate").Coordinate,
+  source: import("ol/proj").ProjectionLike,
+  destination?: import("ol/proj").ProjectionLike
+) {
+  if (!destination) {
+    destination = "EPSG:4326";
+  }
+  return olTransform(coordinate, source, destination);
+}
+
+/**
+ * Transforms an extent to a given projection.
+ * Uf no `destination` is defined, the extent is transformed to EPSG:4326.
+ * @param {import('ol/extent').Extent} extent
+ * @param {import('ol/proj').ProjectionLike} source
+ * @param {import('ol/proj').ProjectionLike=} destination
+ * @returns {import('ol/extent').Extent}
+ */
+export function transformExtent(
+  extent: import("ol/extent").Extent,
+  source: import("ol/proj").ProjectionLike,
+  destination?: import("ol/proj").ProjectionLike
+) {
+  if (!destination) {
+    destination = "EPSG:4326";
+  }
+  return olTransformExtent(extent, source, destination);
 }

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import "../main";
 import vectorLayerStyleJson from "./vectorLayer.json";
 import ecoRegionsFixture from "./fixtures/ecoregions.json";
+import { EOxMap } from "../main";
 
 describe("view projections", () => {
   it("can set the initial projection of the view", () => {
@@ -138,11 +139,39 @@ describe("view projections", () => {
         "can transform coordinate from custom system"
       ).to.be.deep.equal([10, 10]);
 
-      const transformedExtentFromWgs = eoxMap.transformExtent([10, 10, 11, 11], 'EPSG:4326', 'ESRI:53009');
-      expect(transformedExtentFromWgs.map(Math.round), 'can transform extent to custom system').to.be.deep.equal([989714, 1232660, 1090862, 1355370])
-      const transformedExtentToWgs = eoxMap.transformExtent([989714.093446643, 1232660.4789432778, 1090862.1263438729, 1355370.4556459172], 'ESRI:53009');
-      expect(transformedExtentToWgs.map(Math.round), 'can transform extent from custom system').to.be.deep.equal([10, 10, 11, 11])
+      const transformedExtentFromWgs = eoxMap.transformExtent(
+        [10, 10, 11, 11],
+        "EPSG:4326",
+        "ESRI:53009"
+      );
+      expect(
+        transformedExtentFromWgs.map(Math.round),
+        "can transform extent to custom system"
+      ).to.be.deep.equal([989714, 1232660, 1090862, 1355370]);
 
+      const transformedExtentToWgs = eoxMap.transformExtent(
+        [
+          989714.093446643, 1232660.4789432778, 1090862.1263438729,
+          1355370.4556459172,
+        ],
+        "ESRI:53009"
+      );
+      expect(
+        transformedExtentToWgs.map(Math.round),
+        "can transform extent from custom system"
+      ).to.be.deep.equal([10, 10, 11, 11]);
+
+      eoxMap.zoomExtent = transformedExtentFromWgs;
+      setTimeout(() => {
+        expect(
+          eoxMap.lonLatExtent.map(Math.round),
+          "getter of lonLatExtent"
+        ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
+        expect(
+          transformedExtentToWgs.map(Math.round),
+          "can transform extent from custom system"
+        ).to.be.deep.equal([10, 10, 11, 11]);
+      }, 10);
     });
   });
 

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -118,16 +118,35 @@ describe("view projections", () => {
       expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
         "ESRI:53009"
       );
+
+      eoxMap.getLayerById("regions").getSource().refresh();
+      const transformedCoordinateFromWgs = eoxMap.transform(
+        [10, 10],
+        "EPSG:4326",
+        "ESRI:53009"
+      );
+      expect(
+        transformedCoordinateFromWgs.map(Math.round),
+        "can transform coordinate to custom system"
+      ).to.be.deep.equal([991693, 1232660]);
+      const transformedCoordinateToWgs = eoxMap.transform(
+        [991693, 1232660],
+        "ESRI:53009"
+      );
+      expect(
+        transformedCoordinateToWgs.map(Math.round),
+        "can transform coordinate from custom system"
+      ).to.be.deep.equal([10, 10]);
+
+      const transformedExtentFromWgs = eoxMap.transformExtent([10, 10, 11, 11], 'EPSG:4326', 'ESRI:53009');
+      expect(transformedExtentFromWgs.map(Math.round), 'can transform extent to custom system').to.be.deep.equal([989714, 1232660, 1090862, 1355370])
+      const transformedExtentToWgs = eoxMap.transformExtent([989714.093446643, 1232660.4789432778, 1090862.1263438729, 1355370.4556459172], 'ESRI:53009');
+      expect(transformedExtentToWgs.map(Math.round), 'can transform extent from custom system').to.be.deep.equal([10, 10, 11, 11])
+
     });
   });
 
   it("fetch projection from code", () => {
-    cy.intercept(
-      "https://openlayers.org/data/vector/ecoregions.json",
-      (req) => {
-        req.reply(ecoRegionsFixture);
-      }
-    );
     cy.mount(
       html`<eox-map
         .controls=${{


### PR DESCRIPTION
## Implemented changes

This PR adds the read-only-properties `EOxMap.lonLatCenter` and `EOxMap.lonLatExtent`, which return the current center and extent in EPSG:4326, no matter the current projection of the view. 
Additionally, the new methods `transform` and `transformExtent` are now exposed, allowing more flexible transformations between all registered coordinate systems. Basically, these methods are the `ol/proj` [transform](https://openlayers.org/en/latest/apidoc/module-ol_proj.html#.transform) and [transformExtent](https://openlayers.org/en/latest/apidoc/module-ol_proj.html#.transformExtent) functions, with the small adaptation that the `destination` defaults to `EPSG:4326` if not defined.


## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
