### PR TITLE
feat: implement loading indicator

### DIFF
--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -8,6 +8,17 @@ import { styleEOX } from "./style.eox";
 
 import { getElement } from "../../../utils/getElement";
 
+const loaderSvg = html`
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" width="50" height="50" style="shape-rendering: auto; display: block; background: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g>
+      <circle stroke-dasharray="120 50" r="30" stroke-width="22" stroke="#cd4609" fill="none" cy="50" cx="50">
+        <animateTransform keyTimes="0;1" values="0 50 50;360 50 50" dur="0.4s" repeatCount="indefinite" type="rotate" attributeName="transform"></animateTransform>
+      </circle>
+      <g></g>
+    </g>
+  </svg>
+`;
+
 class EOxGeoSearch extends LitElement {
   static get properties() {
     return {
@@ -283,40 +294,14 @@ class EOxGeoSearch extends LitElement {
         ${!this.unstyled && buttonStyle}
         ${!this.unstyled && styleEOX}
 
-        .loader {
-            width: 25px;
-            aspect-ratio: 1;
-            border-radius: 50%;
-            border: 4px solid #0000;
-            border-right-color: #004170;
-            position: relative;
-            animation: l24 1s infinite linear;
-          }
-          .loader:before,
-          .loader:after {
-            content: "";
-            position: absolute;
-            inset: -4px;
-            border-radius: 50%;
-            border: inherit;
-            animation: inherit;
-            animation-duration: 2s;
-          }
-          .loader:after {
-            animation-duration: 4s;
-          }
-          @keyframes l24 {
-            100% {transform: rotate(1turn)}
-          }
-
-          .fill {
-            width: 100%;
-            height: 100%;
-            min-height: 100px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-          }
+        .fill {
+          width: 100%;
+          height: 100%;
+          min-height: 100px;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
       </style>
       <div
         class="geosearch ${this.small ? "small" : ""}"
@@ -367,7 +352,7 @@ class EOxGeoSearch extends LitElement {
           <ul class="results-container ${this._isListVisible ? "" : "hidden"}">
             ${
               this._isLoading
-                ? html`<div class="fill"><div class="loader"></div></div>`
+                ? html`<div class="fill">${loaderSvg}</div>`
                 : this._query.length < 2
                   ? html`<span class="hint"
                       >Enter at least two characters to search</span

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -132,7 +132,10 @@ class EOxGeoSearch extends LitElement {
         attribute: "results-direction",
       },
       unstyled: { type: Boolean },
-      loaderSvg: { type: String },
+      loaderSvg: {
+        type: String,
+        attribute: "loader-svg",
+      },
     };
   }
 

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -158,39 +158,7 @@ class EOxGeoSearch extends LitElement {
     this.listDirection = "right";
     this.resultsDirection = "down";
     this.interval = 800;
-    this.loaderSvg = html`
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 100 100"
-        preserveAspectRatio="xMidYMid"
-        width="50"
-        height="50"
-        style="shape-rendering: auto; display: block; background: transparent;"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-      >
-        <g>
-          <circle
-            stroke-dasharray="164.93361431346415 56.97787143782138"
-            r="35"
-            stroke-width="12"
-            stroke="#1a467c"
-            fill="none"
-            cy="50"
-            cx="50"
-          >
-            <animateTransform
-              keyTimes="0;1"
-              values="0 50 50;360 50 50"
-              dur="1.2222222222222223s"
-              repeatCount="indefinite"
-              type="rotate"
-              attributeName="transform"
-            ></animateTransform>
-          </circle>
-          <g></g>
-        </g>
-      </svg>
-    `;
+    this.loaderSvg = loaderSvg;
 
     this.fetchDebounced = _debounce(async () => {
       if (this._query.length < 2) return;

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -1,4 +1,5 @@
 import { LitElement, html } from "lit";
+import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import proj4 from "proj4";
 import _debounce from "lodash.debounce";
 
@@ -8,7 +9,7 @@ import { styleEOX } from "./style.eox";
 
 import { getElement } from "../../../utils/getElement";
 
-const loaderSvg = html`
+const loaderSvg = `
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 100 100"
@@ -375,7 +376,7 @@ class EOxGeoSearch extends LitElement {
           />
           <ul class="results-container ${this._isListVisible ? "" : "hidden"}">
             ${this._isLoading
-              ? html`<div class="fill">${this.loaderSvg}</div>`
+              ? html`<div class="fill">${unsafeSVG(this.loaderSvg)}</div>`
               : this._query.length < 2
               ? html`<span class="hint"
                   >Enter at least two characters to search</span

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -9,9 +9,37 @@ import { styleEOX } from "./style.eox";
 import { getElement } from "../../../utils/getElement";
 
 const loaderSvg = html`
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" width="50" height="50" style="shape-rendering: auto; display: block; background: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink"><g><circle stroke-dasharray="164.93361431346415 56.97787143782138" r="35" stroke-width="12" stroke="#1a467c" fill="none" cy="50" cx="50">
-  <animateTransform keyTimes="0;1" values="0 50 50;360 50 50" dur="1.2222222222222223s" repeatCount="indefinite" type="rotate" attributeName="transform"></animateTransform>
-  </circle><g></g></g></svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 100 100"
+    preserveAspectRatio="xMidYMid"
+    width="50"
+    height="50"
+    style="shape-rendering: auto; display: block; background: transparent;"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+  >
+    <g>
+      <circle
+        stroke-dasharray="164.93361431346415 56.97787143782138"
+        r="35"
+        stroke-width="12"
+        stroke="#1a467c"
+        fill="none"
+        cy="50"
+        cx="50"
+      >
+        <animateTransform
+          keyTimes="0;1"
+          values="0 50 50;360 50 50"
+          dur="1.2222222222222223s"
+          repeatCount="indefinite"
+          type="rotate"
+          attributeName="transform"
+        ></animateTransform>
+      </circle>
+      <g></g>
+    </g>
+  </svg>
 `;
 
 class EOxGeoSearch extends LitElement {
@@ -103,6 +131,7 @@ class EOxGeoSearch extends LitElement {
         attribute: "results-direction",
       },
       unstyled: { type: Boolean },
+      loaderSvg: { type: String },
     };
   }
 
@@ -129,6 +158,39 @@ class EOxGeoSearch extends LitElement {
     this.listDirection = "right";
     this.resultsDirection = "down";
     this.interval = 800;
+    this.loaderSvg = html`
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="xMidYMid"
+        width="50"
+        height="50"
+        style="shape-rendering: auto; display: block; background: transparent;"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+      >
+        <g>
+          <circle
+            stroke-dasharray="164.93361431346415 56.97787143782138"
+            r="35"
+            stroke-width="12"
+            stroke="#1a467c"
+            fill="none"
+            cy="50"
+            cx="50"
+          >
+            <animateTransform
+              keyTimes="0;1"
+              values="0 50 50;360 50 50"
+              dur="1.2222222222222223s"
+              repeatCount="indefinite"
+              type="rotate"
+              attributeName="transform"
+            ></animateTransform>
+          </circle>
+          <g></g>
+        </g>
+      </svg>
+    `;
 
     this.fetchDebounced = _debounce(async () => {
       if (this._query.length < 2) return;
@@ -345,7 +407,7 @@ class EOxGeoSearch extends LitElement {
           />
           <ul class="results-container ${this._isListVisible ? "" : "hidden"}">
             ${this._isLoading
-              ? html`<div class="fill">${loaderSvg}</div>`
+              ? html`<div class="fill">${this.loaderSvg}</div>`
               : this._query.length < 2
               ? html`<span class="hint"
                   >Enter at least two characters to search</span

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -9,10 +9,33 @@ import { styleEOX } from "./style.eox";
 import { getElement } from "../../../utils/getElement";
 
 const loaderSvg = html`
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" width="50" height="50" style="shape-rendering: auto; display: block; background: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 100 100"
+    preserveAspectRatio="xMidYMid"
+    width="50"
+    height="50"
+    style="shape-rendering: auto; display: block; background: transparent;"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+  >
     <g>
-      <circle stroke-dasharray="120 50" r="30" stroke-width="22" stroke="#cd4609" fill="none" cy="50" cx="50">
-        <animateTransform keyTimes="0;1" values="0 50 50;360 50 50" dur="0.4s" repeatCount="indefinite" type="rotate" attributeName="transform"></animateTransform>
+      <circle
+        stroke-dasharray="120 50"
+        r="30"
+        stroke-width="22"
+        stroke="#cd4609"
+        fill="none"
+        cy="50"
+        cx="50"
+      >
+        <animateTransform
+          keyTimes="0;1"
+          values="0 50 50;360 50 50"
+          dur="0.4s"
+          repeatCount="indefinite"
+          type="rotate"
+          attributeName="transform"
+        ></animateTransform>
       </circle>
       <g></g>
     </g>
@@ -291,10 +314,9 @@ class EOxGeoSearch extends LitElement {
           display: none;
         }
         ${!this.unstyled && mainStyle}
-        ${!this.unstyled && buttonStyle}
-        ${!this.unstyled && styleEOX}
-
-        .fill {
+          ${!this.unstyled && buttonStyle}
+          ${!this.unstyled && styleEOX}
+          .fill {
           width: 100%;
           height: 100%;
           min-height: 100px;
@@ -350,25 +372,23 @@ class EOxGeoSearch extends LitElement {
             @input="${this.onInput}"
           />
           <ul class="results-container ${this._isListVisible ? "" : "hidden"}">
-            ${
-              this._isLoading
-                ? html`<div class="fill">${loaderSvg}</div>`
-                : this._query.length < 2
-                  ? html`<span class="hint"
-                      >Enter at least two characters to search</span
-                    >`
-                  : this._data.map(
-                    (item) => html`
-                      <eox-geosearch-item
-                        .item="${item}"
-                        .onClick="${(e) => {
-                          this.handleSelect(e);
-                        }}"
-                        .unstyled=${this.unstyled}
-                      />
-                    `
-                  )
-            }
+            ${this._isLoading
+              ? html`<div class="fill">${loaderSvg}</div>`
+              : this._query.length < 2
+              ? html`<span class="hint"
+                  >Enter at least two characters to search</span
+                >`
+              : this._data.map(
+                  (item) => html`
+                    <eox-geosearch-item
+                      .item="${item}"
+                      .onClick="${(e) => {
+                        this.handleSelect(e);
+                      }}"
+                      .unstyled=${this.unstyled}
+                    />
+                  `
+                )}
           </ul>
         </div>
       </div>

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -9,37 +9,9 @@ import { styleEOX } from "./style.eox";
 import { getElement } from "../../../utils/getElement";
 
 const loaderSvg = html`
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 100 100"
-    preserveAspectRatio="xMidYMid"
-    width="50"
-    height="50"
-    style="shape-rendering: auto; display: block; background: transparent;"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-  >
-    <g>
-      <circle
-        stroke-dasharray="120 50"
-        r="30"
-        stroke-width="22"
-        stroke="#cd4609"
-        fill="none"
-        cy="50"
-        cx="50"
-      >
-        <animateTransform
-          keyTimes="0;1"
-          values="0 50 50;360 50 50"
-          dur="0.4s"
-          repeatCount="indefinite"
-          type="rotate"
-          attributeName="transform"
-        ></animateTransform>
-      </circle>
-      <g></g>
-    </g>
-  </svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" width="50" height="50" style="shape-rendering: auto; display: block; background: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink"><g><circle stroke-dasharray="164.93361431346415 56.97787143782138" r="35" stroke-width="12" stroke="#1a467c" fill="none" cy="50" cx="50">
+  <animateTransform keyTimes="0;1" values="0 50 50;360 50 50" dur="1.2222222222222223s" repeatCount="indefinite" type="rotate" attributeName="transform"></animateTransform>
+  </circle><g></g></g></svg>
 `;
 
 class EOxGeoSearch extends LitElement {

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import proj4 from "proj4";
 import _debounce from "lodash.debounce";
 

--- a/elements/geosearch/stories/custom-loader.js
+++ b/elements/geosearch/stories/custom-loader.js
@@ -1,0 +1,105 @@
+import { html } from "lit";
+
+const CustomLoader = {
+  args: {
+    endpoint: "/opencage-mock-data.json",
+    customLoader: html`
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="48px"
+        height="48px"
+        viewBox="0 0 24 24"
+      >
+        <circle cx="12" cy="12" r="0" fill="currentColor">
+          <animate
+            id="svgSpinnersPulseMultiple0"
+            fill="freeze"
+            attributeName="r"
+            begin="0;svgSpinnersPulseMultiple2.end"
+            calcMode="spline"
+            dur="1.2s"
+            keySplines=".52,.6,.25,.99"
+            values="0;11"
+          />
+          <animate
+            fill="freeze"
+            attributeName="opacity"
+            begin="0;svgSpinnersPulseMultiple2.end"
+            calcMode="spline"
+            dur="1.2s"
+            keySplines=".52,.6,.25,.99"
+            values="1;0"
+          />
+        </circle>
+        <circle cx="12" cy="12" r="0" fill="currentColor">
+          <animate
+            id="svgSpinnersPulseMultiple1"
+            fill="freeze"
+            attributeName="r"
+            begin="svgSpinnersPulseMultiple0.begin+0.2s"
+            calcMode="spline"
+            dur="1.2s"
+            keySplines=".52,.6,.25,.99"
+            values="0;11"
+          />
+          <animate
+            fill="freeze"
+            attributeName="opacity"
+            begin="svgSpinnersPulseMultiple0.begin+0.2s"
+            calcMode="spline"
+            dur="1.2s"
+            keySplines=".52,.6,.25,.99"
+            values="1;0"
+          />
+        </circle>
+        <circle cx="12" cy="12" r="0" fill="currentColor">
+          <animate
+            id="svgSpinnersPulseMultiple2"
+            fill="freeze"
+            attributeName="r"
+            begin="svgSpinnersPulseMultiple0.begin+0.4s"
+            calcMode="spline"
+            dur="1.2s"
+            keySplines=".52,.6,.25,.99"
+            values="0;11"
+          />
+          <animate
+            fill="freeze"
+            attributeName="opacity"
+            begin="svgSpinnersPulseMultiple0.begin+0.4s"
+            calcMode="spline"
+            dur="1.2s"
+            keySplines=".52,.6,.25,.99"
+            values="1;0"
+          />
+        </circle>
+      </svg>
+    `,
+  },
+  render: (args) => {
+    return html`
+      <eox-geosearch
+        label="Search"
+        style="position: absolute; top: 36px; left: 32px; z-index: 12;"
+        .endpoint="${args.endpoint}"
+        .loaderSvg="${args.customLoader}"
+      ></eox-geosearch>
+
+      <eox-map
+        id="geosearch-map-primary"
+        .animationOptions=${{
+          duration: 400,
+          padding: [10, 10, 10, 10],
+        }}
+        .config=${{
+          layers: [{ type: "Tile", source: { type: "OSM" } }],
+          view: { center: [15, 48], zoom: 3 },
+        }}
+        style="width: 100%; height: 500px;"
+      >
+      </eox-map>
+    `;
+  },
+};
+
+export default CustomLoader;

--- a/elements/geosearch/stories/custom-loader.js
+++ b/elements/geosearch/stories/custom-loader.js
@@ -3,7 +3,7 @@ import { html } from "lit";
 const CustomLoader = {
   args: {
     endpoint: "/opencage-mock-data.json",
-    customLoader: html`
+    loaderSvg: `
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="48px"
@@ -82,7 +82,7 @@ const CustomLoader = {
         label="Search"
         style="position: absolute; top: 36px; left: 32px; z-index: 12;"
         .endpoint="${args.endpoint}"
-        .loaderSvg="${args.customLoader}"
+        .loaderSvg="${args.loaderSvg}"
       ></eox-geosearch>
 
       <eox-map

--- a/elements/geosearch/stories/geosearch.stories.js
+++ b/elements/geosearch/stories/geosearch.stories.js
@@ -1,6 +1,7 @@
 import {
   ButtonModeStory,
   CustomAlignmentsStory,
+  CustomLoaderStory,
   PrimaryStory,
 } from "./index.js";
 
@@ -15,3 +16,5 @@ export const Primary = PrimaryStory;
 export const ButtonMode = ButtonModeStory;
 
 export const CustomAlignments = CustomAlignmentsStory;
+
+export const CustomLoader = CustomLoaderStory;

--- a/elements/geosearch/stories/index.js
+++ b/elements/geosearch/stories/index.js
@@ -1,3 +1,4 @@
 export { default as PrimaryStory } from "./primary";
 export { default as ButtonModeStory } from "./button-mode";
 export { default as CustomAlignmentsStory } from "./custom-alignments";
+export { default as CustomLoaderStory } from "./custom-loader";


### PR DESCRIPTION
## Implemented changes

Integrates the recently implemented standard map loading indicator into the geosearch element, with an option to customize the SVG loader using the `loaderSvg` attribute, as demonstrated in the new Custom Loader story.

Do you, @silvester-pari think maybe we should centralize the loader/spinner SVG, similar to how we handled the styles for buttons, radio buttons and checkboxes? Also I think maybe a blue would fit better with the rest, instead of orange.

## Screenshots/Videos

### Default

![Screen Recording 2024-08-07 at 14 03 01](https://github.com/user-attachments/assets/186c6caf-0adc-4ddc-af7e-91096443a754)

### Custom Loader

![Screen Recording 2024-08-07 at 14 21 43](https://github.com/user-attachments/assets/eb2168b5-ed22-4a8e-9786-feec8fd24ef2)



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
