### PR TITLE
fix: remove default style

### DIFF
--- a/elements/layout/src/enums/index.js
+++ b/elements/layout/src/enums/index.js
@@ -1,3 +1,3 @@
-export { STORIES_LAYOUT_STYLE } from "./stories";
+export { STORIES_LAYOUT_STYLE, STORIES_LAYOUT_ITEM_STYLE } from "./stories";
 
 export { TEST_SELECTORS } from "./test";

--- a/elements/layout/src/enums/stories.js
+++ b/elements/layout/src/enums/stories.js
@@ -1,1 +1,3 @@
 export const STORIES_LAYOUT_STYLE = "width: 100%; height: 400px;";
+export const STORIES_LAYOUT_ITEM_STYLE =
+  "background: lightgrey; border: 1px solid darkgrey; border-radius: 4px; padding: 4px 8px;";

--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -49,12 +49,7 @@ export class EOxLayoutItem extends HTMLElement {
     this.shadowRoot.innerHTML = `
       <style>
         :host {
-          background: lightgrey;
-          border: 1px solid darkgrey;
-          border-radius: 4px;
-          padding: 4px 8px;
           overflow: hidden;
-
 
           grid-column: ${
             parseInt(this.getAttribute("x")) + 1

--- a/elements/layout/stories/gap.js
+++ b/elements/layout/stories/gap.js
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { STORIES_LAYOUT_STYLE } from "../src/enums";
+import { STORIES_LAYOUT_STYLE, STORIES_LAYOUT_ITEM_STYLE } from "../src/enums";
 
 export const GapStory = {
   args: {},
@@ -14,6 +14,11 @@ export const GapStory = {
       <eox-layout-item x="10" y="0" w="2" h="12"></eox-layout-item>
       <eox-layout-item x="4" y="10" w="4" h="2"></eox-layout-item>
     </eox-layout>
+    <style>
+      eox-layout-item {
+        ${STORIES_LAYOUT_ITEM_STYLE}
+      }
+    </style>
   `,
 };
 

--- a/elements/layout/stories/grid.js
+++ b/elements/layout/stories/grid.js
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { STORIES_LAYOUT_STYLE } from "../src/enums";
+import { STORIES_LAYOUT_STYLE, STORIES_LAYOUT_ITEM_STYLE } from "../src/enums";
 
 // Generate one [x,y] array for each slot in a 12x12 grid
 const renderItems = () => {
@@ -24,6 +24,11 @@ export const Grid = {
           >`
       )}
     </eox-layout>
+    <style>
+      eox-layout-item {
+        ${STORIES_LAYOUT_ITEM_STYLE}
+      }
+    </style>
   `,
 };
 

--- a/elements/layout/stories/primary.js
+++ b/elements/layout/stories/primary.js
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { STORIES_LAYOUT_STYLE } from "../src/enums";
+import { STORIES_LAYOUT_STYLE, STORIES_LAYOUT_ITEM_STYLE } from "../src/enums";
 
 export const Primary = {
   args: {},
@@ -19,6 +19,11 @@ export const Primary = {
         x="4" y="10" w="4" h="2"
       </eox-layout-item>
     </eox-layout>
+    <style>
+      eox-layout-item {
+        ${STORIES_LAYOUT_ITEM_STYLE}
+      }
+    </style>
   `,
 };
 


### PR DESCRIPTION
## Implemented changes

Removes default styling for eox-layout since we anyways tend to override it for each use. The style has instead been added to the storybook stories.

Closes #1110

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
