### PR TITLE
fix(style): adapt padding for non-aggregated lists

### DIFF
--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -144,7 +144,7 @@ section:not(section:last-of-type) {
 ul:not(#filters) > li {
   padding: 5px 0;
 }
-.details-results ul:not(#filters) li {
+ul#results li {
   padding: 5px var(--padding);
 }
 section {


### PR DESCRIPTION
## Implemented changes

This fixes a small issue with non-aggregated lists, following the previous PR that introduced paddings

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
