### PR TITLE
fix: properly remove interaction on layer update

### DIFF
--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -273,7 +273,11 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
 
         if (!correspondingNewInteraction) {
           // Remove interactions that don't exist in the new definition
-          EOxMap.removeInteraction(interactionDefinition.options.id);
+          if (interactionDefinition.type === "select") {
+            EOxMap.removeSelect(interactionDefinition.options.id);
+          } else {
+            EOxMap.removeInteraction(interactionDefinition.options.id);
+          }
         } else {
           // Update existing interaction if it has changed
           if (correspondingNewInteraction.type === "draw") {

--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -127,7 +127,7 @@ export class EOxSelectInteraction {
      * Listener to handle selection events
      * @param {import("ol/MapBrowserEvent").default<UIEvent>} event
      * **/
-    const listener = (event) => {
+    this.listener = (event) => {
       if (!this.active) {
         return;
       }
@@ -179,7 +179,7 @@ export class EOxSelectInteraction {
     };
 
     // Set up the map event listener for the specified condition (e.g., click, pointermove)
-    this.eoxMap.map.on(options.condition || "click", listener);
+    this.eoxMap.map.on(options.condition || "click", this.listener);
 
     // Set up the map event listener for the specified condition (e.g., click, pointermove)
     this.selectLayer.on("change:opacity", () => {
@@ -282,6 +282,7 @@ export class EOxSelectInteraction {
     this.selectStyleLayer.setMap(null);
     delete this.eoxMap.selectInteractions[this.options.id];
     this.selectLayer.un("change:source", this.changeSourceListener);
+    this.eoxMap.map.un(this.options.condition || "click", this.listener);
   }
 
   /**

--- a/elements/map/src/main.js
+++ b/elements/map/src/main.js
@@ -428,7 +428,7 @@ export class EOxMap extends LitElement {
   /**
    * Removes a select interaction from the map by its ID.
    *
-   * @param {string} id - The ID of the select interaction to remove.
+   * @param {string | number} id - The ID of the select interaction to remove.
    */
   removeSelect(id) {
     removeSelectMethod(id, this);

--- a/elements/map/src/methods/map/remove.js
+++ b/elements/map/src/methods/map/remove.js
@@ -21,7 +21,7 @@ export function removeInteractionMethod(id, EOxMap) {
 /**
  * Removes a select interaction from the map and deletes it from the select interactions list in EOxMap.
  *
- * @param {string} id - The identifier for the select interaction to be removed.
+ * @param {string | number} id - The identifier for the select interaction to be removed.
  * @param {import("../../main").EOxMap} EOxMap - The map object containing the select interactions list.
  */
 export function removeSelectMethod(id, EOxMap) {

--- a/elements/map/test/cases/select/index.js
+++ b/elements/map/test/cases/select/index.js
@@ -5,3 +5,4 @@ export { default as addSelectInteractionVector } from "./add-select-interaction-
 export { default as highlightByIdVectorLayer } from "./highlight-by-id-vector-layer";
 export { default as highlightByIdVectorTileLayer } from "./highlight-by-id-vector-tile-layer";
 export { default as removeSelectInteraction } from "./remove-select-interaction";
+export { default as removeSelectInteractionLayer } from "./remove-select-interaction-layer";

--- a/elements/map/test/cases/select/remove-select-interaction-layer.js
+++ b/elements/map/test/cases/select/remove-select-interaction-layer.js
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import vectorLayerJson from "../../fixtures/vectorLayer.json";
 import vectorTileLayerJson from "../../fixtures/vectorTilesLayer.json";
 
 /**
@@ -23,7 +24,7 @@ const removeSelectInteraction = () => {
   cy.get("eox-map").and(($el) => {
     const eoxMap = $el[0];
     expect(eoxMap.selectInteractions.selectInteraction).to.exist;
-    eoxMap.layers = JSON.parse(JSON.stringify(vectorTileLayerJson));
+    eoxMap.layers = vectorLayerJson;
     expect(eoxMap.selectInteractions.selectInteraction).to.not.exist;
   });
 };

--- a/elements/map/test/selectInteraction.cy.js
+++ b/elements/map/test/selectInteraction.cy.js
@@ -4,6 +4,7 @@ import {
   addSelectInteractionVectorTile,
   highlightByIdVectorLayer,
   highlightByIdVectorTileLayer,
+  removeSelectInteractionLayer,
   removeSelectInteraction,
 } from "./cases/select/index.js";
 
@@ -57,6 +58,11 @@ describe("select interaction on click", () => {
    */
   it("programmatically highlight by IDs (VectorTileLayer)", () =>
     highlightByIdVectorTileLayer(vectorTileInteraction));
+
+  /**
+   * Test case to remove interaction by removing the layer
+   */
+  it("remove interaction with the layer", () => removeSelectInteractionLayer());
 
   /**
    * Test case to remove interaction

--- a/elements/map/test/selectInteraction.cy.js
+++ b/elements/map/test/selectInteraction.cy.js
@@ -55,7 +55,7 @@ describe("select interaction on click", () => {
   /**
    * Test case to highlight by ID (Vector Tile Layer)
    */
-  it.only("programmatically highlight by IDs (VectorTileLayer)", () =>
+  it("programmatically highlight by IDs (VectorTileLayer)", () =>
     highlightByIdVectorTileLayer(vectorTileInteraction));
 
   /**


### PR DESCRIPTION
## Implemented changes

This PR fixes a bug with removing the select interaction when updating the layer. Also, there was still an .only on the select-interaction tests from the refactoring, causing test cases to be disabled.

Originating from commits in https://github.com/EOX-A/EOxElements/pull/1342.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
