### PR TITLE
Feat: disable individual title from nav 

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -321,9 +321,10 @@ export function parseNavWithAddSection(
       <div class="container">
         <ul>
           ${nav
-            .map(
-              ({ id, title }) =>
-                `<li class="nav-${id}"><a href="#${id}">${title}</a></li>`
+            .map(({ id, title, state }) =>
+              state
+                ? `<li class="nav-${id}"><a href="#${id}">${title}</a></li>`
+                : ""
             )
             .join("")}
         </ul>

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -278,7 +278,11 @@ function parseInlineContent(
     const id = attrsId || titleSlug;
     const sectionId = `section-${id}`;
 
-    if (stack.last.tag === "h2" && title) nav.push({ title, id: sectionId });
+    const attrNav = getAttr(stack.last.attrs, "nav");
+    const navState = attrNav !== "false";
+
+    if (stack.last.tag === "h2" && title)
+      nav.push({ title, id: sectionId, state: navState });
 
     const currentSectionToken = finalTokens[sectionStartIndex];
     const currentHeadingSectionToken = finalTokens[finalTokens.length - 1];


### PR DESCRIPTION
## Implemented changes
- Disable individual title from nav bar using `nav: false` config like - 
```md
## Title 2 <!-- nav="false" -->
```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/user-attachments/assets/3e659273-8098-4645-927e-8f069ce72708



<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
