### PR TITLE
feat: color swatches for layers and layer groups

### DIFF
--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -233,6 +233,9 @@ export class EOxLayerControlLayer extends LitElement {
       background: var(--layer-color);
       border-radius: 3px;
       content: "" !important;
+      width: 16px;
+      min-width: 16px;
+      height: 16px;
     }
     [data-type=group] .title::before {
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%230041703a' viewBox='0 0 24 24'%3E%3Ctitle%3Efolder-outline%3C/title%3E%3Cpath d='M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z' /%3E%3C/svg%3E");

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -175,17 +175,17 @@ export class EOxLayerControlLayer extends LitElement {
               />
 
               <!-- Layer title -->
-              <span class="title">${this.#getLayer(this.titleProperty)}</span>
+              <span
+                class="title ${this.#getLayer("color") ? 'color-swatch' : ''}"
+                style="--layer-color: ${this.#getLayer("color")}"
+              >
+                ${this.#getLayer(this.titleProperty)}
+              </span>
               ${when(
                 isToolsAvail,
                 () => html`<span class="tools-placeholder"></span>`,
               )}
             </label>
-
-            <span
-              class="color-swatch"
-              style="background-color: ${this.#getLayer("color")}"
-            />
           </div>
 
           <!-- Render layer tools -->
@@ -223,19 +223,16 @@ export class EOxLayerControlLayer extends LitElement {
       align-items: center;
       cursor: pointer;
     }
-    .layer .color-swatch {
-      position: absolute;
-      top: 12px;
-      right: 2px;
-      width: 8px;
-      height: 8px;
-      border-radius: 3px;
-    }
     [data-type] .title::before {
       width: 20px;
       min-width: 20px;
       height: 20px;
       margin-right: 6px;
+    }
+    [data-type] .title.color-swatch::before {
+      background: var(--layer-color);
+      border-radius: 3px;
+      content: "" !important;
     }
     [data-type=group] .title::before {
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%230041703a' viewBox='0 0 24 24'%3E%3Ctitle%3Efolder-outline%3C/title%3E%3Cpath d='M20,18H4V8H20M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z' /%3E%3C/svg%3E");

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -176,7 +176,7 @@ export class EOxLayerControlLayer extends LitElement {
 
               <!-- Layer title -->
               <span
-                class="title ${this.#getLayer("color") ? 'color-swatch' : ''}"
+                class="title ${this.#getLayer("color") ? "color-swatch" : ""}"
                 style="--layer-color: ${this.#getLayer("color")}"
               >
                 ${this.#getLayer(this.titleProperty)}

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -181,6 +181,11 @@ export class EOxLayerControlLayer extends LitElement {
                 () => html`<span class="tools-placeholder"></span>`,
               )}
             </label>
+
+            <span
+              class="color-swatch"
+              style="background-color: ${this.#getLayer("color")}"
+            />
           </div>
 
           <!-- Render layer tools -->
@@ -201,6 +206,7 @@ export class EOxLayerControlLayer extends LitElement {
     ${checkbox}
     eox-layercontrol-layer {
       width: 100%;
+      position: relative;
     }
     .layer.zoom-state-invisible {
       background: #d2e2ee;
@@ -216,6 +222,14 @@ export class EOxLayerControlLayer extends LitElement {
       display: flex;
       align-items: center;
       cursor: pointer;
+    }
+    .layer .color-swatch {
+      position: absolute;
+      top: 12px;
+      right: 2px;
+      width: 8px;
+      height: 8px;
+      border-radius: 3px;
     }
     [data-type] .title::before {
       width: 20px;

--- a/elements/layercontrol/stories/index.js
+++ b/elements/layercontrol/stories/index.js
@@ -18,3 +18,4 @@ export { default as addExternalLayerStory } from "./add-external-layer";
 export { default as layerZoomStateStory } from "./layer-zoom-state";
 export { default as unstyledStory } from "./unstyled";
 export { default as toolsAsListStory } from "./tools-as-list";
+export { default as layerColorStory } from "./layer-color";

--- a/elements/layercontrol/stories/layer-color.js
+++ b/elements/layercontrol/stories/layer-color.js
@@ -18,11 +18,19 @@ const COLORED_LAYERS = [
       description: "# Hello world",
     },
     layers: [
-      STORIES_LAYER_SENTINEL_HUB.wind,
-      STORIES_LAYER_SENTINEL_HUB.no2,
-      STORIES_LAYER_REGION,
+      {
+        ...STORIES_LAYER_SENTINEL_HUB.wind,
+        color: "#008955",
+      },
+      {
+        ...STORIES_LAYER_SENTINEL_HUB.no2,
+        color: "#008397",
+      },
+      {
+        ...STORIES_LAYER_REGION,
+        color: "#007bcb",
+      },
     ],
-    color: "red",
   },
   {
     type: "Group",
@@ -31,7 +39,6 @@ const COLORED_LAYERS = [
       title: "Background Layers",
     },
     layers: [STORIES_LAYER_S2, STORIES_LAYER_OSM],
-    color: "blue",
   },
 ];
 

--- a/elements/layercontrol/stories/layer-color.js
+++ b/elements/layercontrol/stories/layer-color.js
@@ -1,0 +1,61 @@
+import { html } from "lit";
+import {
+  STORIES_MAIN_MAP_LAYERS,
+  STORIES_MAP_STYLE,
+  STORIES_LAYER_SENTINEL_HUB,
+  STORIES_LAYER_REGION,
+  STORIES_LAYER_S2,
+  STORIES_LAYER_OSM,
+} from "../src/enums";
+
+const COLORED_LAYERS = [
+  {
+    type: "Group",
+    properties: {
+      id: "group2",
+      title: "Data Layers",
+      layerControlExpand: true,
+      description: "# Hello world",
+    },
+    layers: [
+      STORIES_LAYER_SENTINEL_HUB.wind,
+      STORIES_LAYER_SENTINEL_HUB.no2,
+      STORIES_LAYER_REGION,
+    ],
+    color: "red",
+  },
+  {
+    type: "Group",
+    properties: {
+      id: "group1",
+      title: "Background Layers",
+    },
+    layers: [STORIES_LAYER_S2, STORIES_LAYER_OSM],
+    color: "blue",
+  },
+];
+
+export const LayerColor = {
+  args: {
+    idProperty: "id",
+    titleProperty: "title",
+    unstyled: false,
+  },
+  render: (args) => html`
+    <div style="display: flex">
+      <eox-layercontrol
+        .idProperty=${args.idProperty}
+        .titleProperty=${args.titleProperty}
+        .unstyled=${args.unstyled}
+        for="eox-map"
+      ></eox-layercontrol>
+      <eox-map
+        .style=${STORIES_MAP_STYLE}
+        .zoom=${3}
+        .layers=${COLORED_LAYERS}
+      ></eox-map>
+    </div>
+  `,
+};
+
+export default LayerColor;

--- a/elements/layercontrol/stories/layer-color.js
+++ b/elements/layercontrol/stories/layer-color.js
@@ -1,6 +1,5 @@
 import { html } from "lit";
 import {
-  STORIES_MAIN_MAP_LAYERS,
   STORIES_MAP_STYLE,
   STORIES_LAYER_SENTINEL_HUB,
   STORIES_LAYER_REGION,

--- a/elements/layercontrol/stories/layercontrol.stories.js
+++ b/elements/layercontrol/stories/layercontrol.stories.js
@@ -13,6 +13,7 @@ import {
   layerZoomStateStory,
   toolsAsListStory,
   layerLegendStory,
+  layerColorStory,
 } from ".";
 
 export default {
@@ -110,3 +111,9 @@ export const Unstyled = unstyledStory;
  * Tools rendered as list instead of tabs
  */
 export const ToolsAsList = toolsAsListStory;
+
+
+/**
+ * Shows how to define color "swatches" for layers.
+ */
+export const LayerColor = layerColorStory;

--- a/elements/layercontrol/stories/layercontrol.stories.js
+++ b/elements/layercontrol/stories/layercontrol.stories.js
@@ -112,8 +112,7 @@ export const Unstyled = unstyledStory;
  */
 export const ToolsAsList = toolsAsListStory;
 
-
 /**
  * Shows how to define color "swatches" for layers.
  */
-export const LayerColor = layerColorStory;
+export const ColoredLayers = layerColorStory;

--- a/elements/layercontrol/test/cases/general/color-swatch.js
+++ b/elements/layercontrol/test/cases/general/color-swatch.js
@@ -1,0 +1,23 @@
+// 
+const colorSwatch = () => {
+  // Set up the layers in the mock map
+  cy.get("mock-map").then(($el) => {
+    const mockMap = $el[0]; // Accessing the mock map element
+
+    // Setting layers: one visible and another with layerControlDisable: true
+    mockMap.setLayers([
+      { visible: true, color: "green" },
+      { properties: { layerControlDisable: true } },
+    ]);
+  });
+
+  // Verify the effect on the LayerControl
+  cy.get("eox-layercontrol")
+    .shadow()
+    .within(() => {
+      cy.get(".color-swatch").should("exist");
+  });
+};
+  
+export default colorSwatch;
+  

--- a/elements/layercontrol/test/cases/general/color-swatch.js
+++ b/elements/layercontrol/test/cases/general/color-swatch.js
@@ -1,4 +1,4 @@
-// 
+// Check if the color swatch appears when a `color` property is present
 const colorSwatch = () => {
   // Set up the layers in the mock map
   cy.get("mock-map").then(($el) => {
@@ -16,8 +16,7 @@ const colorSwatch = () => {
     .shadow()
     .within(() => {
       cy.get(".color-swatch").should("exist");
-  });
+    });
 };
-  
+
 export default colorSwatch;
-  

--- a/elements/layercontrol/test/cases/general/index.js
+++ b/elements/layercontrol/test/cases/general/index.js
@@ -8,3 +8,4 @@ export { default as hideLayers } from "./hide-layers";
 export { default as emptyGroup } from "./empty-groups";
 export { default as renderOptionalLayer } from "./render-optional-layer";
 export { default as showCorrectLayerTitle } from "./show-layer-title";
+export { default as colorSwatch } from "./color-swatch";

--- a/elements/layercontrol/test/general.cy.js
+++ b/elements/layercontrol/test/general.cy.js
@@ -12,6 +12,7 @@ import {
   renderOptionalLayer,
   showCorrectLayerTitle,
   checkLayerLegend,
+  colorSwatch,
 } from "./cases/general";
 
 describe("LayerControl", () => {
@@ -57,5 +58,9 @@ describe("LayerControl", () => {
     checkPreOpenLayerTools());
   it("renders layer specific legend", () => {
     checkLayerLegend();
+  });
+
+  it("replaces icon with color swatch if color property is present on the layer", () => {
+    colorSwatch();
   });
 });


### PR DESCRIPTION
## Implemented changes

To make it easier to associate layers with additional information in a parent app, this pull requests implements color swatches for individual layers. These automatically replace the icons of layers and layer groups with the color swatch as long as the `color` attribute is set in the OpenLayers layer.

<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
<img width="682" alt="Screenshot 2024-11-27 at 16 06 03" src="https://github.com/user-attachments/assets/091e9c4b-c9f9-4c19-9094-509183598008">

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
