### PR TITLE
feat: add support for code editor

### DIFF
--- a/elements/jsonform/package.json
+++ b/elements/jsonform/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@eox/elements-utils": "^0.1.5",
     "@json-editor/json-editor": "^2.11.0",
+    "ace-builds": "^1.37.5",
     "easymde": "^2.18.0",
     "isomorphic-dompurify": "^2.4.0",
     "lit": "^3.2.0",

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -76,7 +76,7 @@ export const createEditor = (element) => {
     }
 
     // Check if any editor requires AceEditor
-    const aceUsed = Object.values(editor.editors).find((e) => e.ace_container);
+    const aceUsed = Object.values(editor.editors).find((e) => e?.ace_container);
     if (aceUsed && !element.noShadow) {
       // Attach to shadow root
       aceUsed.ace_editor_instance.renderer.attachToShadowRoot();

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -78,6 +78,12 @@ export const createEditor = (element) => {
     // Check if any editor requires AceEditor
     const aceUsed = Object.values(editor.editors).find((e) => e?.ace_container);
     if (aceUsed && !element.noShadow) {
+      // https://github.com/ajaxorg/ace/wiki/Configuring-Ace
+      aceUsed.ace_editor_instance.setOptions({
+        showPrintMargin: false,
+        useSoftTabs: true,
+        wrap: true,
+      });
       // Attach to shadow root
       aceUsed.ace_editor_instance.renderer.attachToShadowRoot();
       aceUsed.ace_editor_instance.resize();

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -1,11 +1,18 @@
 import { JSONEditor } from "@json-editor/json-editor/src/core.js";
 import { SimplemdeEditor } from "@json-editor/json-editor/src/editors/simplemde.js";
 import EasyMDE from "easymde/dist/easymde.min.js";
+import AceEditor from "ace-builds";
+import "ace-builds/esm-resolver.js";
 import addCustomInputs from "../custom-inputs";
 
 // using a drop-in replacement for EasyMDE,
 // see https://github.com/json-editor/json-editor/issues/1093
 window.SimpleMDE = EasyMDE;
+
+// using Ace editor for code
+// see https://github.com/json-editor/json-editor/tree/master?tab=readme-ov-file#specialized-string-editors
+window.ace = AceEditor;
+window.ace.config.set("useWorker", false);
 
 /**
  * Create the editor instance
@@ -66,6 +73,14 @@ export const createEditor = (element) => {
           @import url("https://unpkg.com/easymde/dist/easymde.min.css");
         `;
       element.renderRoot.insertBefore(style, element.renderRoot.firstChild);
+    }
+
+    // Check if any editor requires AceEditor
+    const aceUsed = Object.values(editor.editors).find((e) => e.ace_container);
+    if (aceUsed && !element.noShadow) {
+      // Attach to shadow root
+      aceUsed.ace_editor_instance.renderer.attachToShadowRoot();
+      aceUsed.ace_editor_instance.resize();
     }
   });
   return editor;

--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -128,6 +128,15 @@ export const styleEOX = `
     border-radius: 2px !important;
   }
 
+  /* Ace Editor */
+  .ace_editor,
+  .ace_editor * {
+    font-family: "Monaco", "Menlo", "Ubuntu Mono", "Droid Sans Mono", "Consolas", monospace !important;
+  }
+  .ace_editor {
+    background: transparent;
+  }
+
   /* Buttons overrides */
   button {
     vertical-align: middle;

--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -133,9 +133,6 @@ export const styleEOX = `
   .ace_editor * {
     font-family: "Monaco", "Menlo", "Ubuntu Mono", "Droid Sans Mono", "Consolas", monospace !important;
   }
-  .ace_editor {
-    background: transparent;
-  }
 
   /* Buttons overrides */
   button {

--- a/elements/jsonform/stories/code.js
+++ b/elements/jsonform/stories/code.js
@@ -1,0 +1,19 @@
+/**
+ * Story demonstrating the Ace editor
+ */
+import codeSchema from "./public/codeSchema.json";
+
+const Code = {
+  args: {
+    schema: codeSchema,
+    value: {
+      code: `// Some code here
+function sayHello() {
+  console.log("Hello World!");  
+}
+
+sayHello();`,
+    },
+  },
+};
+export default Code;

--- a/elements/jsonform/stories/index.js
+++ b/elements/jsonform/stories/index.js
@@ -13,3 +13,4 @@ export { default as WKTStory } from "./wkt"; // Input form based on Drawtools th
 export { default as GeoJSONStory } from "./geojson"; // Input form based on Drawtools that returns GeoJSON
 export { default as CustomEditorInterfacesStory } from "./custom-editor-interfaces"; // Custom editor interfaces
 export { default as ValidationStory } from "./validation";
+export { default as CodeStory } from "./code";

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -16,6 +16,7 @@ import {
   LineStory,
   CustomEditorInterfacesStory,
   ValidationStory,
+  CodeStory,
 } from "./index.js";
 
 export default {
@@ -45,6 +46,11 @@ export const Primary = PrimaryStory;
  * Basic validation example. Includes submit button that is only clickable once validation passes.
  */
 export const Validation = ValidationStory;
+
+/**
+ * Example showing the usage of Ace editor for code editing
+ */
+export const Code = CodeStory;
 
 /**
  * JSON Form based on STAC Catalog config

--- a/elements/jsonform/stories/public/codeSchema.json
+++ b/elements/jsonform/stories/public/codeSchema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": "string",
+      "title": "Code editor powered by <a href='https://ace.c9.io/'>Ace</a>",
+      "description": "See the <a href='https://github.com/ajaxorg/ace/wiki/Configuring-Ace'>configuration options</a> and <a href='https://github.com/ajaxorg/ace/tree/master/src/theme'>themes</a> that can be passed to <code>options.ace</code>",
+      "format": "javascript",
+      "options": {
+        "ace": {
+          "tabSize": 2,
+          "useSoftTabs": true,
+          "wrap": true
+        }
+      }
+    }
+  }
+}

--- a/elements/jsonform/stories/public/codeSchema.json
+++ b/elements/jsonform/stories/public/codeSchema.json
@@ -8,9 +8,7 @@
       "format": "javascript",
       "options": {
         "ace": {
-          "tabSize": 2,
-          "useSoftTabs": true,
-          "wrap": true
+          "tabSize": 2
         }
       }
     }

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -6,6 +6,7 @@ export { default as loadExternalSchemaTest } from "./load-external-schema";
 export { default as loadExternalValueTest } from "./load-external-value";
 export { default as loadReRenderFormOnChangeTest } from "./re-render-form-on-change";
 export { default as loadMarkdownTest } from "./load-markdown";
+export { default as loadCodeTest } from "./load-code";
 export { default as triggerChangeEventTest } from "./trigger-change-event";
 export { default as loadValuesTest } from "./load-values";
 export { default as loadMisMatchingValuesTest } from "./load-mismatching-values";

--- a/elements/jsonform/test/cases/load-code.js
+++ b/elements/jsonform/test/cases/load-code.js
@@ -1,0 +1,54 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+const testVals = {
+  key: "foo",
+  value: "bar",
+  number: 7,
+};
+/**
+ * Test to verify if the code editor loads successfully.
+ */
+const loadCodeTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "json",
+            options: {
+              ace: {
+                tabSize: testVals.number,
+              },
+            },
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: testVals.value,
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+  // Find the jsonForm element and access its shadow DOM
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      // Check if Ace editor has loaded
+      cy.get(".ace_editor").should("exist");
+      // Check if text was rendered correctly
+      cy.get(".ace_line").invoke("text").should("eq", testVals.value);
+    });
+  cy.get(jsonForm).and(($el) => {
+    // Check if editor settings were applied
+    expect(
+      $el[0].editor.editors[`root.${testVals.key}`].options.ace.tabSize,
+    ).to.eq(testVals.number);
+  });
+};
+
+export default loadCodeTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -14,6 +14,7 @@ import {
   renderDrawtools,
   loadCustomEditorInterfaceTest,
   loadSubmitButtonTest,
+  loadCodeTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -26,6 +27,7 @@ describe("Jsonform", () => {
   it("loads value from url", () => loadExternalValueTest());
   it("re-renders form on change", () => loadReRenderFormOnChangeTest());
   it("loads the markdown editor", () => loadMarkdownTest());
+  it("loads the code editor", () => loadCodeTest());
   it("triggers a change event when typing", () => triggerChangeEventTest());
   it("loads values", () => loadValuesTest());
   it("loads mismatching values", () => loadMisMatchingValuesTest());

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
         "@json-editor/json-editor": "^2.11.0",
+        "ace-builds": "^1.37.5",
         "easymde": "^2.18.0",
         "isomorphic-dompurify": "^2.4.0",
         "lit": "^3.2.0",
@@ -5313,6 +5314,12 @@
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
       "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
       "optional": true
+    },
+    "node_modules/ace-builds": {
+      "version": "1.37.5",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.5.tgz",
+      "integrity": "sha512-VMJ4Cnhq6L9dwvOCyuyyvQuiVTSwdZC7zDKJBBBJJax0wGQ7MvzQZFoi0gMmCm2I4Zuv/ZbtwU/dlglIhCNLhw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.14.0",


### PR DESCRIPTION
## Implemented changes

This PR adds support for code editors powered by Ace. See the information about the json-editor integration [here](https://github.com/json-editor/json-editor/tree/master?tab=readme-ov-file#specialized-string-editors).

Passing the [configuration options](https://github.com/sparksuite/simplemde-markdown-editor#configuration) (including [themes](https://github.com/ajaxorg/ace/tree/master/src/theme)) to `options.ace` in the schema can modify behavior and appearance of the editor.

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/7d5602d2-c3ad-47d4-a922-06705c481d50)
![image](https://github.com/user-attachments/assets/c9c4436e-2802-48d9-90a9-1524ca2221d4)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
