### PR TITLE
chore: fix flaky tests

### DIFF
--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -97,98 +97,101 @@ describe("view projections", () => {
   });
 
   it("use special projection", () => {
-    cy.intercept(
-      "https://openlayers.org/data/vector/ecoregions.json",
-      (req) => {
-        req.reply(ecoRegionsFixture);
-      }
-    );
-    // not using osm because of performance issues while testing
-    cy.mount(html`<eox-map .layers=${vectorLayerStyleJson}></eox-map>`).as(
-      "eox-map"
-    );
-
-    cy.get("eox-map").and(($el) => {
-      const eoxMap = <EOxMap>$el[0];
-      const testExtent = [-10, -9, 10, 9];
-      eoxMap.registerProjection(
-        "ESRI:53009",
-        "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
-          "+b=6371000 +units=m +no_defs",
-        testExtent
+    return new Cypress.Promise((resolve) => {
+      cy.intercept(
+        "https://openlayers.org/data/vector/ecoregions.json",
+        (req) => {
+          req.reply(ecoRegionsFixture);
+        }
       );
-      eoxMap.setAttribute("projection", "ESRI:53009");
-      expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
-        "ESRI:53009"
-      );
-      expect(
-        eoxMap.map.getView().getProjection().getExtent(),
-        "passes the projection extent correctly"
-      ).to.be.deep.equal(testExtent);
-
-      eoxMap.getLayerById("regions").getSource().refresh();
-      const transformedCoordinateFromWgs = eoxMap.transform(
-        [10, 10],
-        "EPSG:4326",
-        "ESRI:53009"
-      );
-      expect(
-        transformedCoordinateFromWgs.map(Math.round),
-        "can transform coordinate to custom system"
-      ).to.be.deep.equal([991693, 1232660]);
-      const transformedCoordinateToWgs = eoxMap.transform(
-        [991693, 1232660],
-        "ESRI:53009"
-      );
-      expect(
-        transformedCoordinateToWgs.map(Math.round),
-        "can transform coordinate from custom system"
-      ).to.be.deep.equal([10, 10]);
-
-      const transformedExtentFromWgs = eoxMap.transformExtent(
-        [10, 10, 11, 11],
-        "EPSG:4326",
-        "ESRI:53009"
-      );
-      expect(
-        transformedExtentFromWgs.map(Math.round),
-        "can transform extent to custom system"
-      ).to.be.deep.equal([989714, 1232660, 1090862, 1355370]);
-
-      const transformedExtentToWgs = eoxMap.transformExtent(
-        [
-          989714.093446643, 1232660.4789432778, 1090862.1263438729,
-          1355370.4556459172,
-        ],
-        "ESRI:53009"
-      );
-      expect(
-        transformedExtentToWgs.map(Math.round),
-        "can transform extent from custom system"
-      ).to.be.deep.equal([10, 10, 11, 11]);
-
-      const transformedCoordinateOutsideExtent = eoxMap.transform(
-        [20, 20],
-        "EPSG:4326",
-        "ESRI:53009"
-      );
-      expect(
-        transformedCoordinateOutsideExtent.map(Math.round),
-        "can transform coordinate to custom system"
-      ).to.be.deep.equal([1926715, 2450840]);
-
-      eoxMap.zoomExtent = transformedExtentFromWgs;
-      setTimeout(() => {
+      // not using osm because of performance issues while testing
+      cy.mount(html`<eox-map .layers=${vectorLayerStyleJson}></eox-map>`).as(
+        "eox-map"
+        );
+        
+      cy.get("eox-map").and(($el) => {
+        const eoxMap = <EOxMap>$el[0];
+        const testExtent = [-10, -9, 10, 9];
+        eoxMap.registerProjection(
+          "ESRI:53009",
+          "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
+            "+b=6371000 +units=m +no_defs",
+          testExtent
+        );
+        eoxMap.setAttribute("projection", "ESRI:53009");
+        expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+          "ESRI:53009"
+        );
         expect(
-          eoxMap.lonLatExtent.map(Math.round),
-          "getter of lonLatExtent"
-        ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
+          eoxMap.map.getView().getProjection().getExtent(),
+          "passes the projection extent correctly"
+        ).to.be.deep.equal(testExtent);
+  
+        eoxMap.getLayerById("regions").getSource().refresh();
+        const transformedCoordinateFromWgs = eoxMap.transform(
+          [10, 10],
+          "EPSG:4326",
+          "ESRI:53009"
+        );
+        expect(
+          transformedCoordinateFromWgs.map(Math.round),
+          "can transform coordinate to custom system"
+        ).to.be.deep.equal([991693, 1232660]);
+        const transformedCoordinateToWgs = eoxMap.transform(
+          [991693, 1232660],
+          "ESRI:53009"
+        );
+        expect(
+          transformedCoordinateToWgs.map(Math.round),
+          "can transform coordinate from custom system"
+        ).to.be.deep.equal([10, 10]);
+  
+        const transformedExtentFromWgs = eoxMap.transformExtent(
+          [10, 10, 11, 11],
+          "EPSG:4326",
+          "ESRI:53009"
+        );
+        expect(
+          transformedExtentFromWgs.map(Math.round),
+          "can transform extent to custom system"
+        ).to.be.deep.equal([989714, 1232660, 1090862, 1355370]);
+  
+        const transformedExtentToWgs = eoxMap.transformExtent(
+          [
+            989714.093446643, 1232660.4789432778, 1090862.1263438729,
+            1355370.4556459172,
+          ],
+          "ESRI:53009"
+        );
         expect(
           transformedExtentToWgs.map(Math.round),
           "can transform extent from custom system"
         ).to.be.deep.equal([10, 10, 11, 11]);
-      }, 10);
-    });
+  
+        const transformedCoordinateOutsideExtent = eoxMap.transform(
+          [20, 20],
+          "EPSG:4326",
+          "ESRI:53009"
+        );
+        expect(
+          transformedCoordinateOutsideExtent.map(Math.round),
+          "can transform coordinate to custom system"
+        ).to.be.deep.equal([1926715, 2450840]);
+  
+        eoxMap.zoomExtent = transformedExtentFromWgs;
+        setTimeout(() => {
+          expect(
+            eoxMap.lonLatExtent.map(Math.round),
+            "getter of lonLatExtent"
+          ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
+          expect(
+            transformedExtentToWgs.map(Math.round),
+            "can transform extent from custom system"
+          ).to.be.deep.equal([10, 10, 11, 11]);
+        }, 10);
+        resolve();
+      });
+    })
   });
 
   it("fetch projection from code", () => {

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -177,6 +177,11 @@ describe("view projections", () => {
         transformedCoordinateOutsideExtent.map(Math.round),
         "can transform coordinate to custom system"
       ).to.be.deep.equal([1926715, 2450840]);
+
+      expect(
+        transformedExtentToWgs.map(Math.round),
+        "can transform extent from custom system"
+      ).to.be.deep.equal([10, 10, 11, 11]);
     });
     cy.get("eox-map").then(($el) => {
       const eoxMap = <EOxMap>$el[0];
@@ -187,11 +192,6 @@ describe("view projections", () => {
           eoxMap.lonLatExtent.map(Math.round),
           "getter of lonLatExtent"
         ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
-
-        expect(
-          transformedExtentToWgs.map(Math.round),
-          "can transform extent from custom system"
-        ).to.be.deep.equal([10, 10, 11, 11]);
       });
     });
   });

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -102,7 +102,7 @@ describe("view projections", () => {
       (req) => {
         req.reply(ecoRegionsFixture);
       }
-    ).as("ecoRegionsIntercept");
+    );
     let transformedExtentFromWgs, transformedExtentToWgs;
     // not using osm because of performance issues while testing
     cy.mount(html`<eox-map .layers=${vectorLayerStyleJson}></eox-map>`).as(

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -97,101 +97,103 @@ describe("view projections", () => {
   });
 
   it("use special projection", () => {
-    return new Cypress.Promise((resolve) => {
-      cy.intercept(
-        "https://openlayers.org/data/vector/ecoregions.json",
-        (req) => {
-          req.reply(ecoRegionsFixture);
-        }
+    cy.intercept(
+      "https://openlayers.org/data/vector/ecoregions.json",
+      (req) => {
+        req.reply(ecoRegionsFixture);
+      }
+    ).as("ecoRegionsIntercept");
+    let transformedExtentFromWgs, transformedExtentToWgs;
+    // not using osm because of performance issues while testing
+    cy.mount(html`<eox-map .layers=${vectorLayerStyleJson}></eox-map>`).as(
+      "eox-map"
+    );
+
+    cy.get("eox-map").and(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      const testExtent = [-10, -9, 10, 9];
+      eoxMap.registerProjection(
+        "ESRI:53009",
+        "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
+          "+b=6371000 +units=m +no_defs",
+        testExtent
       );
-      // not using osm because of performance issues while testing
-      cy.mount(html`<eox-map .layers=${vectorLayerStyleJson}></eox-map>`).as(
-        "eox-map"
-        );
-        
-      cy.get("eox-map").and(($el) => {
-        const eoxMap = <EOxMap>$el[0];
-        const testExtent = [-10, -9, 10, 9];
-        eoxMap.registerProjection(
-          "ESRI:53009",
-          "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 " +
-            "+b=6371000 +units=m +no_defs",
-          testExtent
-        );
-        eoxMap.setAttribute("projection", "ESRI:53009");
-        expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
-          "ESRI:53009"
-        );
+      eoxMap.setAttribute("projection", "ESRI:53009");
+      expect(eoxMap.map.getView().getProjection().getCode()).to.be.equal(
+        "ESRI:53009"
+      );
+      expect(
+        eoxMap.map.getView().getProjection().getExtent(),
+        "passes the projection extent correctly"
+      ).to.be.deep.equal(testExtent);
+
+      eoxMap.getLayerById("regions").getSource().refresh();
+      const transformedCoordinateFromWgs = eoxMap.transform(
+        [10, 10],
+        "EPSG:4326",
+        "ESRI:53009"
+      );
+      expect(
+        transformedCoordinateFromWgs.map(Math.round),
+        "can transform coordinate to custom system"
+      ).to.be.deep.equal([991693, 1232660]);
+      const transformedCoordinateToWgs = eoxMap.transform(
+        [991693, 1232660],
+        "ESRI:53009"
+      );
+      expect(
+        transformedCoordinateToWgs.map(Math.round),
+        "can transform coordinate from custom system"
+      ).to.be.deep.equal([10, 10]);
+
+      transformedExtentFromWgs = eoxMap.transformExtent(
+        [10, 10, 11, 11],
+        "EPSG:4326",
+        "ESRI:53009"
+      );
+      expect(
+        transformedExtentFromWgs.map(Math.round),
+        "can transform extent to custom system"
+      ).to.be.deep.equal([989714, 1232660, 1090862, 1355370]);
+
+      transformedExtentToWgs = eoxMap.transformExtent(
+        [
+          989714.093446643, 1232660.4789432778, 1090862.1263438729,
+          1355370.4556459172,
+        ],
+        "ESRI:53009"
+      );
+      expect(
+        transformedExtentToWgs.map(Math.round),
+        "can transform extent from custom system"
+      ).to.be.deep.equal([10, 10, 11, 11]);
+
+      const transformedCoordinateOutsideExtent = eoxMap.transform(
+        [20, 20],
+        "EPSG:4326",
+        "ESRI:53009"
+      );
+      expect(
+        transformedCoordinateOutsideExtent.map(Math.round),
+        "can transform coordinate to custom system"
+      ).to.be.deep.equal([1926715, 2450840]);
+    });
+    cy.get("eox-map").then(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.zoomExtent = transformedExtentFromWgs;
+
+      return cy.wait("@ecoRegionsIntercept").then(() => {
         expect(
-          eoxMap.map.getView().getProjection().getExtent(),
-          "passes the projection extent correctly"
-        ).to.be.deep.equal(testExtent);
-  
-        eoxMap.getLayerById("regions").getSource().refresh();
-        const transformedCoordinateFromWgs = eoxMap.transform(
-          [10, 10],
-          "EPSG:4326",
-          "ESRI:53009"
-        );
-        expect(
-          transformedCoordinateFromWgs.map(Math.round),
-          "can transform coordinate to custom system"
-        ).to.be.deep.equal([991693, 1232660]);
-        const transformedCoordinateToWgs = eoxMap.transform(
-          [991693, 1232660],
-          "ESRI:53009"
-        );
-        expect(
-          transformedCoordinateToWgs.map(Math.round),
-          "can transform coordinate from custom system"
-        ).to.be.deep.equal([10, 10]);
-  
-        const transformedExtentFromWgs = eoxMap.transformExtent(
-          [10, 10, 11, 11],
-          "EPSG:4326",
-          "ESRI:53009"
-        );
-        expect(
-          transformedExtentFromWgs.map(Math.round),
-          "can transform extent to custom system"
-        ).to.be.deep.equal([989714, 1232660, 1090862, 1355370]);
-  
-        const transformedExtentToWgs = eoxMap.transformExtent(
-          [
-            989714.093446643, 1232660.4789432778, 1090862.1263438729,
-            1355370.4556459172,
-          ],
-          "ESRI:53009"
-        );
+          eoxMap.lonLatExtent.map(Math.round),
+          "getter of lonLatExtent"
+        ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
+
         expect(
           transformedExtentToWgs.map(Math.round),
           "can transform extent from custom system"
         ).to.be.deep.equal([10, 10, 11, 11]);
-  
-        const transformedCoordinateOutsideExtent = eoxMap.transform(
-          [20, 20],
-          "EPSG:4326",
-          "ESRI:53009"
-        );
-        expect(
-          transformedCoordinateOutsideExtent.map(Math.round),
-          "can transform coordinate to custom system"
-        ).to.be.deep.equal([1926715, 2450840]);
-  
-        eoxMap.zoomExtent = transformedExtentFromWgs;
-        setTimeout(() => {
-          expect(
-            eoxMap.lonLatExtent.map(Math.round),
-            "getter of lonLatExtent"
-          ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
-          expect(
-            transformedExtentToWgs.map(Math.round),
-            "can transform extent from custom system"
-          ).to.be.deep.equal([10, 10, 11, 11]);
-        }, 10);
-        resolve();
       });
-    })
+    });
   });
 
   it("fetch projection from code", () => {

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -193,7 +193,7 @@ describe("view projections", () => {
             eoxMap.lonLatExtent.map(Math.round),
             "getter of lonLatExtent"
           ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
-          resolve()
+          resolve();
         }, 10);
       });
     });

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -187,11 +187,14 @@ describe("view projections", () => {
       const eoxMap = <EOxMap>$el[0];
       eoxMap.zoomExtent = transformedExtentFromWgs;
 
-      return cy.wait("@ecoRegionsIntercept").then(() => {
-        expect(
-          eoxMap.lonLatExtent.map(Math.round),
-          "getter of lonLatExtent"
-        ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
+      return new Cypress.Promise((resolve) => {
+        setTimeout(() => {
+          expect(
+            eoxMap.lonLatExtent.map(Math.round),
+            "getter of lonLatExtent"
+          ).to.be.deep.equal(transformedExtentToWgs.map(Math.round));
+          resolve()
+        }, 10);
       });
     });
   });

--- a/elements/map/test/viewProjection.cy.ts
+++ b/elements/map/test/viewProjection.cy.ts
@@ -103,7 +103,7 @@ describe("view projections", () => {
         req.reply(ecoRegionsFixture);
       }
     );
-    let transformedExtentFromWgs, transformedExtentToWgs;
+
     // not using osm because of performance issues while testing
     cy.mount(html`<eox-map .layers=${vectorLayerStyleJson}></eox-map>`).as(
       "eox-map"
@@ -146,7 +146,7 @@ describe("view projections", () => {
         "can transform coordinate from custom system"
       ).to.be.deep.equal([10, 10]);
 
-      transformedExtentFromWgs = eoxMap.transformExtent(
+      const transformedExtentFromWgs = eoxMap.transformExtent(
         [10, 10, 11, 11],
         "EPSG:4326",
         "ESRI:53009"
@@ -156,7 +156,7 @@ describe("view projections", () => {
         "can transform extent to custom system"
       ).to.be.deep.equal([989714, 1232660, 1090862, 1355370]);
 
-      transformedExtentToWgs = eoxMap.transformExtent(
+      const transformedExtentToWgs = eoxMap.transformExtent(
         [
           989714.093446643, 1232660.4789432778, 1090862.1263438729,
           1355370.4556459172,


### PR DESCRIPTION
## Implemented changes
Some tests (e.g. `map/viewProjection`) have assertions that fail after the test has ended.
<img width="421" alt="Screenshot 2024-09-09 at 14 16 58" src="https://github.com/user-attachments/assets/0bf2c48d-0155-4b47-874c-41222edc56b9">
In the above screenshot, the `lonLatExtent` assertion is actually part of "use special projection" test but because of a `setTimeout` it gets pushed down to the next test.
In order to fix this we wrap the assertion in a `Cypress.Promise` (https://docs.cypress.io/api/utilities/promise) as we do in other tests that require a `setTimeout` and as a result the test now fails which needs fixing on the map side.
<img width="541" alt="Screenshot 2024-09-09 at 14 24 31" src="https://github.com/user-attachments/assets/f264b89f-b11b-47a1-9e56-8abc642dd3ce">

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
