### PR TITLE
feat: pass displayFormat property to timecontrol

### DIFF
--- a/elements/layercontrol/src/components/layer-datetime.js
+++ b/elements/layercontrol/src/components/layer-datetime.js
@@ -42,7 +42,8 @@ export class EOxLayerControlLayerDatetime extends LitElement {
      *   disablePlay?: boolean;
      *   slider?: boolean;
      *   currentStep: string|number;
-     *   controlValues: (string|number)[]
+     *   controlValues: (string|number)[];
+     *   displayFormat?: string;
      * }}
      */
     this.layerDatetime = null;
@@ -111,6 +112,7 @@ export class EOxLayerControlLayerDatetime extends LitElement {
             .controlValues=${this.layerDatetime.controlValues}
             .controlProperty=${undefined}
             current-step=${this.layerDatetime.currentStep}
+            .displayFormat=${this.layerDatetime.displayFormat}
             @stepchange=${this.#handleStepChange}
           ></eox-timecontrol>
         `,

--- a/elements/layercontrol/src/enums/stories/index.js
+++ b/elements/layercontrol/src/enums/stories/index.js
@@ -448,6 +448,7 @@ export const STORIES_LAYER_VESSEL_DENSITY_CARGO = {
       disablePlay: true,
       slider: true,
       currentStep: "2021-03-01",
+      displayFormat: "DD.MM.YYYY",
       controlValues: [
         "2022-12-01",
         "2022-11-01",


### PR DESCRIPTION
## Implemented changes
This allows passing the `displayFormat` property in `layerLegend`, so the newly introduced functionality of changing the display format can be used.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
