### PR TITLE
fix(style): summary & spacing CSS variables

### DIFF
--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -41,7 +41,7 @@ export const styleEOX = `
     font-weight: 600;
   }
   form[data-theme="html"] .je-indented-panel {
-    border: none;
+    border: none !important;
     margin: 0.4rem;
   }
   button[class*="json-editor-btntype-"] span {
@@ -100,6 +100,9 @@ export const styleEOX = `
   }
   .je-indented-panel .row {
     margin-top: 10px;
+  }
+  .je-object__controls {
+    margin: 0 !important;
   }
   .EasyMDEContainer span {
     display: unset;

--- a/elements/layercontrol/src/components/layer-group.js
+++ b/elements/layercontrol/src/components/layer-group.js
@@ -163,7 +163,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
   #styleEOX = `
     details summary {
       cursor: pointer;
-      display: flex;
+      display: var(--layer-summary-visibility);
     }
     details summary { list-style-type: none; } /* Firefox */
     details summary::-webkit-details-marker { display: none; } /* Chrome */

--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -185,11 +185,11 @@ export class EOxLayerControlLayerList extends LitElement {
     ul ul {
       padding-left: var(--list-padding);
     }
-    li {
-      list-style: none;
+    li:not(li li) {
       padding-left: var(--padding);
     }
     li {
+      list-style: none;
       border-bottom: 1px solid #0041703a;
       border: var(--layer-visibility);
     }

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -220,7 +220,7 @@ export class EOxLayerControlLayer extends LitElement {
       width: 100%;
       align-items: center;
       justify-content: space-between;
-      padding: 4px 0;
+      padding: var(--padding-vertical) 0;
       display: var(--layer-visibility);
     }
     label, span {

--- a/elements/layercontrol/src/components/tools-items.js
+++ b/elements/layercontrol/src/components/tools-items.js
@@ -168,10 +168,6 @@ export class EOxLayerControlTabs extends LitElement {
     .listed .tab.highlighted {
       display: block;
     }
-    .tabbed label.highlighted,
-    .listed label.highlighted {
-      background: lightgrey;
-    }
   `;
 
   #styleEOX = `
@@ -192,7 +188,9 @@ export class EOxLayerControlTabs extends LitElement {
       font-size: small;
     }
     .tabbed label.highlighted {
-      background: #00417011;
+      border: 1px solid #0041701a;
+      border-radius: 2px;
+      border-bottom: none;
       pointer-events: none;
     }
     nav div label,
@@ -206,8 +204,9 @@ export class EOxLayerControlTabs extends LitElement {
     }
     figure {
       background: var(--background-color);
-      border-top: 1px solid #0041701a;
-      padding: 8px var(--padding);
+      border: 1px solid #0041701a;
+      border-radius: 2px;
+      padding: var(--padding-vertical) var(--padding);
     }
   `;
 }

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -259,8 +259,10 @@ export class EOxLayerControl extends LitElement {
     :host, :root {
       font-family: Roboto, sans-serif;
       --padding: 0.5rem;
+      --padding-vertical: .2rem;
       --list-padding: 48px;
       --layer-input-visibility: flex;
+      --layer-summary-visibility: flex;
       --layer-type-visibility: block;
       --layer-title-visibility: flex;
       --layer-visibility: block;


### PR DESCRIPTION
## Implemented changes

This PR introduces two new CSS variables to better control the layout:
-  `--layer-summary-visibility`: controls the layer group summary (for e.g. hiding the dropdown arrow)
-  `--padding-vertical`: vertical padding, similar to previously added horizontal padding

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
