### PR TITLE
feat: display result image with ` imageProperty`

### DIFF
--- a/elements/itemfilter/src/enums/config.js
+++ b/elements/itemfilter/src/enums/config.js
@@ -66,6 +66,11 @@ export const ELEMENT_CONFIG = Object.freeze({
   subTitleProperty: undefined,
 
   /**
+   * The property of the result items used for an image
+   */
+  imageProperty: undefined,
+
+  /**
    * Allow opening multiple filter accordions in parallel
    * @default true
    */
@@ -96,6 +101,7 @@ export const ELEMENT_PROPERTIES = [
   "showResults",
   "titleProperty",
   "subTitleProperty",
+  "imageProperty",
   "idProperty",
   "expandMultipleFilters",
   "expandResults",

--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -56,6 +56,7 @@ export class EOxItemFilter extends LitElement {
       idProperty: { attribute: "id-property", type: String },
       titleProperty: { attribute: "title-property", type: String },
       subTitleProperty: { attribute: "sub-title-property", type: String },
+      imageProperty: { attribute: "image-property", type: String },
       expandMultipleFilters: {
         attribute: "enable-multiple-filter",
         type: Boolean,
@@ -198,6 +199,13 @@ export class EOxItemFilter extends LitElement {
      * @type String
      */
     this.subTitleProperty = undefined;
+
+    /**
+     * The property of the result items used for an image
+     *
+     * @type String
+     */
+    this.imageProperty = undefined;
 
     /**
      * Unique id property of items

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { getValue } from "../../helpers";
 
 /**
  * Creates the item details view for the aggregation property in the EOxItemFilterResults component.
@@ -87,6 +88,14 @@ export function createItemListMethod(
               ${when(
                 config.subTitleProperty,
                 () => html`
+                  ${getValue(config.imageProperty, item)
+                    ? html`
+                        <img
+                          class="image"
+                          src="${getValue(config.imageProperty, item)}"
+                        />
+                      `
+                    : nothing}
                   <div class="title-container">
                     <span class="title"
                       >${unsafeHTML(item[config.titleProperty])}</span

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -50,6 +50,11 @@ li {
 li span {
   text-overflow: ellipsis;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+}
+.cards li span {
+  display: block;
 }
 li label {
   display: flex;
@@ -78,6 +83,7 @@ details > summary::-webkit-details-marker {
   font-size: 16px;
   font-weight: 600;
   text-wrap: auto;
+  line-height: 19px;
 }
 .subtitle {
   font-size: 11px;
@@ -88,6 +94,19 @@ details > summary::-webkit-details-marker {
   font-size: 14px;
   color: #757575;
   text-wrap: auto;
+  line-height: 19px;
+}
+.image {
+  width: 24px;
+  height: 24px;
+  object-fit: cover;
+  overflow: hidden;
+  margin-right: 8px;
+}
+.cards .image {
+  width: 100%;
+  height: 190px;
+  margin-bottom: 8px;
 }
 .title-container {
   display: flex;
@@ -175,12 +194,12 @@ ul#results ul.cards {
   width: 100%;
   gap: 40px;
   margin: 20px 0;
+  cursor: initial;
 }
 ul#results ul.cards li {
   flex-basis: calc(33.3% - 77px);
   min-width: 0;
-  border: 1px solid var(--border-color);
-  padding: 12px 24px;
+  align-self: flex-start;
 }
 @media screen and (max-width: 768px) {
   ul#results ul.cards li {

--- a/elements/itemfilter/stories/card-display.js
+++ b/elements/itemfilter/stories/card-display.js
@@ -13,6 +13,7 @@ function CardDisplayStory() {
         .aggregateResults=${args.aggregateResults}
         .items=${args.items}
         .titleProperty=${args.titleProperty}
+        .imageProperty=${args.imageProperty}
         .subTitleProperty=${args.subTitleProperty}
         .filterProperties=${args.filterProperties}
         .resultType=${args.resultType}
@@ -21,6 +22,7 @@ function CardDisplayStory() {
       aggregateResults: "themes",
       titleProperty: "title",
       subTitleProperty: "description",
+      imageProperty: "assets.thumbnail.href",
       resultType: "cards",
       filterProperties: [
         {

--- a/elements/itemfilter/test/cases/general/image.js
+++ b/elements/itemfilter/test/cases/general/image.js
@@ -1,0 +1,15 @@
+/**
+ * Tests the image functionality. If the config option `imageProperty` is set,
+ * then an additional image is rendered.
+ */
+const imageTest = () => {
+  cy.get("eox-itemfilter")
+    .shadow()
+    .within(() => {
+      cy.get("eox-itemfilter-results").within(() => {
+        cy.get(".title").parent().siblings("img").should("exist");
+      });
+    });
+};
+
+export default imageTest;

--- a/elements/itemfilter/test/cases/general/index.js
+++ b/elements/itemfilter/test/cases/general/index.js
@@ -10,5 +10,6 @@ export { default as spatialFilterTest } from "./spatial-filter";
 export { default as externalFilterTest } from "./external-filter";
 export { default as nestedPropertyTest } from "./nested-property";
 export { default as subtitleTest } from "./subtitle";
+export { default as imageTest } from "./image";
 export { default as validationTest } from "./validation";
 export { default as slotRenderTest } from "./slots";

--- a/elements/itemfilter/test/general.cy.js
+++ b/elements/itemfilter/test/general.cy.js
@@ -12,6 +12,7 @@ import {
   externalFilterTest,
   nestedPropertyTest,
   subtitleTest,
+  imageTest,
   validationTest,
   slotRenderTest,
 } from "./cases/general/";
@@ -37,6 +38,7 @@ describe("Item Filter Config", () => {
         Object.assign(eoxItemFilter, {
           titleProperty: "title",
           subTitleProperty: "description",
+          imageProperty: "assets.thumbnail.href",
           filterProperties: [
             {
               keys: ["title", "themes"],
@@ -110,6 +112,11 @@ describe("Item Filter Config", () => {
   it("should render subtitles", () => subtitleTest());
 
   /**
+   * Test case to check if images are rendered correctly
+   */
+  it("should render images", () => imageTest());
+
+  /**
    * Test case to check if input validation is working
    */
   it("should have working validation", () => validationTest());
@@ -117,7 +124,7 @@ describe("Item Filter Config", () => {
   /**
    * Test case to check slot rendering
    */
-  it.only("renders slots correctly", { skipBeforeEach: true }, () =>
+  it("renders slots correctly", { skipBeforeEach: true }, () =>
     slotRenderTest(),
   );
 });

--- a/elements/itemfilter/test/testItems.json
+++ b/elements/itemfilter/test/testItems.json
@@ -43,6 +43,13 @@
           ]
         ]
       }
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://raw.githubusercontent.com/eurodatacube/eodash-assets/main/collections/NASAPopulation/NASAPopulation.png",
+        "type": "image/png",
+        "roles": ["thumbnail"]
+      }
     }
   },
   {
@@ -88,6 +95,13 @@
             [0, 10]
           ]
         ]
+      }
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://raw.githubusercontent.com/eurodatacube/eodash-assets/main/collections/ESDL_Hydrology_Precipitation/image.png",
+        "type": "image/png",
+        "roles": ["thumbnail"]
       }
     }
   },

--- a/elements/itemfilter/test/testItems.json
+++ b/elements/itemfilter/test/testItems.json
@@ -30,6 +30,11 @@
     "status": {
       "code": "active"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=1"
+      }
+    },
     "properties": {
       "started": "2023-06-14T13:56:38+00:00",
       "geometry": {
@@ -42,13 +47,6 @@
             [-90.0, 82.0]
           ]
         ]
-      }
-    },
-    "assets": {
-      "thumbnail": {
-        "href": "https://raw.githubusercontent.com/eurodatacube/eodash-assets/main/collections/NASAPopulation/NASAPopulation.png",
-        "type": "image/png",
-        "roles": ["thumbnail"]
       }
     }
   },
