### PR TITLE
fix: remove superfluous second map

### DIFF
--- a/elements/map/stories/map.stories.js
+++ b/elements/map/stories/map.stories.js
@@ -43,13 +43,6 @@ export default {
       .layers=${args.layers}
       .zoom=${args.zoom}
     ></eox-map>
-    <eox-map-2
-      style="width: 100%; height: 300px;"
-      .center=${args.center}
-      .controls=${args.controls}
-      .layers=${args.layers}
-      .zoom=${args.zoom}
-    ></eox-map-2>
   `,
 };
 


### PR DESCRIPTION
## Implemented changes

Due to a stupid mistake of mine, the Storybook examples of `eox-map` have an invalid second reference to a map where I seemingly confused the class name with the tag name. It is not visible in the rendered components, but will still be confusing.

This pull requests removes [the wrongly placed and incorrect snippet](https://github.com/EOX-A/EOxElements/blob/main/elements/map/stories/map.stories.js#L46-L52).

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<img width="1027" alt="Screenshot 2025-02-05 at 00 10 34" src="https://github.com/user-attachments/assets/8ea66687-5866-4928-9390-c3065171c1d5" />

<!-- upload 
and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
