### PR TITLE
feat: add hover interaction pointer cursor (alternative)

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -215,6 +215,28 @@ export class EOxSelectInteraction {
       }
     };
     eoxMap.map.getLayerGroup().on("change", changeLayerListener);
+
+    /**
+     * Adds a listener on pointermove
+     */
+    this.pointerMoveListener = (e) => {
+      if (e.dragging) return;
+      eoxMap.map.getTargetElement().style.cursor = eoxMap.map.hasFeatureAtPixel(
+        e.pixel,
+        {
+          layerFilter: (l) =>
+            l
+              .get("interactions")
+              ?.find(
+                (i) => i.type == "select" && i.options?.condition === "click",
+              ),
+          ...options.atPixelOptions,
+        },
+      )
+        ? options.cursor || "pointer"
+        : "auto";
+    };
+    eoxMap.map.on("pointermove", this.pointerMoveListener);
   }
 
   /**
@@ -282,6 +304,7 @@ export class EOxSelectInteraction {
     this.selectStyleLayer.setMap(null);
     delete this.eoxMap.selectInteractions[this.options.id];
     this.selectLayer.un("change:source", this.changeSourceListener);
+    this.eoxMap.map.un("pointermove", this.pointerMoveListener);
   }
 
   /**

--- a/elements/map/test/cases/select/add-select-interaction-vector-tile.js
+++ b/elements/map/test/cases/select/add-select-interaction-vector-tile.js
@@ -18,7 +18,10 @@ const addSelectInteractionVectorTile = (vectorTileInteraction) => {
     cy.get("eox-map").and(($el) => {
       const eoxMap = $el[0];
       eoxMap.addEventListener("select", (evt) => {
-        expect(eoxMap.map.getTargetElement().style.cursor, 'changes cursor to pointer').to.be.equal('pointer');
+        expect(
+          eoxMap.map.getTargetElement().style.cursor,
+          "changes cursor to pointer",
+        ).to.be.equal("pointer");
         expect(evt.detail.feature).to.exist;
         resolve();
       });

--- a/elements/map/test/cases/select/add-select-interaction-vector-tile.js
+++ b/elements/map/test/cases/select/add-select-interaction-vector-tile.js
@@ -18,10 +18,12 @@ const addSelectInteractionVectorTile = (vectorTileInteraction) => {
     cy.get("eox-map").and(($el) => {
       const eoxMap = $el[0];
       eoxMap.addEventListener("select", (evt) => {
+        expect(eoxMap.map.getTargetElement().style.cursor, 'changes cursor to pointer').to.be.equal('pointer');
         expect(evt.detail.feature).to.exist;
         resolve();
       });
       eoxMap.map.on("loadend", () => {
+        simulateEvent(eoxMap.map, "pointermove", 65, 13); // a feature here
         simulateEvent(eoxMap.map, "click", 65, 13);
       });
     });

--- a/elements/map/types.ts
+++ b/elements/map/types.ts
@@ -113,6 +113,8 @@ export type SelectOptions = Omit<
   modify?: boolean;
   type?: string;
   geometryFunction?: import("ol/interaction/Draw").GeometryFunction;
+  cursor?: "string";
+  atPixelOptions?: import("ol/Map").AtPixelOptions;
 };
 
 export type ControlOptions = import("ol/control/Control").Options;


### PR DESCRIPTION
## Implemented changes

This PR adds a `pointer` cursor in situations where we have a "click" select interaction.
It also adds two more options for the interaction:
- `cursor`: the desired cursor if the mouse hovers over a feature
- `atPixelOptions`: the native [ol `atPixelOptions` object](https://openlayers.org/en/latest/apidoc/module-ol_Map.html) allowing to set things like `hitTolerance` or `checkWrapped`.


This is an alternative implementation to #1342.

## Screenshots/Videos

[Screencast from 2024-10-29 11:29:18.webm](https://github.com/user-attachments/assets/bc53c512-9057-4a61-a020-f6f7abc6634b)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
