### PR TITLE
feat: fallback for not-existing result images

### DIFF
--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -95,7 +95,20 @@ export function createItemListMethod(
                           src="${getValue(config.imageProperty, item)}"
                         />
                       `
-                    : nothing}
+                    : html`
+                        <svg
+                          class="image"
+                          width="800"
+                          height="600"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            width="800"
+                            height="600"
+                            fill="var(--primary-color)"
+                          />
+                        </svg>
+                      `}
                   <div class="title-container">
                     <span class="title"
                       >${unsafeHTML(item[config.titleProperty])}</span


### PR DESCRIPTION
## Implemented changes
This PR adds a very simple fallback (svg box with primary color) if some of the results don't have an image set.

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/1e76d492-4fe4-45d2-a7c0-15083bad9bce)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
