### PR TITLE
fix: cursor-change after layer-interaction update

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -221,6 +221,8 @@ export class EOxSelectInteraction {
 
     /**
      * Adds a listener on pointermove
+     * the listener is more complex than `l === selectLayer` to
+     * prevent multiple select-interactions from overriding eachother
      */
     this.pointerMoveListener = (e) => {
       if (e.dragging) return;
@@ -229,8 +231,8 @@ export class EOxSelectInteraction {
         {
           layerFilter: (l) =>
             l
-              .get("interactions")
-              ?.find(
+              .get("_jsonDefinition")
+              ?.interactions?.find(
                 (i) => i.type == "select" && i.options?.condition === "click",
               ),
           ...options.atPixelOptions,

--- a/elements/map/test/cases/select/add-select-interaction-to-existing-layer.js
+++ b/elements/map/test/cases/select/add-select-interaction-to-existing-layer.js
@@ -1,0 +1,51 @@
+import { html } from "lit";
+import { simulateEvent } from "../../utils/events";
+import ecoRegionsFixture from "../../fixtures/ecoregions.json";
+import vectorLayerJson from "../../fixtures/vectorLayer.json";
+
+/**
+ * Tests to adds a select interaction to Vector layer
+ */
+const addSelectInteractionVector = () => {
+  cy.intercept("https://openlayers.org/data/vector/ecoregions.json", (req) => {
+    req.reply(ecoRegionsFixture);
+  });
+  const styleJson = JSON.parse(JSON.stringify(vectorLayerJson));
+  styleJson[0].minZoom = 3;
+
+  cy.mount(html`<eox-map .zoom=${4} .layers=${styleJson}></eox-map>`).as(
+    "eox-map",
+  );
+
+  cy.get("eox-map").and(($el) => {
+    const eoxMap = $el[0];
+
+    eoxMap.map.on("loadend", () => {
+      styleJson[0].interactions = [
+        {
+          type: "select",
+          options: {
+            id: "selectInteraction",
+            condition: "click",
+            style: {
+              "stroke-color": "white",
+              "stroke-width": 3,
+            },
+          },
+        },
+      ];
+      eoxMap.layers = styleJson;
+      eoxMap.addEventListener("select", (evt) => {
+        expect(evt.detail.feature, "adds interaction after update").to.exist;
+        expect(
+          eoxMap.map.getTargetElement().style.cursor,
+          "changes cursor to pointer",
+        ).to.be.equal("pointer");
+      });
+      simulateEvent(eoxMap.map, "pointermove", 120, -140);
+      simulateEvent(eoxMap.map, "click", 120, -140);
+    });
+  });
+};
+
+export default addSelectInteractionVector;

--- a/elements/map/test/cases/select/index.js
+++ b/elements/map/test/cases/select/index.js
@@ -2,6 +2,7 @@
 
 export { default as addSelectInteractionVectorTile } from "./add-select-interaction-vector-tile";
 export { default as addSelectInteractionVector } from "./add-select-interaction-vector";
+export { default as addSelectInteractionToExistingLayer } from "./add-select-interaction-to-existing-layer";
 export { default as highlightByIdVectorLayer } from "./highlight-by-id-vector-layer";
 export { default as highlightByIdVectorTileLayer } from "./highlight-by-id-vector-tile-layer";
 export { default as removeSelectInteraction } from "./remove-select-interaction";

--- a/elements/map/test/selectInteraction.cy.js
+++ b/elements/map/test/selectInteraction.cy.js
@@ -2,6 +2,7 @@ import "../src/main";
 import {
   addSelectInteractionVector,
   addSelectInteractionVectorTile,
+  addSelectInteractionToExistingLayer,
   highlightByIdVectorLayer,
   highlightByIdVectorTileLayer,
   removeSelectInteractionLayer,
@@ -46,6 +47,12 @@ describe("select interaction on click", () => {
    */
   it("adds a select interaction to Vector layer", () =>
     addSelectInteractionVector());
+
+  /**
+   * Test case to add a selection to a layer that was initially created without a selection
+   */
+  it("adds a select interaction to an existing layer (without interaction)", () =>
+    addSelectInteractionToExistingLayer());
 
   /**
    * Test case to highlight by ID (Vector Layer)


### PR DESCRIPTION
## Implemented changes

This PR fixes an issue described in #1404, where the cursor did not change correctly when the interaction was added by updating an existing layer.
The issue was that in https://github.com/EOX-A/EOxElements/pull/1348 the interactions were taken from the properties of the `ol`-layer directly instead of the `_jsonDefinition` or the `interactions` or the `eoxMap`.

A test was added to test both the cursor as well as the select-interaction itself if the interaction was added after a delay.
 
## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
