### PR TITLE
feat: support emitting the drawn features in `WKT` and `GeoJson` formats

### DIFF
--- a/elements/drawtools/src/helpers/features-to-geojson.js
+++ b/elements/drawtools/src/helpers/features-to-geojson.js
@@ -1,0 +1,14 @@
+import GeoJson from "ol/format/GeoJSON";
+
+/**
+ * Converts features to a GeoJSON representation.
+ *
+ * @param {import("ol").Feature[]} features
+ * @param {(Parameters<GeoJson["writeFeaturesObject"]>)["1"]} [options]
+ */
+const featuresToGeoJson = (features, options) => {
+  const format = new GeoJson();
+  return format.writeFeaturesObject(features, options);
+};
+
+export default featuresToGeoJson;

--- a/elements/drawtools/src/helpers/features-to-wkt.js
+++ b/elements/drawtools/src/helpers/features-to-wkt.js
@@ -1,0 +1,13 @@
+import WKT from "ol/format/WKT.js";
+
+/**
+ * Converts features to a Well-Known Text (WKT) representation.
+ *
+ * @type {WKT["writeFeatures"]}
+ */
+const featureToWKT = (features, options) => {
+  const format = new WKT();
+  return format.writeFeatures(features, options);
+};
+
+export default featureToWKT;

--- a/elements/drawtools/src/helpers/index.js
+++ b/elements/drawtools/src/helpers/index.js
@@ -1,3 +1,5 @@
 // Import and export helper functions
 
 export { default as copyTextToClipboard } from "./copy-text-to-clipboard"; // Copy a given text string to the clipboard
+export { default as featuresToGeoJson } from "./features-to-geojson"; // Convert a feature to a GeoJSON representation
+export { default as featuresToWKT } from "./features-to-wkt"; // Convert a feature to a Well-Known Text (WKT) representation

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -40,6 +40,7 @@ export class EOxDrawTools extends LitElement {
       showList: { attribute: "show-list", type: Boolean },
       projection: { type: String },
       noShadow: { type: Boolean },
+      format: { type: String },
       type: { type: String },
       unstyled: { type: Boolean },
     };
