### PR TITLE
feat(style): add text-transform variable

### DIFF
--- a/elements/itemfilter/src/components/expand-container.js
+++ b/elements/itemfilter/src/components/expand-container.js
@@ -72,7 +72,7 @@ export class EOxItemFilterExpandContainer extends LitElement {
             <span
               class="title"
               style="${!this.filterObject.title &&
-              "text-transform: capitalize"}"
+              "text-transform: var(--text-transform)"}"
             >
               ${this.filterObject.title || this.filterObject.key || "Filter"}
               <slot name="reset-button"></slot>

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -23,6 +23,7 @@ export const styleEOX = `
   );
   --background-color: #fff;
   --padding: 0.5rem;
+  --text-transform: capitalize;
 }
 * {
   font-family: Roboto, sans-serif;
@@ -59,7 +60,7 @@ details > summary::-webkit-details-marker {
 .title {
   font-size: 13px;
   align-items: center;
-  text-transform: capitalize;
+  text-transform: var(--text-transform);
 }
 .subtitle {
   font-size: 11px;
@@ -110,7 +111,7 @@ eox-itemfilter-expandcontainer > [data-type=filter] {
 }
 [data-type=filter] .title,
 details summary {
-  text-transform: capitalize;
+  text-transform: var(--text-transform);
 }
 li,
 label,
@@ -290,7 +291,7 @@ button.icon {
 }
 .chip-title {
   pointer-events: none;
-  text-transform: capitalize;
+  text-transform: var(--text-transform);
 }
 .chip {
   display: flex;


### PR DESCRIPTION
## Implemented changes

This PR introduces a new CSS variable called `text-transform`. With this, the default text-transform of filter property titles, filter properties and results can be overridden (default is `capitalize`).

## Screenshots/Videos
### Default (`capitalize`)
![image](https://github.com/user-attachments/assets/4d8e64ca-a78c-49c0-bb70-3c1339a5cfcd)

### `--text-transform: none`
![image](https://github.com/user-attachments/assets/89b5c75b-618f-4792-851b-aac9fff50b41)

### `--text-transform: uppercase`
![image](https://github.com/user-attachments/assets/c1a4089c-d391-4a59-9bd6-b2c4f79da2d8)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
