### PR TITLE
fix: trigger `change` event on text inputs

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -87,6 +87,19 @@ export const createEditor = (element) => {
         }
       });
 
+    // Workaround to emit "change" event also from text inputs
+    // TEMP - see https://github.com/json-editor/json-editor/issues/1445
+    const inputElements = element.renderRoot.querySelectorAll(
+      "[data-schematype=string] input",
+    );
+    inputElements.forEach((element) => {
+      element.addEventListener("input", () => {
+        element.dispatchEvent(
+          new CustomEvent("change", { detail: element.value }),
+        );
+      });
+    });
+
     /// Check if any editor requires SimpleMDE and load necessary stylesheets
     if (
       Object.values(editor.editors).some((e) => e instanceof SimplemdeEditor)

--- a/elements/jsonform/stories/feature-selection.js
+++ b/elements/jsonform/stories/feature-selection.js
@@ -13,7 +13,7 @@ import featureSchema from "./public/featureSchema.json";
 const FeatureSelection = {
   args: {
     schema: featureSchema,
-    onChange: (e) => console.log("value:", e.detail),
+    onChange: (e) => console.info("New value:", e.detail),
   },
   render: (args) => html`
     <eox-map 

--- a/elements/jsonform/stories/geojson.js
+++ b/elements/jsonform/stories/geojson.js
@@ -8,9 +8,7 @@ import geojsonSchema from "./public/geojsonSchema.json";
 const geoJson = {
   args: {
     schema: geojsonSchema,
-    onChange: (e) => {
-      console.log("value:", e.detail);
-    },
+    onChange: (e) => console.info("New value:", e.detail),
   },
   render: (args) => html`
     <p>Refer to the console for the returned values</p>

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -32,8 +32,8 @@ export default {
       .value=${args.value}
       .noShadow=${args.noShadow}
       .unstyled=${args.unstyled}
-      @change=${(e) => console.log("Changed event triggered! New value: " + e.detail)}
-      @submit=${(e) => alert(JSON.stringify(e.detail))}
+      @change=${args.onChange}
+      @submit=${args.onSubmit}
     ></eox-jsonform>
   `,
 };

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -32,6 +32,7 @@ export default {
       .value=${args.value}
       .noShadow=${args.noShadow}
       .unstyled=${args.unstyled}
+      @change=${(e) => console.log(e.detail)}
       @submit=${(e) => alert(JSON.stringify(e.detail))}
     ></eox-jsonform>
   `,

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -32,7 +32,7 @@ export default {
       .value=${args.value}
       .noShadow=${args.noShadow}
       .unstyled=${args.unstyled}
-      @change=${(e) => console.log(e.detail)}
+      @change=${(e) => console.log("Changed event triggered! New value: " + e.detail)}
       @submit=${(e) => alert(JSON.stringify(e.detail))}
     ></eox-jsonform>
   `,

--- a/elements/jsonform/stories/primary.js
+++ b/elements/jsonform/stories/primary.js
@@ -7,6 +7,7 @@ import basicSchema from "./public/basicSchema.json";
 const Primary = {
   args: {
     schema: basicSchema,
+    onChange: (e) => console.info("New value:", e.detail),
   },
 };
 export default Primary;

--- a/elements/jsonform/stories/public/basicSchema.json
+++ b/elements/jsonform/stories/public/basicSchema.json
@@ -22,6 +22,9 @@
     "cbar": {
       "type": "string",
       "enum": ["rain", "temperature"]
+    },
+    "foobar": {
+      "type": "string"
     }
   }
 }

--- a/elements/jsonform/stories/validation.js
+++ b/elements/jsonform/stories/validation.js
@@ -69,6 +69,7 @@ const Validation = {
         },
       },
     },
+    onSubmit: (e) => alert(JSON.stringify(e.detail)),
   },
 };
 export default Validation;

--- a/elements/jsonform/stories/wkt.js
+++ b/elements/jsonform/stories/wkt.js
@@ -8,9 +8,7 @@ import wktSchema from "./public/wktSchema.json";
 const wkt = {
   args: {
     schema: wktSchema,
-    onChange: (e) => {
-      console.log("value:", e.detail);
-    },
+    onChange: (e) => console.info("New value:", e.detail),
   },
   render: (args) => html`
     <p>Refer to the console for the returned values</p>

--- a/elements/jsonform/test/cases/trigger-change-event.js
+++ b/elements/jsonform/test/cases/trigger-change-event.js
@@ -34,9 +34,6 @@ const triggerChangeEventTest = () => {
     .shadow()
     .within(() => {
       cy.get("input[name]").type(testVals.value);
-      // String input needs blur to trigger change event
-      // see https://github.com/json-editor/json-editor/issues/1081
-      cy.get(".form-control").click({ force: true });
     });
   cy.get("@change").should("have.been.called");
 };


### PR DESCRIPTION
## Implemented changes

This PR adds a workaround to emit a `change` event for string type input fields (`input` event). This makes the text input behavior harmonized with all the other inputs.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
