### PR TITLE
fix: layer order stability insided group layers

### DIFF
--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -361,7 +361,7 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
 
     // Reorder the layers to match the REVERSE of the new definition
     // (EOx-Layers-JSON is in reverse painters order)
-    const reverseNewLayerIds = [...newLayerIds.reverse()];
+    const reverseNewLayerIds = newLayerIds.toReversed();
     layerCollection
       .getArray()
       .sort(

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -359,7 +359,9 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
       }
     });
 
-    // Reorder the layers to match the new definition
+    // Reorder the layers to match the REVERSE of the new definition
+    // (EOx-Layers-JSON is in reverse painters order)
+    const reverseNewLayerIds = [...newLayerIds.reverse()];
     layerCollection
       .getArray()
       .sort(
@@ -368,8 +370,8 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
           /** @type {import("ol/layer/Base").default} **/ layerB,
         ) => {
           return (
-            newLayerIds.indexOf(layerA.get("id")) -
-            newLayerIds.indexOf(layerB.get("id"))
+            reverseNewLayerIds.indexOf(layerA.get("id")) -
+            reverseNewLayerIds.indexOf(layerB.get("id"))
           );
         },
       );

--- a/elements/map/test/cases/group-layer/index.js
+++ b/elements/map/test/cases/group-layer/index.js
@@ -6,3 +6,4 @@ export { default as checkLayerInsideReactive } from "./check-layer-inside-reacti
 export { default as addNewLayersNestedGroup } from "./add-new-layers-nested-group";
 export { default as realisticGroupLayerReactivity } from "./realistic-group-layer-reactivity";
 export { default as reactivelyRemovesLayerFromGroup } from "./reactively-removes-layer-from-group";
+export { default as keepsLayerOrder } from "./keeps-layer-order-inside-group";

--- a/elements/map/test/cases/group-layer/keeps-layer-order-inside-group.js
+++ b/elements/map/test/cases/group-layer/keeps-layer-order-inside-group.js
@@ -1,0 +1,34 @@
+import { html } from "lit";
+import ecoRegionsFixture from "../../fixtures/ecoregions.json";
+
+/**
+ * Tests to check layer order stability inside group
+ */
+const keepsLayerOrder = (layersJson) => {
+  console.log(layersJson);
+  cy.intercept("https://openlayers.org/data/vector/ecoregions.json", (req) => {
+    req.reply(ecoRegionsFixture);
+  });
+  cy.intercept(/^.*openstreetmap.*$/, {
+    fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
+  });
+  cy.mount(html`<eox-map .layers=${layersJson}></eox-map>`).as("eox-map");
+  cy.get("eox-map").and(($el) => {
+    const eoxMap = $el[0];
+    const layerOrderInJSON = layersJson[0].layers.map((l) => l.properties.id);
+    eoxMap.layers = structuredClone(layersJson);
+    const groupLayer = eoxMap.getLayerById("group");
+    const reversedLayerOrderInOl = groupLayer
+      .getLayers()
+      .getArray()
+      .map((l) => l.get("id"))
+      .toReversed();
+
+    expect(
+      layerOrderInJSON,
+      "keeps transformation from revese painters order to painters order",
+    ).to.be.deep.equal(reversedLayerOrderInOl);
+  });
+};
+
+export default keepsLayerOrder;

--- a/elements/map/test/groupLayer.cy.js
+++ b/elements/map/test/groupLayer.cy.js
@@ -6,6 +6,7 @@ import {
   reactivelyAddsLayerToGroup,
   reactivelyRemovesLayerFromGroup,
   realisticGroupLayerReactivity,
+  keepsLayerOrder,
 } from "./cases/group-layer";
 
 const osmJson = {
@@ -77,6 +78,12 @@ describe("layers", () => {
    */
   it("reactively removes layer from group", () =>
     reactivelyRemovesLayerFromGroup(layersJson));
+
+  /**
+   * Test case to check layer order stability inside group
+   */
+  it("layers inside group keep layer order after updating", () =>
+    keepsLayerOrder(layersJson));
 
   /**
    * Test case to check layer inside the group is reactive


### PR DESCRIPTION
## Implemented changes

This PR fixes a problem described in #1251 about the stability of nested layers. The problem was a faulty conversion from the reverse-painter-order of the `EOxMap` layer json notation to the painter-order of `ol`.

The problem was quite hidden because it only affected the layer order inside group layers and only occured when `updating` the layers. A simple test has been added that sets the same layer json to a map, which actually reversed the layer order in `ol` until now.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
