### PR TITLE
feat: decade ticks

### DIFF
--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -90,7 +90,7 @@ export class EOxTimeControl extends LitElement {
 
     this._width = 300;
 
-    window.addEventListener('resize', (e) => {
+    window.addEventListener("resize", () => {
       this._width = this.clientWidth;
     });
   }

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -57,6 +57,7 @@ export class EOxTimeControl extends LitElement {
       _isAnimationPlaying: { state: true },
       _newStepIndex: { state: true },
       _eoxMap: { state: true },
+      _width: { state: true },
       unstyled: { type: Boolean },
     };
   }
@@ -86,6 +87,12 @@ export class EOxTimeControl extends LitElement {
     this.controlProperty = undefined;
     /** @type {HTMLElement |undefined} */
     this._eoxMap = undefined;
+
+    this._width = 300;
+
+    window.addEventListener('resize', (e) => {
+      this._width = this.clientWidth;
+    });
   }
 
   /**
@@ -328,7 +335,7 @@ export class EOxTimeControl extends LitElement {
                   ></tc-range-slider>
 
                   <eox-sliderticks
-                    width="300"
+                    .width="${this._width}"
                     .steps="${this.controlValues}"
                   ></eox-sliderticks>
                 </div>

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -218,7 +218,11 @@ export class SliderTicks extends LitElement {
                 ></line>
               `);
 
-          if (date.isYearMarker) {
+          if (date.isYearMarker
+                && this.density > 0.03
+                && this.density < 0.5
+                && yearIndex % 2 == 0
+              ) {
             elements.push(svg`
                   <text
                     key=${`label-${yearIndex}`}
@@ -356,6 +360,7 @@ export class SliderTicks extends LitElement {
     this.requestUpdate();
   }
 
+  // TODO: Can this be fully removed yet (as the year marks are generated alongside ticks)?
   /**
    * @returns {YearMark[]}
    */
@@ -381,13 +386,6 @@ export class SliderTicks extends LitElement {
       // Update previousYear for the next iteration
       previousYear = currentYear;
     });
