### PR TITLE
feat: css variables for layout and visibility

### DIFF
--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -24,9 +24,21 @@ export const styleEOX = `
   --background-color: #fff;
   --padding: 0.5rem;
   --text-transform: capitalize;
+  --form-flex-direction: column;
+  --filter-display: block;
 }
 * {
   font-family: Roboto, sans-serif;
+}
+form#itemfilter {
+  flex-direction: var(--form-flex-direction);
+}
+eox-itemfilter-container {
+  min-width: 200px;
+  display: var(--filter-display);
+}
+eox-itemfilter-results {
+  flex-grow: 1;
 }
 ul {
   padding-left: 0;
@@ -89,8 +101,7 @@ details.details-results summary::before {
   width: 24px;
 }
 details.details-filter summary::after {
-  position: absolute;
-  right: 8px;
+  margin-left: auto;
   transform: rotate(90deg);
 }
 details[open] summary::before {

--- a/elements/itemfilter/stories/css-variables.js
+++ b/elements/itemfilter/stories/css-variables.js
@@ -1,0 +1,36 @@
+import items from "../test/testItems.json";
+import { html } from "lit";
+
+/**
+ * Generates a story configuration for showcasing the CSS variables
+ *
+ * @returns {Object} The story configuration with arguments for the component.
+ */
+function CSSVariablesStory() {
+  return {
+    render: (args) =>
+      html`<eox-itemfilter
+        .aggregateResults=${args.aggregateResults}
+        .items=${args.items}
+        .titleProperty=${args.titleProperty}
+        .subTitleProperty=${args.subTitleProperty}
+        .filterProperties=${args.filterProperties}
+        style="--form-flex-direction: row"
+      ></eox-itemfilter>`,
+    args: {
+      aggregateResults: "themes",
+      titleProperty: "title",
+      subTitleProperty: "description",
+      filterProperties: [
+        {
+          key: "themes",
+          title: "Theme",
+          type: "multiselect",
+        },
+      ],
+      items,
+    },
+  };
+}
+
+export default CSSVariablesStory;

--- a/elements/itemfilter/stories/index.js
+++ b/elements/itemfilter/stories/index.js
@@ -7,3 +7,4 @@ export { default as AutoSpreadStory } from "./auto-spread"; // Item filter with 
 export { default as PreSetFilterStory } from "./pre-set-filter"; // Item filter with pre-set filter
 export { default as NestedPropertyStory } from "./nested-property"; // Item filter with nested property
 export { default as ExternalStory } from "./external"; // Item filter with external endpoint
+export { default as CSSVariablesStory } from "./css-variables";

--- a/elements/itemfilter/stories/itemfilter.stories.js
+++ b/elements/itemfilter/stories/itemfilter.stories.js
@@ -2,6 +2,7 @@
 
 import {
   AutoSpreadStory,
+  CSSVariablesStory,
   ExternalStory,
   InlineModeStory,
   NestedPropertyStory,
@@ -46,3 +47,9 @@ export const External = ExternalStory();
  * get spread to the root level
  */
 export const AutoSpread = AutoSpreadStory();
+
+/**
+ * CSS variables can be used to modify the styling and layout of itemfilter: e.g. the `--form-flex-direction`
+ * variable set to `row` instead of `column` (default)
+ */
+export const CSSVariables = CSSVariablesStory();


### PR DESCRIPTION
## Implemented changes

This PR introduces two new CSS variables that allow modifiying the layout:
- `--form-flex-direction`: make the results either appear under the filter (`column`) or next to it (`row`)
- `--filter-display`: show the filters section (`block`) or hide it (`none`)

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/8c20f007-1169-4350-9af4-da57e324e936)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
