### PR TITLE
feat: submit button callback

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -20,6 +20,22 @@ export const createEditor = (element) => {
   // Get the form element from the shadow DOM
   const formEle = element.renderRoot.querySelector("form");
 
+  // Add default button callback for submit
+  // see https://github.com/json-editor/json-editor?tab=readme-ov-file#button-editor
+  JSONEditor.defaults.callbacks = {
+    button: {
+      onSubmit: function () {
+        element.dispatchEvent(
+          new CustomEvent(`submit`, {
+            detail: element.value,
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      },
+    },
+  };
+
   // Initialize the JSONEditor with the given schema, value, and options
   const initEditor = () =>
     new JSONEditor(formEle, {

--- a/elements/jsonform/stories/index.js
+++ b/elements/jsonform/stories/index.js
@@ -12,3 +12,4 @@ export { default as LineStory } from "./line"; // Input form based on Drawtools 
 export { default as WKTStory } from "./wkt"; // Input form based on Drawtools that returns WKT string
 export { default as GeoJSONStory } from "./geojson"; // Input form based on Drawtools that returns GeoJSON
 export { default as CustomEditorInterfacesStory } from "./custom-editor-interfaces"; // Custom editor interfaces
+export { default as ValidationStory } from "./validation";

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -15,6 +15,7 @@ import {
   GeoJSONStory,
   LineStory,
   CustomEditorInterfacesStory,
+  ValidationStory,
 } from "./index.js";
 
 export default {
@@ -27,6 +28,7 @@ export default {
       .value=${args.value}
       .noShadow=${true}
       .unstyled=${args.unstyled}
+      @submit=${(e) => alert(JSON.stringify(e.detail))}
     ></eox-jsonform>
   `,
 };
@@ -35,6 +37,11 @@ export default {
  * Basic JSON Form example
  */
 export const Primary = PrimaryStory;
+
+/**
+ * Basic validation example. Includes submit button that is only clickable once validation passes.
+ */
+export const Validation = ValidationStory;
 
 /**
  * JSON Form based on STAC Catalog config

--- a/elements/jsonform/stories/validation.js
+++ b/elements/jsonform/stories/validation.js
@@ -1,0 +1,41 @@
+/**
+ * Demonstration of validation and button callback
+ */
+
+const Validation = {
+  args: {
+    schema: {
+      type: "object",
+      required: ["eox"],
+      properties: {
+        eox: {
+          type: "boolean",
+          format: "checkbox",
+          title: `I agree to the EOX Terms And Conditions`,
+          description: `<a target="_blank" href="https://eox.at/terms-conditions/">https://eox.at/terms-conditions/</a>`,
+          const: true,
+          options: {
+            error_messages: {
+              en: {
+                error_const: "Please accept to continue!",
+              },
+            },
+          },
+        },
+        // Adds a submit button that is only cliackable
+        // once the validation passes
+        button: {
+          format: "button",
+          options: {
+            button: {
+              text: "Continue",
+              action: "onSubmit",
+              validated: true,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+export default Validation;

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -11,3 +11,4 @@ export { default as loadValuesTest } from "./load-values";
 export { default as loadMisMatchingValuesTest } from "./load-mismatching-values";
 export { default as renderDrawtools } from "./render-drawtools";
 export { default as loadCustomEditorInterfaceTest } from "./load-custom-editor-interface";
+export { default as loadSubmitButtonTest } from "./submit-button";

--- a/elements/jsonform/test/cases/submit-button.js
+++ b/elements/jsonform/test/cases/submit-button.js
@@ -45,6 +45,7 @@ const submitButtonTest = () => {
       cy.get(".json-editor-btn-").should("be.disabled");
       cy.get("input[type=checkbox]").click();
       cy.get(".json-editor-btn-").should("be.enabled");
+      // eslint-disable-next-line cypress/unsafe-to-chain-command
       cy.get(".json-editor-btn-")
         .click()
         .then(() => {

--- a/elements/jsonform/test/cases/submit-button.js
+++ b/elements/jsonform/test/cases/submit-button.js
@@ -1,0 +1,56 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the jsonform component loads successfully.
+ */
+const submitButtonTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        required: ["foo"],
+        properties: {
+          foo: {
+            type: "boolean",
+            format: "checkbox",
+            const: true,
+          },
+          button: {
+            format: "button",
+            options: {
+              button: {
+                text: "Submit",
+                action: "onSubmit",
+                validated: true,
+              },
+            },
+          },
+        },
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  const clickEventHandlerSpy = cy.spy();
+  cy.get(jsonForm).and(($jsonForm) => {
+    $jsonForm.get(0).addEventListener("submit", clickEventHandlerSpy);
+  });
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".json-editor-btn-").should("be.disabled");
+      cy.get("input[type=checkbox]").click();
+      cy.get(".json-editor-btn-").should("be.enabled");
+      cy.get(".json-editor-btn-")
+        .click()
+        .then(() => {
+          expect(clickEventHandlerSpy).to.be.calledOnce;
+        });
+    });
+};
+
+export default submitButtonTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -13,6 +13,7 @@ import {
   loadMisMatchingValuesTest,
   renderDrawtools,
   loadCustomEditorInterfaceTest,
+  loadSubmitButtonTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -29,5 +30,6 @@ describe("Jsonform", () => {
   it("loads values", () => loadValuesTest());
   it("loads mismatching values", () => loadMisMatchingValuesTest());
   it("loads custom editor interface", () => loadCustomEditorInterfaceTest());
-  it.only("renders drawtools as a custom input", () => renderDrawtools());
+  it("renders drawtools as a custom input", () => renderDrawtools());
+  it("handles a submit button correctly", () => loadSubmitButtonTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR adds a default callback for an `onSubmit` function, which just emits the `submit` event on the `eox-jsonform` element.

### Background
`json-editor` supports [defining a button on the form](https://github.com/json-editor/json-editor?tab=readme-ov-file#button-editor), which only is clickable once validation passes, e.g.:
```js
button: {
  format: "button",
  options: {
    button: {
      text: "Submit",
      action: "onSubmit",
      validated: true,
    },
  },
},
```
In order to do something on click, an `onSubmit` callback must be registered before initializing the JSONEditor. In order to support a generic "submit" functionality, a `onSubmit` callback was registered, which dispatches a custom `submit` event, so that it can be listened e.g.:
```html
<eox-jsonform
  @submit=${(e) => alert(`Submitted: ${JSON.stringify(e.detail)}`)}
></eox-jsonform>
```

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
