### PR TITLE
fix: range-control output fixed width

### DIFF
--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -18,6 +18,9 @@ export const styleEOX = `
   .je-range-control {
     padding: 0.5rem 0;
   }
+  .je-range-control output {
+    width: 35px;
+  }
   .errmsg {
     font-size: x-small;
   }


### PR DESCRIPTION
## Implemented changes
Force output to have fixed with so slider isn't shaky
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
Before
![slider-before](https://github.com/user-attachments/assets/724d043f-d43c-42af-a73d-f978d40675c5)

After
![slider-after](https://github.com/user-attachments/assets/a5ed6358-d839-483d-a35e-4d5e7abeaf15)

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
