### PR TITLE
fix(style): prevent legend and info overflow

### DIFF
--- a/elements/layercontrol/src/components/layer-legend.js
+++ b/elements/layercontrol/src/components/layer-legend.js
@@ -73,6 +73,13 @@ export class EOxLayerControlLayerLegend extends LitElement {
     return this.noShadow ? this : super.createRenderRoot();
   }
 
+  updated() {
+    if (this.offsetWidth < 325 && this.offsetWidth !== this.layerLegend.width) {
+      this.layerLegend.width = this.offsetWidth;
+      this.requestUpdate();
+    }
+  }
+
   /**
    * Renders a Time Control for datetime options of a layer.
    */
@@ -124,6 +131,7 @@ export class EOxLayerControlLayerLegend extends LitElement {
       --cle-font-size: inherit;
       --cle-font-weight: inherit --cle-letter-spacing: inherit;
       --cle-letter-spacing-title: inherit;
+      --cle-padding: 0;
     }
   `;
   #styleEOX = ``;

--- a/elements/layercontrol/src/components/layer-legend.js
+++ b/elements/layercontrol/src/components/layer-legend.js
@@ -73,14 +73,15 @@ export class EOxLayerControlLayerLegend extends LitElement {
     return this.noShadow ? this : super.createRenderRoot();
   }
 
-  updated() {
-    if (
-      !this.layerLegend.width &&
-      this.offsetWidth < 325 &&
-      this.offsetWidth !== this.layerLegend.width
-    ) {
-      this.layerLegend.width = this.offsetWidth;
-      this.requestUpdate();
+  firstUpdated() {
+    // if the width is explicitly set, don't auto-update
+    if (!this.layerLegend.width) {
+      new ResizeObserver(() => {
+        if (this.offsetWidth !== this.layerLegend.width) {
+          this.layerLegend.width = this.offsetWidth;
+          this.requestUpdate();
+        }
+      }).observe(this.renderRoot.querySelector(".legend-container"));
     }
   }
 

--- a/elements/layercontrol/src/components/layer-legend.js
+++ b/elements/layercontrol/src/components/layer-legend.js
@@ -74,7 +74,11 @@ export class EOxLayerControlLayerLegend extends LitElement {
   }
 
   updated() {
-    if (this.offsetWidth < 325 && this.offsetWidth !== this.layerLegend.width) {
+    if (
+      !this.layerLegend.width &&
+      this.offsetWidth < 325 &&
+      this.offsetWidth !== this.layerLegend.width
+    ) {
       this.layerLegend.width = this.offsetWidth;
       this.requestUpdate();
     }

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -344,6 +344,9 @@ export class EOxLayerControlLayerTools extends LitElement {
     [slot=opacity-content] {
       padding: 12px 6px;
     }
+    [slot=info-content] * {
+      max-width: 100%;
+    }
   `;
 }
 


### PR DESCRIPTION
## Implemented changes
This PR adds two small fixes to limit the width of images and legends inside layercontrol:
- in the `info` tool, the `max-width` was limited to `100%`
- in the layer legend, the width was taken from the elements `offsetWidth` and applied (additional render requested)

## Screenshots/Videos

### Before
![image](https://github.com/user-attachments/assets/a4d01eba-fa79-475f-92f8-0dd8513370ed)

### After
![image](https://github.com/user-attachments/assets/420d9587-49e6-4aaa-a787-c11d2aa59676)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