@@ -83,6 +81,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=2"
+      }
+    },
     "properties": {
       "started": "2023-06-13T13:56:38+00:00",
       "geometry": {
@@ -95,13 +98,6 @@
             [0, 10]
           ]
         ]
-      }
-    },
-    "assets": {
-      "thumbnail": {
-        "href": "https://raw.githubusercontent.com/eurodatacube/eodash-assets/main/collections/ESDL_Hydrology_Precipitation/image.png",
-        "type": "image/png",
-        "roles": ["thumbnail"]
       }
     }
   },
@@ -135,6 +131,11 @@
     "tags": ["air quality", "sea ice", "freeboard"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=3"
+      }
     },
     "properties": {
       "started": "2023-06-12T13:56:38+00:00",
@@ -170,6 +171,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=4"
+      }
+    },
     "properties": {
       "started": "2023-06-11T13:56:38+00:00"
     }
@@ -192,6 +198,11 @@
     "tags": ["economy", "vessel density", "cargo"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=5"
+      }
     },
     "properties": {
       "started": "2023-06-10T13:56:38+00:00"
@@ -216,6 +227,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=6"
+      }
+    },
     "properties": {
       "started": "2023-06-09T13:56:38+00:00"
     }
@@ -238,6 +254,11 @@
     "tags": ["economy", "vessel density", "others"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=7"
+      }
     },
     "properties": {
       "started": "2023-06-08T13:56:38+00:00"
@@ -263,6 +284,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=8"
+      }
+    },
     "properties": {
       "started": "2023-06-07T13:56:38+00:00"
     }
