### PR TITLE
fix: correctly render title-container also if no subtitle present

### DIFF
--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -86,7 +86,7 @@ export function createItemListMethod(
               }}
             >
               ${when(
-                config.subTitleProperty,
+                config.subTitleProperty || config.imageProperty,
                 () => html`
                   ${getValue(config.imageProperty, item)
                     ? html`


### PR DESCRIPTION
## Implemented changes

This fixes a small bug where the image container was only rendered if there was a subtitle present.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