-
-    // Filter out year marks that are too close together, in favor of the second one.
-    return yearMarks.filter((current, i) => {
-      const next = yearMarks[i + 1];
-
-      return !(next && next.position - current.position < 25);
-    });
   }
 
   /**
@@ -410,7 +408,7 @@ export class SliderTicks extends LitElement {
           style="width: ${this.width}px; height: 30px;"
           viewBox="-1 0 ${this.width + 2} ${this.height}"
         >
-          ${this.sliderTicks} ${this.yearMarks}
+          ${this.sliderTicks}
         </svg>
       </div>
     `;

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -416,19 +416,4 @@ export class SliderTicks extends LitElement {
   }
 }
 
-/*
-this.years.map((year, index) => svg`
-  <text
-    key=${`y${index}`}
-    x=${year.position}
-    y=${this.height - 1}
-    fill="#555"
-    font-size="13"
-    font-weight="500"
-  >
-    ${year.label}
-  </text>
-`)
-*/
-
 customElements.define("eox-sliderticks", SliderTicks);

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -202,8 +202,7 @@ export class SliderTicks extends LitElement {
         .map((date, i) => {
           // Calculate position within the entire slider based on global index
           const globalIndex = this.steps.indexOf(date.date);
-          const position =
-            (globalIndex / (this.steps.length - 1)) * this.width;
+          const position = (globalIndex / (this.steps.length - 1)) * this.width;
 
           const elements = [];
 
@@ -248,13 +247,13 @@ export class SliderTicks extends LitElement {
     console.log("No. of Steps: ", this.steps.length);
 
     if (this.density <= 0.5) {
-      console.log('TICKS START');
+      console.log("TICKS START");
       return this.calculateIndividualTicks();
     } else if (this.density > 0.5 && this.density < 10.0) {
-      console.log('YEARBARS START');
+      console.log("YEARBARS START");
       return this.calculateYearBars();
     } else if (this.density >= 10.0) {
-      console.log('DECADEBARS START');
+      console.log("DECADEBARS START");
       return this.calculateDecadeBars();
     }
   }
@@ -319,7 +318,11 @@ export class SliderTicks extends LitElement {
     });
 
     const endTime = performance.now();
-    console.log('Time taken to calculate decade bars: ', endTime - startTime, 'ms');
+    console.log(
+      "Time taken to calculate decade bars: ",
+      endTime - startTime,
+      "ms"
+    );
 
     return res;
   }
@@ -413,8 +416,7 @@ export class SliderTicks extends LitElement {
           style="width: ${this.width}px; height: 30px;"
           viewBox="-1 0 ${this.width + 2} ${this.height}"
         >
-          ${this.sliderTicks}
-          ${this.yearMarks}
+          ${this.sliderTicks} ${this.yearMarks}
         </svg>
       </div>
     `;

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -116,13 +116,12 @@ export class SliderTicks extends LitElement {
           dates: [],
         };
         yearGroups.push(yearGroup);
-      } else {
-        // We've seen this before, add it to the existing year group
-        yearGroup.dates.push({
-          date: step,
-          isYearMarker: yearGroup.dates.length === 0,
-        });
       }
+
+      yearGroup.dates.push({
+        date: step,
+        isYearMarker: yearGroup.dates.length === 0,
+      });
     });
 
     for (let g of yearGroups) {

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -243,17 +243,11 @@ export class SliderTicks extends LitElement {
   }
 
   calculateSliderTicks() {
-    console.log("Density: ", this.density);
-    console.log("No. of Steps: ", this.steps.length);
-
     if (this.density <= 0.5) {
-      console.log("TICKS START");
       return this.calculateIndividualTicks();
     } else if (this.density > 0.5 && this.density < 10.0) {
-      console.log("YEARBARS START");
       return this.calculateYearBars();
     } else if (this.density >= 10.0) {
-      console.log("DECADEBARS START");
       return this.calculateDecadeBars();
     }
   }
@@ -318,11 +312,11 @@ export class SliderTicks extends LitElement {
     });
 
     const endTime = performance.now();
-    console.log(
+    /*console.log(
       "Time taken to calculate decade bars: ",
       endTime - startTime,
       "ms"
-    );
+    );*/
 
     return res;
   }

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -218,11 +218,12 @@ export class SliderTicks extends LitElement {
                 ></line>
               `);
 
-          if (date.isYearMarker
-                && this.density > 0.03
-                && this.density < 0.5
-                && yearIndex % 2 == 0
-              ) {
+          if (
+            date.isYearMarker &&
+            this.density > 0.03 &&
+            this.density < 0.5 &&
+            yearIndex % 2 == 0
+          ) {
             elements.push(svg`
                   <text
                     key=${`label-${yearIndex}`}

--- a/elements/timecontrol/src/sliderticks.js
+++ b/elements/timecontrol/src/sliderticks.js
@@ -253,7 +253,7 @@ export class SliderTicks extends LitElement {
   }
 
   calculateDecadeBars() {
-    const startTime = performance.now();
+    //const startTime = performance.now();
 
     const minBarWidth = 30;
     // Very high density: Render bars or labels for each decade
@@ -311,7 +311,7 @@ export class SliderTicks extends LitElement {
       return elements;
     });
 
-    const endTime = performance.now();
+    //const endTime = performance.now();
     /*console.log(
       "Time taken to calculate decade bars: ",
       endTime - startTime,


### PR DESCRIPTION
## Implemented changes

Time Control slider ticks tend to get out of alignment as the size of the date array grows larger. This becomes an issue especially with datasets that span multiple decades, as some datasets easily go from 1960 to 2024.

This PR implements a high-density mode which condenses individual ticks into bars automatically if the density of slider ticks gets too high. Furthermore, the last unnecessary getter/setter has been removed inside the ticks to yield a bit better performance with large datasets (20-25k entries).

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

![timecontrol_decade_ticks](https://github.com/user-attachments/assets/e37f2c0e-5e9a-4d3a-90c7-cfc8a37fe778)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
