### PR TITLE
fix: re-enable result title slot

### DIFF
--- a/elements/itemfilter/src/components/results.js
+++ b/elements/itemfilter/src/components/results.js
@@ -114,9 +114,7 @@ export class EOxItemFilterResults extends LitElement {
   render() {
     return html`
       <section id="section-results">
-        <div>
-          <h6 class="main-heading">Results</h6>
-        </div>
+        <div slot="resultstitle"></div>
         <div id="container-results" class="scroll">
           ${when(
             this.results.length < 1,

--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -455,7 +455,11 @@ export class EOxItemFilter extends LitElement {
               .resultAggregation=${this.#resultAggregation}
               .selectedResult=${this.selectedResult}
               @result=${this.updateResult}
-            ></eox-itemfilter-results>
+            >
+              <slot name="resultstitle"
+                ><h6 class="main-heading">Results</h6></slot
+              >
+            </eox-itemfilter-results>
           `,
         )}
       </form>


### PR DESCRIPTION
## Implemented changes

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
