### PR TITLE
fix(style): remove last row margin and prevent form overflow

### DIFF
--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -1,4 +1,8 @@
 export const styleEOX = `
+  :host, :root {
+    display: block;
+    overflow: hidden;
+  }
   :host, :root, form, .CodeMirror {
     --background-color: var(--eox-background-color, transparent);
     background-color: var(--background-color, transparent);
@@ -55,7 +59,7 @@ export const styleEOX = `
   .je-header {
     margin-top: var(--eox-panel-spacing, 10px);
   }
-  .row:not(.row .row) {
+  .row:not(.row .row):not(.row:last-child) {
     margin-bottom: 8px;
   }
   form[data-theme="html"][data-theme-custom="eox"] .je-form-input-label:not([data-schematype="boolean"] label) {
@@ -69,7 +73,7 @@ export const styleEOX = `
     padding-top: var(--eox-panel-spacing, 10px);
     padding-bottom: var(--eox-panel-spacing, 10px);
   }
-  .form-control:not([data-schematype="boolean"] .form-control) {
+  .form-control:not([data-schematype="boolean"] .form-control):not(.row:last-child .form-control) {
     margin-bottom: 15px;
   }
   .form-control input:not([data-schematype="boolean"] input),


### PR DESCRIPTION
## Implemented changes

This PR removes the bottom margin of the last rows and last form controls in order to not set unnecessary bottom margin if not needed. It also sets the eox-jsonform to `display: block` and `overflow:hidden` by default, which allows more versatility and less repeated setup needed for usage in applications.

## Screenshots/Videos

### Before
![image](https://github.com/user-attachments/assets/e15d0c9d-4e90-4cf4-80d7-8d5df04f178e)


### After
![image](https://github.com/user-attachments/assets/aa298d95-db39-41d2-af79-8c1d3a0090c5)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