@@ -285,6 +311,11 @@
     "tags": ["air", "temperature", "C3S Data"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=9"
+      }
     },
     "properties": {
       "started": "2023-06-06T13:56:38+00:00"
@@ -309,6 +340,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=10"
+      }
+    },
     "properties": {
       "started": "2023-06-05T13:56:38+00:00"
     }
@@ -331,6 +367,11 @@
     "tags": ["air", "NO2", "city level"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=11"
+      }
     },
     "properties": {
       "started": "2023-06-04T13:56:38+00:00"
@@ -355,6 +396,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=12"
+      }
+    },
     "properties": {
       "started": "2023-06-03T13:56:38+00:00"
     }
@@ -377,6 +423,11 @@
     "tags": ["air", "O3", "city level"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=13"
+      }
     },
     "properties": {
       "started": "2023-06-02T13:56:38+00:00"
@@ -401,6 +452,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=14"
+      }
+    },
     "properties": {
       "started": "2023-06-01T13:56:38+00:00"
     }
@@ -423,6 +479,11 @@
     "tags": ["economy", "traffic", "mobile data"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=15"
+      }
     },
     "properties": {
       "started": "2023-05-29T13:56:38+00:00"
@@ -447,6 +508,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=16"
+      }
+    },
     "properties": {
       "started": "2023-05-28T13:56:38+00:00"
     }
@@ -469,6 +535,11 @@
     "tags": ["health", "Covid-19", "cases"],
     "status": {
       "code": "active"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=17"
+      }
     },
     "properties": {
       "started": "2023-05-27T13:56:38+00:00"
@@ -493,6 +564,11 @@
     "status": {
       "code": "inactive"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=18"
+      }
+    },
     "properties": {
       "started": "2023-05-26T13:56:38+00:00"
     }
@@ -516,6 +592,11 @@
     "status": {
       "code": "active"
     },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=19"
+      }
+    },
     "properties": {
       "started": "2023-05-25T13:56:38+00:00"
     }
@@ -538,6 +619,11 @@
     "tags": ["economy", "cruise ships", "AIS data"],
     "status": {
       "code": "inactive"
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "https://picsum.photos/800/600?random=20"
+      }
     },
     "properties": {
       "started": "2023-05-24T13:56:38+00:00"


### PR DESCRIPTION
## Implemented changes

This PR introduces an `imageProperty` property, which allows (similarly to `titleProperty` and `subTitleProperty`) to define a property to render as image, both in "cards" and "list" mode.

## Screenshots/Videos

### "Cards" mode
![image](https://github.com/user-attachments/assets/0971ebd3-41ed-4634-86b0-d3ea76a31b6c)

### "List" mode
![image](https://github.com/user-attachments/assets/69136c26-e911-4a2f-ba06-17ea2b333853)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] I added a test for this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
