### PR TITLE
fix: hide category tabs where property has `options.hidden`

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -63,7 +63,7 @@ export const createEditor = (element) => {
     element.renderRoot.querySelector("form").dataset.themeCustom = "eox";
 
     // Workaround to hide tabs where property has `options.hiden`
-    // See https://github.com/json-editor/json-editor/issues/1577
+    // TEMP - see https://github.com/json-editor/json-editor/issues/1577
     const tabsTitles = Array.from(
       element.renderRoot.querySelectorAll(
         ".tabs.je-tabholder--top > .je-tab--top > span",

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -62,6 +62,25 @@ export const createEditor = (element) => {
     //
     element.renderRoot.querySelector("form").dataset.themeCustom = "eox";
 
+    // Workaround to hide tabs where property has `options.hiden`
+    // See https://github.com/json-editor/json-editor/issues/1577
+    const tabsTitles = Array.from(
+      element.renderRoot.querySelectorAll(
+        ".tabs.je-tabholder--top > .je-tab--top > span",
+      ),
+    );
+    Object.entries(editor.expandSchema(editor.schema).properties)
+      .filter(([_, property]) => property.options?.hidden)
+      .map(([key, property]) => property.title || key)
+      .forEach((title) => {
+        const tabTitle = tabsTitles.find(
+          (tabTitle) => tabTitle.textContent === title,
+        );
+        if (tabTitle) {
+          tabTitle.parentElement.dataset.hidden = "";
+        }
+      });
+
     /// Check if any editor requires SimpleMDE and load necessary stylesheets
     if (
       Object.values(editor.editors).some((e) => e instanceof SimplemdeEditor)

--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -3,6 +3,9 @@ export const styleEOX = `
     --background-color: var(--eox-background-color, transparent);
     background-color: var(--background-color, transparent);
   }
+  form[data-theme="html"][data-theme-custom="eox"] .tabs.je-tabholder--top > .je-tab--top[data-hidden] {
+    display: none;
+  }
   form[data-theme="html"][data-theme-custom="eox"] .je-indented-panel {
     min-height: 20px;
     padding: var(--eox-panel-spacing, 10px);


### PR DESCRIPTION
## Implemented changes

Workaround to hide tabs where `options.hidden` is set on a property. See https://github.com/json-editor/json-editor/issues/1577

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
