### PR TITLE
feat: added optional extent for the registerProjection function

### DIFF
--- a/elements/map/helpers.ts
+++ b/elements/map/helpers.ts
@@ -239,13 +239,12 @@ export async function registerProjectionFromCode(code: string | number) {
 export function registerProjection(
   name: string,
   projection: string | proj4.ProjectionDefinition,
-  extent?: number[]
+  extent?: import("ol/extent").Extent
 ) {
   proj4.defs(name, projection);
   register(proj4);
   if (typeof extent !== "undefined") {
-    const projection = getProj(name);
-    projection.setExtent(extent);
+    getProj(name).setExtent(extent);
   }
 }
 

--- a/elements/map/helpers.ts
+++ b/elements/map/helpers.ts
@@ -9,6 +9,7 @@ import { getArea, getLength } from "ol/sphere";
 import { getUid } from "ol";
 import { DrawEvent } from "ol/interaction/Draw";
 import { DragAndDropEvent } from "ol/interaction/DragAndDrop";
+import { get as getProj } from "ol/proj";
 import Feature from "ol/Feature";
 import proj4 from "proj4";
 import { fromEPSGCode, register } from "ol/proj/proj4";
@@ -237,10 +238,15 @@ export async function registerProjectionFromCode(code: string | number) {
  */
 export function registerProjection(
   name: string,
-  projection: string | proj4.ProjectionDefinition
+  projection: string | proj4.ProjectionDefinition,
+  extent?: number[]
 ) {
   proj4.defs(name, projection);
   register(proj4);
+  if (typeof extent !== "undefined") {
+    const projection = getProj(name);
+    projection.setExtent(extent);
+  }
 }
 
 /**

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -110,15 +110,21 @@ describe("view projections", () => {
 
     cy.get("eox-map").and(($el) => {
       const eoxMap = <EOxMap>$el[0];
+      const testExtent = [-10, -9, 10, 9];
       eoxMap.registerProjection(
         "ESRI:53009",
         "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
-          "+b=6371000 +units=m +no_defs"
+          "+b=6371000 +units=m +no_defs",
+        testExtent
       );
       eoxMap.setAttribute("projection", "ESRI:53009");
       expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
         "ESRI:53009"
       );
+      expect(
+        eoxMap.map.getView().getProjection().getExtent(),
+        "passes the projection extent correctly"
+      ).to.be.deep.equal(testExtent);
 
       eoxMap.getLayerById("regions").getSource().refresh();
       const transformedCoordinateFromWgs = eoxMap.transform(
@@ -160,6 +166,16 @@ describe("view projections", () => {
         transformedExtentToWgs.map(Math.round),
         "can transform extent from custom system"
       ).to.be.deep.equal([10, 10, 11, 11]);
+
+      const transformedCoordinateOutsideExtent = eoxMap.transform(
+        [20, 20],
+        "EPSG:4326",
+        "ESRI:53009"
+      );
+      expect(
+        transformedCoordinateOutsideExtent.map(Math.round),
+        "can transform coordinate to custom system"
+      ).to.be.deep.equal([1926715, 2450840]);
 
       eoxMap.zoomExtent = transformedExtentFromWgs;
       setTimeout(() => {


### PR DESCRIPTION
## Implemented changes

This PR adds `extent` as an optional third parameter to the `registerProjection` function. This allows setting the validity extent for the set projection. Details see [the corresponding OL docs](https://openlayers.org/en/latest/apidoc/module-ol_proj_Projection-Projection.html#setExtent).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
