### PR TITLE
fix: ensure custom theme overrides are applied

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -52,6 +52,9 @@ export const createEditor = (element) => {
 
   // Event listener for the 'ready' event
   editor.on("ready", () => {
+    //
+    element.renderRoot.querySelector("form").dataset.themeCustom = "eox";
+
     /// Check if any editor requires SimpleMDE and load necessary stylesheets
     if (
       Object.values(editor.editors).some((e) => e instanceof SimplemdeEditor)

--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -3,7 +3,7 @@ export const styleEOX = `
     --background-color: var(--eox-background-color, transparent);
     background-color: var(--background-color, transparent);
   }
-  form[data-theme="html"] .je-indented-panel {
+  form[data-theme="html"][data-theme-custom="eox"] .je-indented-panel {
     min-height: 20px;
     padding: var(--eox-panel-spacing, 10px);
     margin: var(--eox-panel-spacing, 10px);
@@ -17,7 +17,7 @@ export const styleEOX = `
     -webkit-box-shadow: none;
     box-shadow: none;
   }
-  form[data-theme="html"] .je-child-editor-holder {
+  form[data-theme="html"][data-theme-custom="eox"] .je-child-editor-holder {
     margin-bottom: 0;
   }
   .je-object__container {
@@ -32,7 +32,7 @@ export const styleEOX = `
   .row:not(.row .row) {
     margin-bottom: 8px;
   }
-  form[data-theme="html"] .je-form-input-label:not([data-schematype="boolean"] label) {
+  form[data-theme="html"][data-theme-custom="eox"] .je-form-input-label:not([data-schematype="boolean"] label) {
     display: inline-block;
     max-width: 100%;
     margin-bottom: 5px;
@@ -86,22 +86,22 @@ export const styleEOX = `
   }
 
   /* MD Editor */
-  .editor-toolbar button {
+  [data-theme-custom="eox"] .editor-toolbar button {
     background: none;
     box-shadow: none;
     color: #555;
   }
-  .editor-toolbar button:hover:not([disabled]):not(.icon),
-  .editor-toolbar button:hover:not([disabled]):not(.icon) {
+  [data-theme-custom="eox"] .editor-toolbar button:hover:not([disabled]):not(.icon),
+  [data-theme-custom="eox"] .editor-toolbar button:hover:not([disabled]):not(.icon) {
     box-shadow: none;
     background: #fcfcfc;
     border-color: #95a5a6;
     color: #2c3e50;
   }
-  .editor-toolbar button i {
+  [data-theme-custom="eox"] .editor-toolbar button i {
     font-size: 17px;
   }
-  .editor-statusbar {
+  [data-theme-custom="eox"] .editor-statusbar {
     padding-bottom: 0;
   }
   .cm-header-1 {
@@ -204,13 +204,13 @@ export const styleEOX = `
   }
 
   /* Hide stuff on the root level */
-  form[data-theme="html"] > [data-schemaid="root"] > .je-indented-panel {
+  form[data-theme="html"][data-theme-custom="eox"] > [data-schemaid="root"] > .je-indented-panel {
     margin: 0;
     padding: 0;
     border: none;
   }
-  form[data-theme="html"] > [data-schemaid="root"] > .je-header,
-  form[data-theme="html"] > [data-schemaid="root"] > .je-object__controls {
+  form[data-theme="html"][data-theme-custom="eox"] > [data-schemaid="root"] > .je-header,
+  form[data-theme="html"][data-theme-custom="eox"] > [data-schemaid="root"] > .je-object__controls {
     display: none;
   }
 `;

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -29,7 +29,7 @@ export default {
     <eox-jsonform
       .schema=${args.schema}
       .value=${args.value}
-      .noShadow=${true}
+      .noShadow=${args.noShadow}
       .unstyled=${args.unstyled}
       @submit=${(e) => alert(JSON.stringify(e.detail))}
     ></eox-jsonform>


### PR DESCRIPTION
## Implemented changes

This PR adds another property on the `form` element (`[data-theme-custom="eox"]`) to ensure the overriden styles are actually overridden. There were some issues that styles bundled in jsonform were loaded in a different order, causing style glitches.

In the future, we should probably create a proper custom theme and not base it on the `html` theme.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
