### PR TITLE
chore: replace bg colors with css variables

### DIFF
--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -21,7 +21,7 @@ export const styleEOX = `
     #000000 20%,
     transparent
   );
-  --background-color: #fff;
+  --background-color: var(--background-color);
   --padding: 0.5rem;
   --text-transform: capitalize;
   --form-flex-direction: column;

--- a/elements/layercontrol/src/components/tools-items.js
+++ b/elements/layercontrol/src/components/tools-items.js
@@ -169,7 +169,7 @@ export class EOxLayerControlTabs extends LitElement {
 
   #styleEOX = `
     .listed {
-      background: #ffffff !important;
+      background: var(--background-color) !important;
       display: flex;
       justify-content: end;
     }
@@ -190,7 +190,7 @@ export class EOxLayerControlTabs extends LitElement {
       cursor: pointer;
     }
     figure {
-      background: #00417011;
+      background: var(--background-color);
       border-top: 1px solid #0041701a;
     }
   `;


### PR DESCRIPTION
## Implemented changes
In this PR we remove some hard coded background colors and replace them with css variables so that elements are easier to customize
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
