### PR TITLE
Fix: Repeated form child creation on jsonform

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -27,6 +27,7 @@ export const createEditor = (element) => {
 
   // Get the form element from the shadow DOM
   const formEle = element.renderRoot.querySelector("form");
+  while (formEle.firstChild) formEle.removeChild(formEle.firstChild);
 
   // Add default button callback for submit
   // see https://github.com/json-editor/json-editor?tab=readme-ov-file#button-editor


### PR DESCRIPTION
## Implemented changes
- Repeated child creation occurs inside `eox-jsonform` because the child is not removed from the form when generating a new form.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/user-attachments/assets/7ba6230d-be09-4501-a569-c5f345f26ad6



<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
