### PR TITLE
feat: allow HTML in titles and descriptions

### DIFF
--- a/elements/jsonform/package.json
+++ b/elements/jsonform/package.json
@@ -35,6 +35,7 @@
     "@eox/elements-utils": "^0.1.5",
     "@json-editor/json-editor": "^2.11.0",
     "easymde": "^2.18.0",
+    "isomorphic-dompurify": "^2.4.0",
     "lit": "^3.2.0",
     "lodash.isequal": "^4.5.0",
     "toolcool-range-slider": "^4.0.28"

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -3,6 +3,7 @@ import { createEditor, parseProperty } from "./helpers";
 import { style } from "./style";
 import { styleEOX } from "./style.eox";
 import isEqual from "lodash.isequal";
+import _DOMPurify from "isomorphic-dompurify"; // required for allowing HTML in jsonform-rendered titles & descriptions
 import allStyle from "@eox/elements-utils/styles/dist/all.style";
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
         "@eox/elements-utils": "^0.1.5",
         "@json-editor/json-editor": "^2.11.0",
         "easymde": "^2.18.0",
+        "isomorphic-dompurify": "^2.4.0",
         "lit": "^3.2.0",
         "lodash.isequal": "^4.5.0",
         "toolcool-range-slider": "^4.0.28"


### PR DESCRIPTION
## Implemented changes

This PR adds the functionality to use (sanitized) HTML in titles, descriptions etc. This is achieved by adding a DOM sanitizer (see https://github.com/json-editor/json-editor/blob/cb10e1cc2ca3d3be57e4e51827e6f2de74f76fe4/UPGRADING.md#option-description).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
