### PR TITLE
Fix: Adding content without any sections breaks editor

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -359,10 +359,16 @@ export function parseNavWithAddSection(
     html.splice(navIndex, 0, navDOM);
   }
 
+  let containsSectionWrap = false;
+
   if (html.length) {
     const sectionStartIndex = navIndex + 1;
     html[sectionStartIndex].classList.add("section-start");
     html.slice(sectionStartIndex).forEach((section, key) => {
+      if (!section.classList) return;
+      if (section.classList.contains("section-wrap"))
+        containsSectionWrap = true;
+
       section.classList.add("section-item");
       section.setAttribute("data-section", `${key + 1}`);
 
@@ -380,6 +386,18 @@ export function parseNavWithAddSection(
         });
       }
     });
+  }
+
+  if (!containsSectionWrap) {
+    let sectionWrap = document.createElement("div");
+    sectionWrap.className = "section-wrap container section-item";
+    html.forEach((element) => {
+      sectionWrap.appendChild(element);
+    });
+    sectionWrap.addEventListener("click", function (event) {
+      generateAddSectionClickEvt(event, false, this, EOxStoryTelling);
+    });
+    html = [sectionWrap];
   }
 
   return html;


### PR DESCRIPTION
## Implemented changes
- Fixed two senario: 
  - When there is no content in storytelling editor and it shows (+) button
  - When there is content without section tag (##), then error is removed

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/user-attachments/assets/0e3620c0-4f96-4538-afdd-88e472c7d804



<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
