### PR TITLE
fix(style): use auto overflow for pre/code blocks

### DIFF
--- a/utils/styles/main.css
+++ b/utils/styles/main.css
@@ -177,6 +177,7 @@ pre {
   padding: 20px 0;
   background: transparent;
   background: var(--code-bg-color, #8e96aa24);
+  overflow: auto;
 }
 code {
   display: block;


### PR DESCRIPTION
## Implemented changes
This PR introduces a small fix that enables `overflow: auto` for code blocks. Previously the content was overflowing.

## Screenshots/Videos

### Before
![image](https://github.com/user-attachments/assets/d1ccce3f-a2a5-4aaf-a2d8-a772e9a111d3)

### After
![image](https://github.com/user-attachments/assets/0220ba17-1033-4bd6-818f-164610ff45ea)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
