### PR TITLE
fix: view sync between a visible and a hidden view

### DIFF
--- a/elements/map/src/methods/map/setters.js
+++ b/elements/map/src/methods/map/setters.js
@@ -351,7 +351,17 @@ export function setSyncMethod(sync, EOxMap) {
       );
 
       // Set the view of the current map to match the view of the origin map
-      if (originMap) EOxMap.map.setView(originMap.map.getView());
+      if (originMap) {
+        // Check if the current map is hidden and the origin
+        // has no zoom - in this case the current map view
+        // takes over the zoom and resets it; so in this case it is
+        // better to sync the "other way round"
+        if (EOxMap.clientHeight < 1 && !originMap.zoom) {
+          originMap.map.setView(EOxMap.map.getView());
+        } else {
+          EOxMap.map.setView(originMap.map.getView());
+        }
+      }
     });
   }
 


### PR DESCRIPTION
## Implemented changes

This adds a small fix when syncing two views: for some reason, when syncing two views and the "receiving" one is not visible (and thus its view is not initially visible and usually defaults to 0 zoom if nothing else is defined), it "forces" its zoom onto the "giving" one (if no explicit zoom is set there as well). To mitigate this, when the "receiving" one is hidden **and** the "giving" one has no zoom set, it syncs the "other way round" in order for this zoom reset not to happen.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
