### PR TITLE
chore: fix hardcoded background color in jsonform

### DIFF
--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -9,6 +9,9 @@ export const styleEOX = `
   .CodeMirror {
     background-color: var(--background-color, transparent);
   }
+  select {
+    background-color: var(--background-color);
+  }
   [data-schemaid=root] > .je-header {
     display: none;
   }

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -352,6 +352,7 @@ export class EOxLayerControlLayerTools extends LitElement {
       padding: 6px 0;
     }
     [slot=info-content] * {
+      text-align: left !important;
       max-width: 100%;
     }
   `;

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -352,7 +352,6 @@ export class EOxLayerControlLayerTools extends LitElement {
       padding: 6px 0;
     }
     [slot=info-content] * {
-      text-align: left !important;
       max-width: 100%;
     }
   `;


### PR DESCRIPTION
## Implemented changes
Fixes alignment of `info-content` slot in `eox-layercontrol` and hardcoded background in `eox-jsonform`'s `select`
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/3f0e85f9-fc8b-45aa-9b37-1be6ee4fcb8c)
<img width="474" alt="image" src="https://github.com/user-attachments/assets/fdcdf89b-3971-40ee-a7cf-39ee57e179c0" />

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
