### PR TITLE
feat: changed style 

### DIFF
--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -292,9 +292,12 @@ export class EOxTimeControl extends LitElement {
           >
             <
           </button>
+          <span part="current">${this.controlValues[this._newStepIndex]}</span>
           <button part="next" class="icon next" @click="${() => this.next()}">
             >
           </button>
+        </div>
+        <div>
           ${!this.disablePlay
             ? html`
                 <button
@@ -334,8 +337,6 @@ export class EOxTimeControl extends LitElement {
                 </div>
               `
             : ""}
-
-          <span part="current">${this.controlValues[this._newStepIndex]}</span>
         </div>
       </main>
     `;

--- a/elements/timecontrol/src/style.eox.js
+++ b/elements/timecontrol/src/style.eox.js
@@ -5,6 +5,10 @@ export const styleEOX = `
   font-family: Roboto, sans-serif;
 }
 
+main {
+  text-align: center;
+}
+
 ${button}
 
 button.icon-text.play:before {


### PR DESCRIPTION


## Implemented changes

* selected time label is now between previous/next buttons
* added text-center style to main to center component to where they are integrated (slider is not width reactive)
* buttons and label have their own div container to be on same row

## Screenshots/Videos

Now:
![image](https://github.com/user-attachments/assets/399fa7ae-905f-47e5-addb-4ec1e3ac8bd7)

Previous:
![image](https://github.com/user-attachments/assets/2821b2c5-87de-4ac3-8f5f-9d18b75ea57a)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
