### PR TITLE
fix: Remove the drawLayer when the element is disconnected

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -300,6 +300,10 @@ export class EOxDrawTools extends LitElement {
     this.requestUpdate("eoxMap", oldValue);
   }
 
+  disconnectedCallback() {
+    this.eoxMap?.map.removeLayer(this.drawLayer);
+    super.disconnectedCallback();
+  }
   // Render method for UI display
   render() {
     return html`


### PR DESCRIPTION
## Implemented changes

This PR fixes the removal of the `eox-drawtools` element - when disconnecting, it makes sure to also remove the automatically created `drawLayer`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
