### PR TITLE
feat: date/time display format

### DIFF
--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -53,8 +53,9 @@ export class EOxTimeControl extends LitElement {
 
       /**
        * Date format string for displaying the current step
+       * using [dayjs format token strings](https://day.js.org/docs/en/display/format)
        */
-      format: { type: String, attribute: "format" },
+      displayFormat: { type: String, attribute: "display-format" },
 
       currentStep: { type: String, attribute: "current-step" },
       _animationInterval: { state: true },
@@ -100,7 +101,7 @@ export class EOxTimeControl extends LitElement {
     });
 
     /** @type {string} */
-    this.format = undefined; // Default empty string means no formatting
+    this.displayFormat = undefined;
   }
 
   /**
@@ -308,9 +309,9 @@ export class EOxTimeControl extends LitElement {
             <
           </button>
           <span part="current">
-            ${this.format
+            ${this.displayFormat
               ? dayjs(this.controlValues[this._newStepIndex]).format(
-                  this.format,
+                  this.displayFormat,
                 )
               : this.controlValues[this._newStepIndex]}
           </span>

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -51,6 +51,11 @@ export class EOxTimeControl extends LitElement {
        */
       disablePlay: { type: Boolean, attribute: "disable-play" },
 
+      /**
+       * Date format string for displaying the current step
+       */
+      format: { type: String, attribute: "format" },
+
       currentStep: { type: String, attribute: "current-step" },
       _animationInterval: { state: true },
       _controlSource: { state: true },
@@ -93,6 +98,9 @@ export class EOxTimeControl extends LitElement {
     window.addEventListener("resize", () => {
       this._width = this.clientWidth;
     });
+
+    /** @type {string} */
+    this.format = undefined; // Default empty string means no formatting
   }
 
   /**
@@ -299,7 +307,13 @@ export class EOxTimeControl extends LitElement {
           >
             <
           </button>
-          <span part="current">${this.controlValues[this._newStepIndex]}</span>
+          <span part="current">
+            ${this.format
+              ? dayjs(this.controlValues[this._newStepIndex]).format(
+                  this.format,
+                )
+              : this.controlValues[this._newStepIndex]}
+          </span>
           <button part="next" class="icon next" @click="${() => this.next()}">
             >
           </button>

--- a/elements/timecontrol/stories/format.js
+++ b/elements/timecontrol/stories/format.js
@@ -1,0 +1,30 @@
+import { html } from "lit";
+import { DEFAULT_ARGS } from "../src/enums/stories";
+
+export const Format = {
+  args: {
+    ...DEFAULT_ARGS,
+    for: "eox-map#primary",
+    format: "MMMM DD, YYYY",
+  },
+  render: (args) => html`
+    <eox-map
+      id="primary"
+      style="width: 1005; height: 300px;"
+      .zoom=${args.zoom}
+      .center=${args.center}
+      .layers=${args.layers}
+    ></eox-map>
+    <eox-timecontrol
+      .for=${args.for}
+      .layer=${args.layer}
+      .controlProperty=${args.controlProperty}
+      .controlValues=${args.controlValues}
+      .slider=${args.slider}
+      style="margin-top: 10px;"
+      .format=${args.format}
+    ></eox-timecontrol>
+  `,
+};
+
+export default Format;

--- a/elements/timecontrol/stories/format.js
+++ b/elements/timecontrol/stories/format.js
@@ -5,7 +5,7 @@ export const Format = {
   args: {
     ...DEFAULT_ARGS,
     for: "eox-map#primary",
-    format: "MMMM DD, YYYY",
+    displayFormat: "MMMM DD, YYYY",
   },
   render: (args) => html`
     <eox-map
@@ -22,7 +22,7 @@ export const Format = {
       .controlValues=${args.controlValues}
       .slider=${args.slider}
       style="margin-top: 10px;"
-      .format=${args.format}
+      .displayFormat=${args.displayFormat}
     ></eox-timecontrol>
   `,
 };

--- a/elements/timecontrol/stories/index.js
+++ b/elements/timecontrol/stories/index.js
@@ -6,3 +6,4 @@ export { default as SliderStory } from "./slider"; // Slider story
 export { default as ProgrammaticTimeSelectionStory } from "./programmatic-time-selection"; // Programmatic time selection story
 export { default as DisabledPlayButtonStory } from "./disabled-play-button"; // Disabled play button story
 export { default as NoMapStory } from "./no-map"; // No map provided story
+export { default as FormatStory } from "./format"; // Date-Time Format story

--- a/elements/timecontrol/stories/timecontrol.stories.js
+++ b/elements/timecontrol/stories/timecontrol.stories.js
@@ -5,6 +5,7 @@ import {
   ProgrammaticTimeSelectionStory,
   DisabledPlayButtonStory,
   NoMapStory,
+  FormatStory,
 } from "./index";
 
 export default {
@@ -22,3 +23,5 @@ export const ProgrammaticTimeSelection = ProgrammaticTimeSelectionStory;
 export const DisabledPlayButton = DisabledPlayButtonStory;
 
 export const NoMap = NoMapStory;
+
+export const Format = FormatStory;

--- a/elements/timecontrol/stories/timecontrol.stories.js
+++ b/elements/timecontrol/stories/timecontrol.stories.js
@@ -24,4 +24,8 @@ export const DisabledPlayButton = DisabledPlayButtonStory;
 
 export const NoMap = NoMapStory;
 
+/**
+ * Passing the `format` property/attribute, the displayed format can be changed.
+ * Supports [dayjs format token strings](https://day.js.org/docs/en/display/format)
+ */
 export const Format = FormatStory;

