### PR TITLE
feat: add hover interaction pointer cursor

### DIFF
--- a/elements/map/package.json
+++ b/elements/map/package.json
@@ -7,10 +7,12 @@
     "flatgeobuf": "^3.35.0",
     "lit": "^3.0.2",
     "ol": "^10.2.0",
+    "ol-ext": "^4.0.24",
     "ol-stac": "^1.0.0-beta.10",
     "proj4": "^2.9.2"
   },
   "devDependencies": {
+    "@types/ol-ext": "github:siedlerchr/types-ol-ext#a76d90780322f405e6fd4ac1756cb7de89ac387b",
     "@types/proj4": "^2.5.4",
     "vite": "^5.0.2"
   },

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -273,7 +273,11 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
 
         if (!correspondingNewInteraction) {
           // Remove interactions that don't exist in the new definition
-          EOxMap.removeInteraction(interactionDefinition.options.id);
+          if (interactionDefinition.type === "select") {
+            EOxMap.removeSelect(interactionDefinition.options.id);
+          } else {
+            EOxMap.removeInteraction(interactionDefinition.options.id);
+          }
         } else {
           // Update existing interaction if it has changed
           if (correspondingNewInteraction.type === "draw") {

--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -5,6 +5,7 @@ import Feature from "ol/Feature";
 import RenderFeature from "ol/render/Feature";
 import VectorLayer from "ol/layer/Vector";
 import { createEmpty, extend, isEmpty } from "ol/extent";
+import Hover from "ol-ext/interaction/Hover";
 
 /**
  * @typedef {import('../main').EOxMap} EOxMap
@@ -215,6 +216,23 @@ export class EOxSelectInteraction {
       }
     };
     eoxMap.map.getLayerGroup().on("change", changeLayerListener);
+
+    /**
+     * Sets up the ol-ext Hover interaction
+     * for the selection layer
+     * and passes the `options.hover` object
+     */
+    this.hover = new Hover({
+      ...options.hover,
+      layers: [this.selectLayer],
+    });
+    this.hover.setActive(this.active);
+    this.eoxMap.map.addInteraction(this.hover);
+    if (options.condition === "click") {
+      this.hover.on("enter", () => {
+        this.hover.setCursor("pointer");
+      });
+    }
   }
 
   /**
@@ -223,6 +241,7 @@ export class EOxSelectInteraction {
    */
   setActive(active) {
     this.active = active;
+    this.hover?.setActive(active);
   }
 
   /**

--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -121,7 +121,7 @@ export class EOxSelectInteraction {
           return initialStyle(feature, resolution); // Apply style only if the feature is selected
         }
         return null;
-      }
+      },
     );
 
     /**
@@ -278,7 +278,7 @@ export class EOxSelectInteraction {
       } else {
         const map = this.eoxMap.map;
         const allRenderedFeatures = this.selectLayer.getFeaturesInExtent(
-          map.getView().calculateExtent(map.getSize())
+          map.getView().calculateExtent(map.getSize()),
         );
         for (let i = 0; i < allRenderedFeatures.length; i++) {
           const renderFeature = allRenderedFeatures[i];
@@ -321,7 +321,7 @@ export class EOxSelectInteraction {
       return feature.get("id");
     }
     throw Error(
-      "No feature id found. Please provide which feature property should be taken instead using idProperty."
+      "No feature id found. Please provide which feature property should be taken instead using idProperty.",
     );
   }
 }
@@ -344,7 +344,7 @@ export function addSelect(EOxMap, selectLayer, options) {
     EOxMap,
     selectLayer,
     // @ts-expect-error - Argument of type 'DrawOptions | SelectOptions' is not assignable to parameter of type 'SelectOptions'
-    options
+    options,
   );
 
   return EOxMap.selectInteractions[options.id];

--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -121,7 +121,7 @@ export class EOxSelectInteraction {
           return initialStyle(feature, resolution); // Apply style only if the feature is selected
         }
         return null;
-      },
+      }
     );
 
     /**
@@ -278,7 +278,7 @@ export class EOxSelectInteraction {
       } else {
         const map = this.eoxMap.map;
         const allRenderedFeatures = this.selectLayer.getFeaturesInExtent(
-          map.getView().calculateExtent(map.getSize()),
+          map.getView().calculateExtent(map.getSize())
         );
         for (let i = 0; i < allRenderedFeatures.length; i++) {
           const renderFeature = allRenderedFeatures[i];
@@ -300,6 +300,7 @@ export class EOxSelectInteraction {
   remove() {
     this.selectStyleLayer.setMap(null);
     delete this.eoxMap.selectInteractions[this.options.id];
+    this.eoxMap.map.removeInteraction(this.hover);
     this.selectLayer.un("change:source", this.changeSourceListener);
   }
 
@@ -320,7 +321,7 @@ export class EOxSelectInteraction {
       return feature.get("id");
     }
     throw Error(
-      "No feature id found. Please provide which feature property should be taken instead using idProperty.",
+      "No feature id found. Please provide which feature property should be taken instead using idProperty."
     );
   }
 }
@@ -343,7 +344,7 @@ export function addSelect(EOxMap, selectLayer, options) {
     EOxMap,
     selectLayer,
     // @ts-expect-error - Argument of type 'DrawOptions | SelectOptions' is not assignable to parameter of type 'SelectOptions'
-    options,
+    options
   );
 
   return EOxMap.selectInteractions[options.id];

--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -128,7 +128,7 @@ export class EOxSelectInteraction {
      * Listener to handle selection events
      * @param {import("ol/MapBrowserEvent").default<UIEvent>} event
      * **/
-    const listener = (event) => {
+    this.listener = (event) => {
       if (!this.active) {
         return;
       }
@@ -180,7 +180,7 @@ export class EOxSelectInteraction {
     };
 
     // Set up the map event listener for the specified condition (e.g., click, pointermove)
-    this.eoxMap.map.on(options.condition || "click", listener);
+    this.eoxMap.map.on(options.condition || "click", this.listener);
 
     // Set up the map event listener for the specified condition (e.g., click, pointermove)
     this.selectLayer.on("change:opacity", () => {
@@ -302,6 +302,7 @@ export class EOxSelectInteraction {
     delete this.eoxMap.selectInteractions[this.options.id];
     this.eoxMap.map.removeInteraction(this.hover);
     this.selectLayer.un("change:source", this.changeSourceListener);
+    this.eoxMap.map.un(this.options.condition || "click", this.listener);
   }
 
   /**

--- a/elements/map/src/main.js
+++ b/elements/map/src/main.js
@@ -428,7 +428,7 @@ export class EOxMap extends LitElement {
   /**
    * Removes a select interaction from the map by its ID.
    *
-   * @param {string} id - The ID of the select interaction to remove.
+   * @param {string | number} id - The ID of the select interaction to remove.
    */
   removeSelect(id) {
     removeSelectMethod(id, this);

--- a/elements/map/src/methods/map/remove.js
+++ b/elements/map/src/methods/map/remove.js
@@ -21,7 +21,7 @@ export function removeInteractionMethod(id, EOxMap) {
 /**
  * Removes a select interaction from the map and deletes it from the select interactions list in EOxMap.
  *
- * @param {string} id - The identifier for the select interaction to be removed.
+ * @param {string | number} id - The identifier for the select interaction to be removed.
  * @param {import("../../main").EOxMap} EOxMap - The map object containing the select interactions list.
  */
 export function removeSelectMethod(id, EOxMap) {

--- a/elements/map/test/cases/hover/add-select-interaction.js
+++ b/elements/map/test/cases/hover/add-select-interaction.js
@@ -30,6 +30,16 @@ const addSelectInteraction = () => {
         // moving the cursor to a feature, moving it off the feature, and onto the feature again
         expect(featureSelectCounter).to.be.equal(2);
       }
+      expect(
+        eoxMap.map
+          .getInteractions()
+          .getArray()
+          .find(
+            (i) =>
+              i.cursor_ ===
+              vectorLayerStyleJson[0].interactions[0].options.hover.cursor,
+          ),
+      ).to.exist;
     });
 
     eoxMap.map.on("loadend", () => {

--- a/elements/map/test/cases/select/index.js
+++ b/elements/map/test/cases/select/index.js
@@ -5,3 +5,4 @@ export { default as addSelectInteractionVector } from "./add-select-interaction-
 export { default as highlightByIdVectorLayer } from "./highlight-by-id-vector-layer";
 export { default as highlightByIdVectorTileLayer } from "./highlight-by-id-vector-tile-layer";
 export { default as removeSelectInteraction } from "./remove-select-interaction";
+export { default as removeSelectInteractionLayer } from "./remove-select-interaction-layer";

--- a/elements/map/test/cases/select/remove-select-interaction-layer.js
+++ b/elements/map/test/cases/select/remove-select-interaction-layer.js
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import vectorLayerJson from "../../fixtures/vectorLayer.json";
 import vectorTileLayerJson from "../../fixtures/vectorTilesLayer.json";
 
 /**
@@ -23,7 +24,7 @@ const removeSelectInteraction = () => {
   cy.get("eox-map").and(($el) => {
     const eoxMap = $el[0];
     expect(eoxMap.selectInteractions.selectInteraction).to.exist;
-    eoxMap.layers = JSON.parse(JSON.stringify(vectorTileLayerJson));
+    eoxMap.layers = vectorLayerJson;
     expect(eoxMap.selectInteractions.selectInteraction).to.not.exist;
   });
 };

--- a/elements/map/test/fixtures/hoverInteraction.json
+++ b/elements/map/test/fixtures/hoverInteraction.json
@@ -27,6 +27,9 @@
               "stroke-color": "red",
               "stroke-width": 3
             }
+          },
+          "hover": {
+            "cursor": "zoom-in"
           }
         }
       }

--- a/elements/map/test/selectInteraction.cy.js
+++ b/elements/map/test/selectInteraction.cy.js
@@ -4,6 +4,7 @@ import {
   addSelectInteractionVectorTile,
   highlightByIdVectorLayer,
   highlightByIdVectorTileLayer,
+  removeSelectInteractionLayer,
   removeSelectInteraction,
 } from "./cases/select/index.js";
 
@@ -57,6 +58,11 @@ describe("select interaction on click", () => {
    */
   it("programmatically highlight by IDs (VectorTileLayer)", () =>
     highlightByIdVectorTileLayer(vectorTileInteraction));
+
+  /**
+   * Test case to remove interaction by removing the layer
+   */
+  it("remove interaction with the layer", () => removeSelectInteractionLayer());
 
   /**
    * Test case to remove interaction

--- a/elements/map/test/selectInteraction.cy.js
+++ b/elements/map/test/selectInteraction.cy.js
@@ -55,7 +55,7 @@ describe("select interaction on click", () => {
   /**
    * Test case to highlight by ID (Vector Tile Layer)
    */
-  it.only("programmatically highlight by IDs (VectorTileLayer)", () =>
+  it("programmatically highlight by IDs (VectorTileLayer)", () =>
     highlightByIdVectorTileLayer(vectorTileInteraction));
 
   /**

--- a/elements/map/types.ts
+++ b/elements/map/types.ts
@@ -113,6 +113,7 @@ export type SelectOptions = Omit<
   modify?: boolean;
   type?: string;
   geometryFunction?: import("ol/interaction/Draw").GeometryFunction;
+  hover?: import("ol-ext/interaction/Hover").Options;
 };
 
 export type ControlOptions = import("ol/control/Control").Options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,9 +153,9 @@
         "wms-capabilities": "^0.6.0"
       },
       "devDependencies": {
-        "@eox/jsonform": "*",
-        "@eox/map": "*",
-        "@eox/timecontrol": "*",
+        "@eox/jsonform": "latest",
+        "@eox/map": "latest",
+        "@eox/timecontrol": "latest",
         "@types/sortablejs": "^1.15.1",
         "ol": "^10.0.0",
         "sortablejs": "^1.15.0",
@@ -232,10 +232,12 @@
         "flatgeobuf": "^3.35.0",
         "lit": "^3.0.2",
         "ol": "^10.2.0",
+        "ol-ext": "^4.0.24",
         "ol-stac": "^1.0.0-beta.10",
         "proj4": "^2.9.2"
       },
       "devDependencies": {
+        "@types/ol-ext": "github:siedlerchr/types-ol-ext#a76d90780322f405e6fd4ac1756cb7de89ac387b",
         "@types/proj4": "^2.5.4",
         "vite": "^5.0.2"
       },
@@ -4691,6 +4693,16 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/ol-ext": {
+      "name": "@siedlerchr/types-ol-ext",
+      "version": "3.5.1",
+      "resolved": "git+ssh://git@github.com/siedlerchr/types-ol-ext.git#a76d90780322f405e6fd4ac1756cb7de89ac387b",
+      "integrity": "sha512-nK/CHjjpzbeQ/xjmr6fwcKldiC12akLir2SKwdSyejRCgupVlTzKKW7FVufofZfm0Amqrc7BggRUbLB5mXc18g==",
+      "dev": true,
+      "peerDependencies": {
+        "jspdf": "^2.5.1"
+      }
+    },
     "node_modules/@types/proj4": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.5.tgz",
@@ -4708,6 +4720,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
       "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
       "dev": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -5689,6 +5709,19 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5905,6 +5938,17 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6069,6 +6113,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -6197,6 +6254,35 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -6715,6 +6801,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -8871,6 +8968,21 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -9741,6 +9853,33 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/dompurify": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
+      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/jsprim": {
       "version": "2.0.2",
@@ -10819,6 +10958,14 @@
         "url": "https://opencollective.com/openlayers"
       }
     },
+    "node_modules/ol-ext": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-4.0.24.tgz",
+      "integrity": "sha512-VEf1+mjvbe35mMsszVsugqcvWfeGcU8TwS+GgXm3nGYqiHR7CckX2DWmM9B94QCDnrJWKKXBicfInbkoe2xT7w==",
+      "peerDependencies": {
+        "ol": ">= 5.3.0"
+      }
+    },
     "node_modules/ol-pmtiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ol-pmtiles/-/ol-pmtiles-0.2.0.tgz",
@@ -11519,6 +11666,17 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -11866,6 +12024,17 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rimraf": {
       "version": "6.0.1",
@@ -12518,6 +12687,17 @@
         "urijs": "^1.19.11"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -12669,6 +12849,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/sweepline-intersections": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
@@ -12793,6 +12984,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -13363,6 +13565,17 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {


### PR DESCRIPTION
## Implemented changes

This PR adds a `pointer` cursor in situations where we have a "click" select interaction. It uses the `Hover` interaction from `ol-ext` in order to achieve this.
Note: for "pointermove" selection, the pointer does not change!
Via `options.hover` it is also possible to pass further parameters to the interaction (e.g. different cursor, cursor depending on shape, custom callbacks etc.)

## Screenshots/Videos

[Screencast from 2024-10-29 11:29:18.webm](https://github.com/user-attachments/assets/bc53c512-9057-4a61-a020-f6f7abc6634b)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
