### PR TITLE
Feat: Introduce continuous drawing

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -66,6 +66,10 @@ export class EOxDrawTools extends LitElement {
    * @type string
    */
   #layerId;
+  /**
+   * @type boolean
+   */
+  #continuous;
 
   constructor() {
     super();
@@ -149,11 +153,6 @@ export class EOxDrawTools extends LitElement {
     this.type = "Polygon";
 
     /**
-     * Allow continuous drawing when `multipleFeatures` is `true`
-     */
-    this.continuous = false;
-
-    /**
      * @type {ReturnType<typeof import("./methods/draw/create-select-handler").default>}
      */
     this.selectionEvents = null;
@@ -180,8 +179,21 @@ export class EOxDrawTools extends LitElement {
   }
 
   /**
+   * Enables continuous drawing
    *
-   *
+   * @type {boolean}
+   */
+  set continuous(value) {
+    this.#continuous = value;
+    if (value) this.multipleFeatures = true;
+  }
+
+  get continuous() {
+    return this.#continuous;
+  }
+
+  /**
+   * Enables selection mode for the passed layer
    * @type {string}
    */
   set layerId(value) {

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -29,6 +29,7 @@ export class EOxDrawTools extends LitElement {
       allowModify: { attribute: "allow-modify", type: Boolean },
       for: { type: String },
       currentlyDrawing: { attribute: false, state: true, type: Boolean },
+      continuous: { type: Boolean },
       draw: { attribute: false, state: true },
       drawLayer: { attribute: false, state: true },
       layerId: { attribute: "layer-id", type: String },
@@ -146,6 +147,11 @@ export class EOxDrawTools extends LitElement {
      * @type {"Polygon" | "Point" | "LineString" | "Circle" | "Box"}
      */
     this.type = "Polygon";
+
+    /**
+     * Allow continuous drawing when `multipleFeatures` is `true`
+     */
+    this.continuous = false;
 
     /**
      * @type {ReturnType<typeof import("./methods/draw/create-select-handler").default>}

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -179,8 +179,8 @@ export class EOxDrawTools extends LitElement {
   }
 
   /**
-   * Enables continuous drawing
-   *
+   * Enables the user to draw continuously one feature at a time
+   * without removing the last feature manually
    * @type {boolean}
    */
   set continuous(value) {

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -179,8 +179,8 @@ export class EOxDrawTools extends LitElement {
   }
 
   /**
-   * Enables the user to draw continuously one feature at a time
-   * without removing the last feature manually
+   * Enables the user to draw continuously one feature after another
+   * without having to discard previous ones manually
    * @type {boolean}
    */
   set continuous(value) {

--- a/elements/drawtools/src/methods/draw/on-draw-end.js
+++ b/elements/drawtools/src/methods/draw/on-draw-end.js
@@ -12,6 +12,20 @@ const onDrawEndMethod = (EoxDrawTool) => {
       EoxDrawTool.draw.setActive(false); // Deactivate drawing
       EoxDrawTool.selectionEvents.removeSelectionEvent();
       EoxDrawTool.currentlyDrawing = false; // Update drawing status flag
+    } else {
+      if (EoxDrawTool.continuous) {
+        // the selection event selects the feature after draw ends
+        if (!EoxDrawTool.layerId) {
+          EoxDrawTool.drawLayer.getSource().clear(true);
+          EoxDrawTool.drawnFeatures = [];
+        } else {
+          const features = EoxDrawTool.drawLayer.getSource().getFeatures();
+          const latest = features.at(-1);
+          EoxDrawTool.drawLayer.getSource().clear(true);
+          EoxDrawTool.drawLayer.getSource().addFeature(latest);
+          EoxDrawTool.drawnFeatures = [latest];
+        }
+      }
     }
   };
 

--- a/elements/drawtools/stories/continuous-drawing.js
+++ b/elements/drawtools/stories/continuous-drawing.js
@@ -16,11 +16,7 @@ export const ContinuousDrawing = {
     ></eox-map>
 
     <!-- Initialize eox-drawtools for the eox-map with ID "continuous" -->
-    <eox-drawtools
-      for="eox-map#continuous"
-      multiple-features
-      continuous
-    ></eox-drawtools>
+    <eox-drawtools for="eox-map#continuous" continuous></eox-drawtools>
   `,
 };
 

--- a/elements/drawtools/stories/continuous-drawing.js
+++ b/elements/drawtools/stories/continuous-drawing.js
@@ -1,0 +1,27 @@
+/**
+ * Component demonstrating drawing polygons continuously.
+ * This component showcases the usage of eox-drawtools with the `multiple-features` and `continuous` attribute/property set
+ * to be able to draw multiple polygons one at a time continuously on the map.
+ */
+import { html } from "lit";
+import { STORIES_LAYERS_ARRAY, STORIES_MAP_STYLE } from "../src/enums";
+
+export const ContinuousDrawing = {
+  render: () => html`
+    <!-- Render eox-map component with ID "continuous" -->
+    <eox-map
+      id="continuous"
+      style=${STORIES_MAP_STYLE}
+      .layers=${STORIES_LAYERS_ARRAY}
+    ></eox-map>
+
+    <!-- Initialize eox-drawtools for the eox-map with ID "continuous" -->
+    <eox-drawtools
+      for="eox-map#continuous"
+      multiple-features
+      continuous
+    ></eox-drawtools>
+  `,
+};
+
+export default ContinuousDrawing;

--- a/elements/drawtools/stories/continuous-drawing.js
+++ b/elements/drawtools/stories/continuous-drawing.js
@@ -1,6 +1,6 @@
 /**
  * Component demonstrating drawing polygons continuously.
- * This component showcases the usage of eox-drawtools with the `multiple-features` and `continuous` attribute/property set
+ * This component showcases the usage of eox-drawtools with the `continuous` attribute/property set
  * to be able to draw multiple polygons one at a time continuously on the map.
  */
 import { html } from "lit";

--- a/elements/drawtools/stories/drawtools.stories.js
+++ b/elements/drawtools/stories/drawtools.stories.js
@@ -56,7 +56,7 @@ export const DrawType = DrawTypeStory;
 export const MultiPolygonWithList = MultiPolygonWithListStory;
 
 /**
- * By setting the `continuous` and  `multiple-features` attribute/property to `true`,
+ * By setting the `continuous` attribute/property to `true`,
  * the user can draw continuously one polygon at a time without removing the last polygon manually.
  */
 export const ContinuousDrawing = ContinuousDrawingStory;

--- a/elements/drawtools/stories/drawtools.stories.js
+++ b/elements/drawtools/stories/drawtools.stories.js
@@ -15,6 +15,7 @@ import {
   MultiFeaturesSelectStory,
   FeaturesProjectionStory,
   FormatStory,
+  ContinuousDrawingStory,
 } from "./index";
 
 export default {
@@ -54,6 +55,11 @@ export const DrawType = DrawTypeStory;
  */
 export const MultiPolygonWithList = MultiPolygonWithListStory;
 
+/**
+ * By setting the `continuous` and  `multiple-features` attribute/property to `true`,
+ * the user can draw continuously one polygon at a time without removing the last polygon manually.
+ */
+export const ContinuousDrawing = ContinuousDrawingStory;
 /**
  * By setting the `show-editor` attribute or `import-features` property to `true`,
  * generates an editor to edit features and allow users to drag-drop/upload/paste shape files in

--- a/elements/drawtools/stories/index.js
+++ b/elements/drawtools/stories/index.js
@@ -11,5 +11,6 @@ export { default as SelectFeatureStory } from "./select-feature"; // Story demon
 export { default as MultiFeaturesSelectStory } from "./multi-feature-select"; // Story demonstrating multi feature selection with list
 export { default as FeaturesProjectionStory } from "./features-projection"; // Story showcasing emitting drawn features in different projections
 export { default as FormatStory } from "./formats"; // Story showcasing emitting drawn features in different formats
+export { default as ContinuousDrawingStory } from "./continuous-drawing"; // Story demonstrating continuous drawing
 export { default as CSSVariableOverrideStory } from "./css-variable-override"; // Story demonstrating css override
 export { default as UnstyledStory } from "./unstyled"; // Story demonstrating unstyled variant of element.


### PR DESCRIPTION
## Implemented changes
introduced `continuous` attribute. when `continuous` is set to true the user can select/draw continuously without discarding or removing the old feature. related to eodash/eodash#171
## Screen Recording

https://github.com/user-attachments/assets/29f13b89-8e2d-4e5c-ae89-efcdf060e99c



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
