### PR TITLE
fix: always show optional values

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -129,6 +129,18 @@ export const createEditor = (element) => {
       aceUsed.ace_editor_instance.renderer.attachToShadowRoot();
       aceUsed.ace_editor_instance.resize();
     }
+
+    // Workaround to show all fields (including optinal) even though a value is passed
+    // see discussion at https://github.com/json-editor/json-editor/issues/1632#issuecomment-2678397314
+    element.renderRoot
+      .querySelectorAll(".json-editor-opt-in")
+      .forEach((checkbox) => {
+        if (!(checkbox instanceof HTMLInputElement)) {
+          return;
+        }
+        if (!checkbox.checked) checkbox.click();
+        checkbox.parentElement.style.display = "none";
+      });
   });
   return editor;
 };

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -139,7 +139,7 @@ export const createEditor = (element) => {
           return;
         }
         if (!checkbox.checked) checkbox.click();
-        checkbox.parentElement.style.display = "none";
+        checkbox.parentElement.remove();
       });
   });
   return editor;

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -49,7 +49,7 @@ export class EOxJSONForm extends LitElement {
      * @type {object}
      */
     this.options = {
-      show_opt_in: false,
+      show_opt_in: true,
       disable_collapse: true,
       disable_edit_json: true,
       disable_properties: true,

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -10,6 +10,7 @@ export { default as loadCodeTest } from "./load-code";
 export { default as triggerChangeEventTest } from "./trigger-change-event";
 export { default as loadValuesTest } from "./load-values";
 export { default as loadMisMatchingValuesTest } from "./load-mismatching-values";
+export { default as loadOptionalFieldsTest } from "./load-optional-fields";
 export { default as renderDrawtools } from "./render-drawtools";
 export { default as loadCustomEditorInterfaceTest } from "./load-custom-editor-interface";
 export { default as loadSubmitButtonTest } from "./submit-button";

--- a/elements/jsonform/test/cases/load-optional-fields.js
+++ b/elements/jsonform/test/cases/load-optional-fields.js
@@ -1,0 +1,40 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+const testFields = ["foo", "bar"];
+/**
+ * Test to verify if applying a value still renders optional fields
+ */
+const loadOptionalFieldsTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        required: [testFields[0]],
+        properties: {
+          [testFields[0]]: {
+            type: "string",
+          },
+          [testFields[1]]: {
+            type: "string",
+          },
+        },
+      }}
+      .value=${{
+        [testFields[0]]: "",
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+  // Find the jsonForm element and access its shadow DOM
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      // Even though no value was set, this field should still exist
+      cy.get(`input[id="root[${testFields[1]}]"]`).should("exist");
+    });
+};
+
+export default loadOptionalFieldsTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -11,6 +11,7 @@ import {
   triggerChangeEventTest,
   loadValuesTest,
   loadMisMatchingValuesTest,
+  loadOptionalFieldsTest,
   renderDrawtools,
   loadCustomEditorInterfaceTest,
   loadSubmitButtonTest,
@@ -31,6 +32,7 @@ describe("Jsonform", () => {
   it("triggers a change event when typing", () => triggerChangeEventTest());
   it("loads values", () => loadValuesTest());
   it("loads mismatching values", () => loadMisMatchingValuesTest());
+  it("loads optional fields", () => loadOptionalFieldsTest());
   it("loads custom editor interface", () => loadCustomEditorInterfaceTest());
   it("renders drawtools as a custom input", () => renderDrawtools());
   it("handles a submit button correctly", () => loadSubmitButtonTest());


### PR DESCRIPTION
## Implemented changes

This PR ensures optional fields are always shown, even if a `value` has been passed to the editor. By default, json-editor hides optional fields as soon as a value is set 8see linked discussion in the code comment), but we mitigate this by setting `show_opt_in` to true and then both clicking the resulting checkbox and at the same time removes it, in order to make lives easier for users filling out the form.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
