### PR TITLE
feat(style): improve rendering of layer tools list display

### DIFF
--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -307,6 +307,10 @@ export class EOxLayerControlLayerTools extends LitElement {
       display: flex;
       justify-content: center;
     }
+    eox-layercontrol-tools-items.tools-list button.icon,
+    eox-layercontrol-tools-items.tools-list .button.icon {
+      margin-left: -6px;
+    }
     eox-layercontrol-tools-items button.icon::before,
     eox-layercontrol-tools-items .button.icon::before {
       width: 16px;
@@ -345,7 +349,7 @@ export class EOxLayerControlLayerTools extends LitElement {
     [slot=config-content],
     [slot=datetime-content],
     [slot=legend-content] {
-      padding: 6px var(--padding);
+      padding: 6px 0;
     }
   `;
 }

--- a/elements/layercontrol/src/components/tools-items.js
+++ b/elements/layercontrol/src/components/tools-items.js
@@ -79,7 +79,7 @@ export class EOxLayerControlTabs extends LitElement {
         ${this.#styleBasic}
         ${!this.unstyled && this.#styleEOX}
       </style>
-      <div class="tabbed">
+      <div class="${this.toolsAsList ? "listed" : "tabbed"}">
         <!-- Navigation for tabs and actions -->
         ${when(
           isListAvail,
@@ -128,9 +128,10 @@ export class EOxLayerControlTabs extends LitElement {
               ${when(
                 this.toolsAsList,
                 () => html`
-                  <label class="listed">
+                  <label>
                     <!-- Customizable icon for each tab -->
                     <slot name=${`${tab}-icon`}>${tab}</slot>
+                    <span>${tab}</span>
                   </label>
                 `,
               )}
@@ -146,34 +147,48 @@ export class EOxLayerControlTabs extends LitElement {
   }
 
   #styleBasic = `
-    .tabbed figure {
+    .tabbed figure,
+    .listed figure {
       margin: 0;
     }
-    .tabbed nav {
+    .tabbed nav,
+    .listed nav {
       display: flex;
       justify-content: space-between;
     }
-    .tabbed nav div {
+    .tabbed nav div,
+    .listed nav div {
       display: flex;
     }
-    .tabbed .tab {
+    .tabbed .tab,
+    .listed .tab {
       display: none;
     }
-    .tabbed .tab.highlighted {
+    .tabbed .tab.highlighted,
+    .listed .tab.highlighted {
       display: block;
     }
-    .tabbed label.highlighted {
+    .tabbed label.highlighted,
+    .listed label.highlighted {
       background: lightgrey;
     }
   `;
 
   #styleEOX = `
-    .listed {
-      background: #ffffff !important;
+    .listed label {
+      /*background: #ffffff !important;*/
       display: flex;
-      justify-content: end;
+      justify-content: start;
+      align-items: center;
     }
-    .tabbed {
+    .listed label:not(:first-of-type) {
+      margin-top: 10px;
+    }
+    .listed label span {
+      text-transform: capitalize;
+      font-weight: 300;
+    }
+    .tabbed, .listed {
       font-size: small;
     }
     .tabbed label.highlighted {
@@ -192,6 +207,7 @@ export class EOxLayerControlTabs extends LitElement {
     figure {
       background: #00417011;
       border-top: 1px solid #0041701a;
+      padding: 8px var(--padding);
     }
   `;
 }

--- a/elements/layercontrol/src/components/tools-items.js
+++ b/elements/layercontrol/src/components/tools-items.js
@@ -176,7 +176,6 @@ export class EOxLayerControlTabs extends LitElement {
 
   #styleEOX = `
     .listed label {
-      /*background: #ffffff !important;*/
       display: flex;
       justify-content: start;
       align-items: center;


### PR DESCRIPTION
## Implemented changes
This PR improves the rendering of the layer tools in list display:
- moved icon to the left instead of right
- added tool title
- adjusted paddings/margins
- removed white background

## Screenshots/Videos
### Before
![image](https://github.com/user-attachments/assets/6441c20c-5a6d-45ea-9111-3f018b3e4a5c)

### After
![image](https://github.com/user-attachments/assets/965b90e1-5773-40fb-ac40-83d1ef67a657)



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
