### PR TITLE
feat: enable configuring the projection of emitted features

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -38,6 +38,7 @@ export class EOxDrawTools extends LitElement {
       importFeatures: { attribute: "import-features", type: Boolean },
       showEditor: { attribute: "show-editor", type: Boolean },
       showList: { attribute: "show-list", type: Boolean },
+      projection: { type: String },
       noShadow: { type: Boolean },
       type: { type: String },
       unstyled: { type: Boolean },
@@ -134,6 +135,10 @@ export class EOxDrawTools extends LitElement {
      * Show list of features
      */
     this.showList = false;
+    /**
+     * Projection of the emitted drawn features
+     */
+    this.projection = "EPSG:4326";
 
     /**
      * Type of the drawn feature

--- a/elements/drawtools/src/methods/draw/emit-drawn-features.js
+++ b/elements/drawtools/src/methods/draw/emit-drawn-features.js
@@ -8,7 +8,21 @@ const emitDrawnFeaturesMethod = (EoxDrawTool, drawUpdateEvent) => {
   // Function to emit features after a timeout (ensures update)
   const emitFeatures = () => {
     // Update drawnFeatures with features from drawLayer's source
-    EoxDrawTool.drawnFeatures = EoxDrawTool.drawLayer.getSource().getFeatures();
+    const drawnFeatures = EoxDrawTool.drawLayer.getSource().getFeatures();
+    // Transform drawn features to the desired projection
+    const source = EoxDrawTool.eoxMap.projection || "EPSG:3857";
+    // has a default value of EPSG:4326
+    const destination = EoxDrawTool.projection;
+    // Update drawnFeatures with transformed features if the destination is defined
+    EoxDrawTool.drawnFeatures = destination
+      ? drawnFeatures.map((feat) => {
+          feat = feat.clone();
+          const transformed = feat.getGeometry().transform(source, destination);
+          feat.setGeometry(transformed);
+          return feat;
+        })
+      : drawnFeatures;
+
     EoxDrawTool.updateGeoJSON();
     EoxDrawTool.requestUpdate();
 


### PR DESCRIPTION
This closes #1275 by introducing `projection` attribute to `EOxDrawTools` to set the projection of the emitted features. The emitted features are transformed clones of the features on the map, in case the projection is explicitly set to a falsy value for example `undefined` the original features will be emitted. 


## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
