### PR TITLE
fix: initialize draw layer with `zIndex` 100

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -92,7 +92,7 @@ export class EOxDrawTools extends LitElement {
     this.draw = null;
 
     /**
-     * The current native OpenLayers draw `layer`
+     * The current native OpenLayers draw `layer` (initialized with a `zIndex` of 100)
      * @type import("ol/layer/Vector").default
      */
 

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -17,6 +17,7 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
   const OlMap = EoxMap.map;
 
   EoxDrawTool.drawLayer = EoxMap.addOrUpdateLayer({
+    zIndex: 100,
     type: "Vector",
     properties: {
       id: "drawLayer",


### PR DESCRIPTION
## Implemented changes

This initializes the draw layer with a `zIndex` of 100, so that it is on top of other layers in the majority of cases.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
