### PR TITLE
fix: fallback for media src

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -197,6 +197,7 @@ function processNode(node, initDispatchFunc) {
           lightboxGallery.open();
         });
 
+        // Handle media loading error by switching to backup URL if available
         media.onerror = () => {
           if (
             document.body.contains(media) &&
@@ -207,6 +208,7 @@ function processNode(node, initDispatchFunc) {
           }
         };
 
+        // Function to clear the backup URL title attribute after successful load
         const loadFunc = () => {
           if (
             document.body.contains(media) &&

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -184,20 +184,41 @@ function processNode(node, initDispatchFunc) {
     const lightboxElements = [];
 
     const images = node.querySelectorAll("img");
-    // Loop over each image
-    images.forEach((img) => {
-      // Check if the image is already inside a link (to avoid double wrapping)
-      const mode = img.getAttribute("mode");
+    const videos = node.querySelectorAll("video");
 
-      if (img.parentNode.tagName !== "A" && mode !== "hero") {
-        img.style.cursor = "zoom-in";
-        img.addEventListener("click", () => {
+    // Loop over each image/video
+    [...images, ...videos].forEach((media) => {
+      // Check if the image is already inside a link (to avoid double wrapping)
+      const mode = media.getAttribute("mode");
+
+      if (media.parentNode.tagName !== "A" && mode !== "hero") {
+        media.style.cursor = "zoom-in";
+        media.addEventListener("click", () => {
           lightboxGallery.open();
         });
 
+        media.onerror = () => {
+          if (
+            document.body.contains(media) &&
+            media.title.includes("temp-backup-url=")
+          ) {
+            media.src = media.title.replace("temp-backup-url=", "");
+            media.title = "";
+          }
+        };
+
+        media.onload = () => {
+          if (
+            document.body.contains(media) &&
+            media.title.includes("temp-backup-url=")
+          ) {
+            media.title = "";
+          }
+        };
+
         lightboxElements.push({
           type: "image",
-          href: img.src,
+          href: media.src,
         });
       }
     });

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -207,7 +207,7 @@ function processNode(node, initDispatchFunc) {
           }
         };
 
-        media.onload = () => {
+        const loadFunc = () => {
           if (
             document.body.contains(media) &&
             media.title.includes("temp-backup-url=")
@@ -215,6 +215,9 @@ function processNode(node, initDispatchFunc) {
             media.title = "";
           }
         };
+
+        media.onload = loadFunc;
+        media.onloadeddata = loadFunc;
 
         lightboxElements.push({
           type: "image",

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -206,7 +206,7 @@ function processNode(node, initDispatchFunc) {
             media.src = media.getAttribute("data-fallback-src");
             media.removeAttribute("data-fallback-src");
           } else {
-            media.src = "https://placehold.co/600x400?text=Image+not+loaded";
+            media.src = "https://placehold.co/600x400?text=Media+not+found";
           }
         };
 

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -201,10 +201,12 @@ function processNode(node, initDispatchFunc) {
         media.onerror = () => {
           if (
             document.body.contains(media) &&
-            media.title.includes("temp-backup-url=")
+            media.getAttribute("data-fallback-src")
           ) {
-            media.src = media.title.replace("temp-backup-url=", "");
-            media.title = "";
+            media.src = media.getAttribute("data-fallback-src");
+            media.removeAttribute("data-fallback-src");
+          } else {
+            media.src = "https://placehold.co/600x400?text=Image+not+loaded";
           }
         };
 
@@ -212,9 +214,9 @@ function processNode(node, initDispatchFunc) {
         const loadFunc = () => {
           if (
             document.body.contains(media) &&
-            media.title.includes("temp-backup-url=")
+            media.getAttribute("data-fallback-src")
           ) {
-            media.title = "";
+            media.removeAttribute("data-fallback-src");
           }
         };
 


### PR DESCRIPTION
## Implemented Changes

### Problem
When uploading media using the GitHub API in [git-clerk](https://github.com/EOX-A/git-clerk), we can only use its permanent URL. This ensures the media is always accessible, even if the branch is merged or deleted. However, the permanent URL becomes available to users only after a delay of one minute.

### Solution
- Utilize the commit URL as a fallback src. While the commit URL is not suitable for permanent purposes, it is available immediately after merging. This allows the image to be loaded into storytelling until the permanent URL is ready. (This ensures users can view the image without delay.)
- To achieve this, we use the attribute `data-fallback-src=""` property to load the backup URL, as shown below:
```md
<img src="permanent-src" data-fallback-src="temporary-fallback-src"
```
- If any normal image don't load a default `fallback-src` will be loaded - `https://placehold.co/600x400?text=Media+not+found`

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
