### PR TITLE
fix: fall back to filter key if no title is provided (chip display)

### DIFF
--- a/elements/itemfilter/src/helpers/chip-items.js
+++ b/elements/itemfilter/src/helpers/chip-items.js
@@ -9,7 +9,7 @@ import { html } from "lit";
 function getChipItems(filters) {
   return Object.keys(filters)
     .map((filter) => ({
-      title: html`${filters[filter].title}:
+      title: html`${filters[filter].title || filters[filter].key}:
         <strong>${filters[filter].stringifiedState}</strong>`,
       key: filter,
     }))


### PR DESCRIPTION
## Implemented changes

Turns out the issue described in #1325 was a generic issue that didn't render any chip title if no filter `title` is provided. This PR introduces a fallback to use the `key` if no `title` is provided.

## Screenshots/Videos

### Before
![image](https://github.com/user-attachments/assets/78e7a08b-9ded-4d60-ba1e-190c6686d856)

### After
![image](https://github.com/user-attachments/assets/f0350d8b-89d9-4c2f-9a67-af28504274c1)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
