### PR TITLE
fix: pre-calculate slider ticks to reduce loading time

### DIFF
--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -28,6 +28,8 @@ export class SliderTicks extends LitElement {
     this.height = 6;
     /** @type {number} */
     this.svgWidth = 0;
+    /** @type {YearMark[]} */
+    this._yearMarks = [];
   }
 
   connectedCallback() {
@@ -41,6 +43,7 @@ export class SliderTicks extends LitElement {
   }
 
   firstUpdated() {
+    this.yearMarks = this.calculateYearMarks();
     this.handleResize();
   }
 
@@ -66,10 +69,19 @@ export class SliderTicks extends LitElement {
     return this.steps ? this.steps.length : 0;
   }
 
+  get yearMarks() {
+    return this._yearMarks;
+  }
+
+  set yearMarks(value) {
+    this._yearMarks = value;
+    this.requestUpdate();
+  }
+
   /**
    * @returns {YearMark[]}
    */
-  get yearMarks() {
+  calculateYearMarks() {
     /** @type {YearMark[]} */
     const yearMarks = [];
     /** @type {number | null} */
@@ -105,7 +117,7 @@ export class SliderTicks extends LitElement {
    */
   isYearLine(line) {
     // Check if this line's position is approximately equal to any year mark position
-    const isYearMark = this.yearMarks.some(
+    const isYearMark = this._yearMarks.some(
       (yearMark) => Math.abs(yearMark.position - line) < 1.0
     );
 

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -47,9 +47,11 @@ export class SliderTicks extends LitElement {
     this.handleResize();
   }
 
-  updated() {
-    this.yearMarks = this.calculateYearMarks();
-    this.handleResize();
+  updated(changedProperties) {
+    if (changedProperties.has("steps")) {
+      this.yearMarks = this.calculateYearMarks();
+      this.handleResize();
+    }
   }
 
   handleResize() {

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -47,6 +47,11 @@ export class SliderTicks extends LitElement {
     this.handleResize();
   }
 
+  updated() {
+    this.yearMarks = this.calculateYearMarks();
+    this.handleResize();
+  }
+
   handleResize() {
     this.svgWidth = this.shadowRoot.querySelector("svg").clientWidth;
     this.height = this.shadowRoot.querySelector("svg").clientHeight;


### PR DESCRIPTION
Closes #1165.

## Implemented changes

Calculate slider ticks lazily as a method instead of providing a reactive getter, improving initial load performance 10-fold.

<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

| No. of  Test Entries | Previous (eager) start-up time | Current (lazy) start-up time|
|---	|---	|---   	|
|2277   |9.8s   	|760ms   	|

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
