### PR TITLE
fix: keep `selectLayer` activation state in change listener

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -202,10 +202,13 @@ export class EOxSelectInteraction {
     // Set up the map event listener for the specified condition (e.g., click, pointermove)
     const changeLayerListener = () => {
       if (eoxMap.getLayerById(selectLayer.get("id"))) {
-        eoxMap.selectInteractions[options.id]?.setActive(true);
+        // If a select layer exists, keep it in current activation state
+        // (active/inactive) and assign it (and the overlay) to the map
         this.selectStyleLayer?.setMap(this.eoxMap.map);
         overlay?.setMap(this.eoxMap.map);
       } else {
+        // If the selection layer does not exist any more,
+        // set it to inactive, and remove layer plus overlay
         eoxMap.selectInteractions[options.id]?.setActive(false);
         this.selectStyleLayer?.setMap(null);
         overlay?.setMap(null);


### PR DESCRIPTION
## Implemented changes
This PR removes the hardcoded `setActive(true)` in the change listener for `selectLayer`. This caused issues if the selection was currently set to `active = false` and updating the layer would mistakenly reset the interaction back to `active`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
