### PR TITLE
fix: listen for click on entire result instead of just title

### DIFF
--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -69,22 +69,22 @@ export function createItemListMethod(
         items,
         (item) => item.id,
         (item) => html`
-          <li class=${className(item)}>
-            <span
-              id="${item.id}"
-              @click=${() => {
-                if (EOxItemFilterResults.selectedResult === item) {
-                  EOxItemFilterResults.selectedResult = null;
-                } else {
-                  EOxItemFilterResults.selectedResult = item;
-                }
-                EOxItemFilterResults.dispatchEvent(
-                  new CustomEvent("result", {
-                    detail: EOxItemFilterResults.selectedResult,
-                  }),
-                );
-              }}
-            >
+          <li
+            class=${className(item)}
+            @click=${() => {
+              if (EOxItemFilterResults.selectedResult === item) {
+                EOxItemFilterResults.selectedResult = null;
+              } else {
+                EOxItemFilterResults.selectedResult = item;
+              }
+              EOxItemFilterResults.dispatchEvent(
+                new CustomEvent("result", {
+                  detail: EOxItemFilterResults.selectedResult,
+                }),
+              );
+            }}
+          >
+            <span id="${item.id}">
               ${when(
                 config.subTitleProperty || config.imageProperty,
                 () => html`


### PR DESCRIPTION
## Implemented changes
This PR adds a small fix that lets the user click the entire result list item instead of just the title.

## Screenshots/Videos

[Screencast from 2024-12-09 16:39:23.webm](https://github.com/user-attachments/assets/88550785-a151-4f18-823e-0f431cb3ecfa)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