--- a/elements/timecontrol/test/cases/index.js
+++ b/elements/timecontrol/test/cases/index.js
@@ -2,3 +2,4 @@
 
 export { default as loadTimeControlTest } from "./load-timecontrol";
 export { default as changeTimeTest } from "./change-time";
+export { default as loadDateFormatTest } from "./load-date-format";

--- a/elements/timecontrol/test/cases/load-date-format.js
+++ b/elements/timecontrol/test/cases/load-date-format.js
@@ -1,0 +1,19 @@
+import { TEST_SELECTORS } from "../../src/enums";
+import "../_mockMap";
+
+// Destructure TEST_SELECTORS object
+const { timeControl } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the date format is applied correctly.
+ */
+const loadDateFormatTest = () => {
+  cy.mount("<mock-map></mock-map>").as("mock-map");
+  cy.mount(
+    `<eox-timecontrol for="mock-map" format="DD/MM/YYYY" layer="TEST_ID"></eox-timecontrol>`,
+  ).as(timeControl);
+
+  cy.get(timeControl).shadow().find("#controls span").contains("17/12/2024");
+};
+
+export default loadDateFormatTest;

--- a/elements/timecontrol/test/cases/load-date-format.js
+++ b/elements/timecontrol/test/cases/load-date-format.js
@@ -10,7 +10,7 @@ const { timeControl } = TEST_SELECTORS;
 const loadDateFormatTest = () => {
   cy.mount("<mock-map></mock-map>").as("mock-map");
   cy.mount(
-    `<eox-timecontrol for="mock-map" format="DD/MM/YYYY" layer="TEST_ID"></eox-timecontrol>`,
+    `<eox-timecontrol for="mock-map" display-format="DD/MM/YYYY" layer="TEST_ID"></eox-timecontrol>`,
   ).as(timeControl);
 
   cy.get(timeControl).shadow().find("#controls span").contains("17/12/2024");

--- a/elements/timecontrol/test/general.cy.js
+++ b/elements/timecontrol/test/general.cy.js
@@ -1,8 +1,13 @@
 // Importing necessary modules, test cases, and enums
 import "../src/main";
-import { loadTimeControlTest, changeTimeTest } from "./cases";
+import {
+  loadTimeControlTest,
+  changeTimeTest,
+  loadDateFormatTest,
+} from "./cases";
 
 describe("TimeControl", () => {
   it("loads the timecontrol", () => loadTimeControlTest());
   it.only("changes the time correctly", () => changeTimeTest());
+  it.only("loads the date format correctly", () => loadDateFormatTest());
 });


### PR DESCRIPTION
## Implemented changes
- Added `format` attribute inside `<eox-timecontrol>` to format Date and Time using `dayjs` [format](https://day.js.org/docs/en/display/format).

```html
    <eox-timecontrol
      .format="MMMM DD, YYYY"
    ></eox-timecontrol>
```

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<img width="929" alt="image" src="https://github.com/user-attachments/assets/35c39e40-0e83-4d5b-b4da-e191a5f2fc15" />


<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