@@ -147,6 +148,19 @@ export class EOxDrawTools extends LitElement {
     this.type = "Polygon";
 
     /**
+     * @type {ReturnType<typeof import("./methods/draw/create-select-handler").default>}
+     */
+    this.selectionEvents = null;
+
+    /**
+     * The format in which the drawn features should be emitted
+     *
+     * @default "feature"
+     * @type {"feature"| "geojson" | "wkt"}
+     */
+    this.format = "feature";
+
+    /**
      * Render the element without additional styles
      */
     this.unstyled = false;
@@ -157,10 +171,6 @@ export class EOxDrawTools extends LitElement {
      * @type {Boolean}
      */
     this.noShadow = false;
-    /**
-     * @type {ReturnType<typeof import("./methods/draw/create-select-handler").default>}
-     */
-    this.selectionEvents = null;
   }
 
   /**
@@ -234,15 +244,16 @@ export class EOxDrawTools extends LitElement {
    * Triggers different events when the drawing of a shape is completed.
    */
   emitDrawnFeatures() {
-    const drawUpdateEvent = () => {
+    /**
+     * @param {import("./methods/draw/emit-drawn-features").EmitFormat} value
+     */
+    const drawUpdateEvent = (value) => {
       /**
        * Fires whenever features are added, modified or discarded, where the event detail
        * is the `drawnFeatures` array
        * @type Array<import("ol").Feature>
        */
-      this.dispatchEvent(
-        new CustomEvent("drawupdate", { detail: this.drawnFeatures }),
-      );
+      this.dispatchEvent(new CustomEvent("drawupdate", { detail: value }));
     };
     emitDrawnFeaturesMethod(this, drawUpdateEvent);
   }

--- a/elements/drawtools/src/methods/draw/emit-drawn-features.js
+++ b/elements/drawtools/src/methods/draw/emit-drawn-features.js
@@ -1,8 +1,16 @@
+import { featuresToGeoJson, featuresToWKT } from "../../helpers";
+
+/***
+ * @typedef {import("ol").Feature[]
+ * | ReturnType<typeof featuresToGeoJson>
+ * | ReturnType<typeof featuresToWKT>} EmitFormat
+ */
+
 /**
  * Emits drawn features after a timeout to allow updating drawn features.
  *
  * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
- * @param {Function} drawUpdateEvent - event to be triggered after drawFeature is updated
+ * @param {(value:EmitFormat) => void} drawUpdateEvent - event to be triggered after drawFeature is updated
  */
 const emitDrawnFeaturesMethod = (EoxDrawTool, drawUpdateEvent) => {
   // Function to emit features after a timeout (ensures update)
@@ -23,11 +31,28 @@ const emitDrawnFeaturesMethod = (EoxDrawTool, drawUpdateEvent) => {
         })
       : drawnFeatures;
 
+    // Emit features based on the format provided
+    let value;
+    switch (EoxDrawTool.format) {
+      case "geojson":
+        value = featuresToGeoJson(EoxDrawTool.drawnFeatures);
+        break;
+      case "wkt":
+        value = featuresToWKT(EoxDrawTool.drawnFeatures);
+        break;
+      case "feature":
+        value = EoxDrawTool.drawnFeatures;
+        break;
+      default:
+        value = EoxDrawTool.drawnFeatures;
+        break;
+    }
+
     EoxDrawTool.updateGeoJSON();
     EoxDrawTool.requestUpdate();
 
     // Triggering `drawupdate` event after drawFeature is updated
-    drawUpdateEvent();
+    drawUpdateEvent(value);
   };
 
   // Emit features after a timeout (ensures update)

--- a/elements/drawtools/stories/drawtools.stories.js
+++ b/elements/drawtools/stories/drawtools.stories.js
@@ -14,6 +14,7 @@ import {
   SelectFeatureStory,
   MultiFeaturesSelectStory,
   FeaturesProjectionStory,
+  FormatStory,
 } from "./index";
 
 export default {
@@ -73,6 +74,12 @@ export const MultiFeaturesSelect = MultiFeaturesSelectStory;
  * Showcasing the possibilty to emit drawn features in different projections
  */
 export const FeaturesProjection = FeaturesProjectionStory;
+
+/**
+ * Showcasing the possibilty to emit drawn features in different formats
+ */
+export const Formats = FormatStory;
+
 /**
  * Override css variable directly using styles.
  */

--- a/elements/drawtools/stories/formats.js
+++ b/elements/drawtools/stories/formats.js
@@ -1,0 +1,46 @@
+/**
+ * Showcasing different formats of drawtools return values
+ */
+import { html } from "lit";
+import { STORIES_LAYERS_ARRAY, STORIES_MAP_STYLE } from "../src/enums";
+
+export const Formats = {
+  args: {
+    type: "Box",
+    multipleFeatures: true,
+    drawUpdate: (e) => {
+      console.log(`returned values in ${e.target?.format} format `, e.detail);
+    },
+    changeFormat: (format) => {
+      const drawtools = document.querySelector("eox-drawtools#formats");
+      drawtools.setAttribute("format", format);
+      drawtools.emitDrawnFeatures();
+    },
+  },
+  render: (args) => html`
+    <eox-map
+      id="formats"
+      style=${STORIES_MAP_STYLE}
+      .layers=${STORIES_LAYERS_ARRAY}
+    ></eox-map>
+    <button id="formats" @click=${() => args.changeFormat("geojson")}>
+      geoJson
+    </button>
+    <button id="formats" @click=${() => args.changeFormat("wkt")}>WKT</button>
+    <button id="formats" @click=${() => args.changeFormat("feature")}>
+      feature
+    </button>
+    <p>Refer to the console for the emitted values</p>
+
+    <!-- Initialize eox-drawtools for the eox-map with ID "formats" -->
+    <eox-drawtools
+      id="formats"
+      for="eox-map#formats"
+      ?multiple-features=${args.multipleFeatures}
+      type=${args.type}
+      @drawupdate=${args.drawUpdate}
+    />
+  `,
+};
+
+export default Formats;

--- a/elements/drawtools/stories/index.js
+++ b/elements/drawtools/stories/index.js
@@ -10,5 +10,6 @@ export { default as ImportFeaturesWithEditorStory } from "./import-features"; //
 export { default as SelectFeatureStory } from "./select-feature"; // Story demonstrating feature selection
 export { default as MultiFeaturesSelectStory } from "./multi-feature-select"; // Story demonstrating multi feature selection with list
 export { default as FeaturesProjectionStory } from "./features-projection"; // Story showcasing emitting drawn features in different projections
+export { default as FormatStory } from "./formats"; // Story showcasing emitting drawn features in different formats
 export { default as CSSVariableOverrideStory } from "./css-variable-override"; // Story demonstrating css override
 export { default as UnstyledStory } from "./unstyled"; // Story demonstrating unstyled variant of element.

--- a/elements/drawtools/test/cases/index.js
+++ b/elements/drawtools/test/cases/index.js
@@ -5,3 +5,4 @@ export { default as clickDrawBtnTest } from "./click-draw-btn"; // Test for clic
 export { default as loadDrawToolsTest } from "./load-drawtool"; // Test for loading the drawtools component
 export { default as copyGeoJsonEditorTest } from "./copy-geo-json-editor"; // Test to check whether a valid geo-json present in the clipboard
 export { default as setLayerId } from "./set-layer-id"; // Test to set the layer id and check if the draw button icon changes
+export { default as setDifferentFormats } from "./set-different-formats"; // Test if the drawn features are emitted in different formats

--- a/elements/drawtools/test/cases/set-different-formats.js
+++ b/elements/drawtools/test/cases/set-different-formats.js
@@ -1,0 +1,52 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+const { drawTools } = TEST_SELECTORS;
+
+/**
+ * Test to verify the drawn features are emitted in different formats
+ */
+const setDifferentFormats = () => {
+  const testFeatureFormat = () => {
+    cy.get(drawTools).then(($el) => {
+      $el[0].addEventListener("drawupdate", cy.stub().as("drawUpdateStub"));
+      $el[0].setAttribute("format", "feature");
+      $el[0].emitDrawnFeatures();
+    });
+    cy.get("@drawUpdateStub")
+      .should("be.called")
+      .its("lastCall.args.0.detail")
+      .should("be.an", "array");
+  };
+
+  const testGeoJSONFormat = () => {
+    cy.get(drawTools).then(($el) => {
+      $el[0].addEventListener("drawupdate", cy.stub().as("drawUpdateStub"));
+      $el[0].setAttribute("format", "geojson");
+      $el[0].emitDrawnFeatures();
+    });
+    cy.get("@drawUpdateStub")
+      .should("be.called")
+      .its("lastCall.args.0.detail")
+      .should("be.an", "object")
+      .and((val) => {
+        expect(val).to.have.property("type", "FeatureCollection");
+        expect(val).to.have.property("features");
+      });
+  };
+
+  const testWKTFormat = () => {
+    cy.get(drawTools).then(($el) => {
+      $el[0].addEventListener("drawupdate", cy.stub().as("drawUpdateStub"));
+      $el[0].setAttribute("format", "wkt");
+      $el[0].emitDrawnFeatures();
+    });
+    cy.get("@drawUpdateStub")
+      .should("be.called")
+      .its("lastCall.args.0.detail")
+      .should("be.a", "string");
+  };
+  testFeatureFormat();
+  testWKTFormat();
+  testGeoJSONFormat();
+};
+export default setDifferentFormats;

--- a/elements/drawtools/test/general.cy.js
+++ b/elements/drawtools/test/general.cy.js
@@ -6,6 +6,7 @@ import {
   clickDrawBtnTest,
   copyGeoJsonEditorTest,
   loadDrawToolsTest,
+  setDifferentFormats,
   setLayerId,
 } from "./cases";
 
@@ -40,4 +41,7 @@ describe("Drawtools", () => {
     copyGeoJsonEditorTest());
   // Test case to set the layer id and check if the draw button icon changes
   it("setting layer id changes draw btn icon", () => setLayerId());
+
+  // Test case to check if the drawn features are emitted in different formats
+  it("emits drawn features in different formats", () => setDifferentFormats());
 });


### PR DESCRIPTION
## Implemented changes
Related to #1276, This Introduces a new attribute `format` to the drawtools, that determines the emitted format of the drawn features.

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
