### PR TITLE
fix: allow provider roles when filtering out links

### DIFF
--- a/elements/stacinfo/src/helpers/properties.js
+++ b/elements/stacinfo/src/helpers/properties.js
@@ -42,7 +42,8 @@ export function transformProperties(properties, type = "property") {
     const filterLinks = (links) => {
       return Object.entries(links).filter(([_, itemValue]) => {
         let pass = true;
-        if (itemValue.roles) pass = itemValue.roles.includes("metadata");
+        if (itemValue.roles && key !== "providers")
+          pass = itemValue.roles.includes("metadata");
         if (itemValue.rel) pass = itemValue.rel === "example";
         return pass;
       });


### PR DESCRIPTION
## Implemented changes

This PR checks if the rendered links are part of the `providers` object, and if so, disables the `roles === metadata` check.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
