### PR TITLE
fix(style): introduce padding variable

### DIFF
--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -192,9 +192,6 @@ export class EOxLayerControlLayerList extends LitElement {
     li {
       border-bottom: 1px solid #0041703a;
     }
-    li:first-child {
-      border-top: 1px solid #0041703a;
-    }
     li:last-child {
       border: none;
     }

--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -187,6 +187,7 @@ export class EOxLayerControlLayerList extends LitElement {
     }
     li {
       list-style: none;
+      padding-left: var(--padding);
     }
     li {
       border-bottom: 1px solid #0041703a;

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -283,6 +283,7 @@ export class EOxLayerControlLayerTools extends LitElement {
     details.tools summary .icon::before {
       height: 16px;
       width: 16px;
+      margin-right: var(--padding);
     }
     eox-layercontrol-tools-items button.icon,
     eox-layercontrol-tools-items .button.icon {

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -252,7 +252,10 @@ export class EOxLayerControl extends LitElement {
     `;
   }
 
-  #styleEOX = `* { font-family: Roboto, sans-serif; }`;
+  #styleEOX = `* {
+    font-family: Roboto, sans-serif;
+    --padding: 0.5rem
+  }`;
 }
 
 customElements.define("eox-layercontrol", EOxLayerControl);

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -252,10 +252,15 @@ export class EOxLayerControl extends LitElement {
     `;
   }
 
-  #styleEOX = `* {
-    font-family: Roboto, sans-serif;
-    --padding: 0.5rem
-  }`;
+  #styleEOX = `
+    :host, :root {
+      font-family: Roboto, sans-serif;
+      --padding: 0.5rem;
+
+      display: block;
+      padding: var(--padding) 0;
+    }
+  `;
 }
 
 customElements.define("eox-layercontrol", EOxLayerControl);


### PR DESCRIPTION
## Implemented changes

This PR brings the same "treatment" to the layercontrol like previously for the itemfilter in #1280.

## Screenshots/Videos

### Default padding `--padding: 0.5rem`
![image](https://github.com/user-attachments/assets/17283ecb-52d9-4613-9906-81bb752ba9f9)

### No padding `--padding: 0rem`
![image](https://github.com/user-attachments/assets/3cfe4eb5-203e-40bc-8d5d-b07185177945)

### Increased padding `--padding: 2rem`
![image](https://github.com/user-attachments/assets/df86c729-c278-4679-ab01-844527519fd2)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
