### PR TITLE
Fix: Enable passing attributes and properties to the drawtools and generated map

### DIFF
--- a/elements/jsonform/src/custom-inputs/spatial/utils.js
+++ b/elements/jsonform/src/custom-inputs/spatial/utils.js
@@ -60,9 +60,13 @@ export const isSupported = (schema) =>
  * @param {Element} element - The DOM element to set attributes on
  * @param {{[key: string]: any}} attributes - The attributes to set on the element
  */
-export function setAttributes(element, attributes) {
+export function setAttributesAndProperties(element, attributes) {
   Object.keys(attributes).forEach((attr) => {
-    element.setAttribute(attr, attributes[attr]);
+    if (attr.includes("-")) {
+      element.setAttribute(attr, attributes[attr]);
+    } else {
+      element[attr] = attributes[attr];
+    }
   });
 }
 

--- a/elements/jsonform/stories/public/boundingBoxSchema.json
+++ b/elements/jsonform/stories/public/boundingBoxSchema.json
@@ -4,13 +4,11 @@
     "bboxes": {
       "title": "Multi bbox example",
       "type": "array",
-      "properties": {},
       "format": "bounding-boxes"
     },
     "bbox": {
       "title": "Single bbox example",
       "type": "array",
-      "properties": {},
       "format": "bounding-box"
     },
     "bboxes2": {

--- a/elements/jsonform/stories/public/featureSchema.json
+++ b/elements/jsonform/stories/public/featureSchema.json
@@ -6,8 +6,10 @@
       "type": "array",
       "options": {
         "featureProperty": "BIOME_NAME",
-        "layerId": "regions-grey",
-        "for": "eox-map#first"
+        "drawtools": {
+          "layerId": "regions-grey",
+          "for": "eox-map#first"
+        }
       },
       "items": {
         "type": "string"
@@ -18,8 +20,10 @@
       "title": "Select a feature from the map",
       "type": "object",
       "options": {
-        "layerId": "regions-blue",
-        "for": "eox-map#second"
+        "drawtools": {
+          "layerId": "regions-blue",
+          "for": "eox-map#second"
+        }
       },
       "format": "feature"
     }

--- a/elements/jsonform/stories/public/geojsonSchema.json
+++ b/elements/jsonform/stories/public/geojsonSchema.json
@@ -15,7 +15,9 @@
       "title": "Multiple bounding-boxes as Geojson in EPSG:3857",
       "type": "geojson",
       "options": {
-        "projection": "EPSG:3857"
+        "drawtools": {
+          "projection": "EPSG:3857"
+        }
       },
       "format": "bounding-boxes"
     },
@@ -23,7 +25,12 @@
       "title": "Polygon as Geojson in EPSG:3857",
       "type": "geojson",
       "options": {
-        "projection": "EPSG:3857"
+        "drawtools": {
+          "projection": "EPSG:3857"
+        },
+        "map": {
+          "projection": "EPSG:3857"
+        }
       },
       "format": "polygon"
     }

--- a/elements/jsonform/stories/public/lineSchema.json
+++ b/elements/jsonform/stories/public/lineSchema.json
@@ -9,9 +9,6 @@
     "lines": {
       "title": "Multiple lines example",
       "type": "array",
-      "options": {
-        "projection": "EPSG:3857"
-      },
       "format": "lines"
     }
   }

--- a/elements/jsonform/stories/public/pointSchema.json
+++ b/elements/jsonform/stories/public/pointSchema.json
@@ -9,9 +9,6 @@
     "points": {
       "title": "Multiple points example",
       "type": "array",
-      "options": {
-        "projection": "EPSG:3857"
-      },
       "format": "points"
     }
   }

--- a/elements/jsonform/stories/public/polygonSchema.json
+++ b/elements/jsonform/stories/public/polygonSchema.json
@@ -4,7 +4,6 @@
     "polygons": {
       "title": "Multi polygon",
       "type": "array",
-      "properties": {},
       "format": "polygons"
     },
     "polygon": {

--- a/elements/jsonform/stories/public/wktSchema.json
+++ b/elements/jsonform/stories/public/wktSchema.json
@@ -7,20 +7,28 @@
       "format": "point"
     },
     "bounding-boxes": {
-      "title": "Multiple bounding boxes as WKT in EPSG:3857",
+      "title": "Multiple bounding boxes as WKT in EPSG:3857 without a list",
       "type": "wkt",
       "options": {
-        "projection": "EPSG:3857"
+        "drawtools": {
+          "projection": "EPSG:3857",
+          "show-list": false
+        }
       },
       "format": "bounding-boxes"
     },
     "polygon": {
-      "title": "Polygon as WKT in EPSG:3857",
+      "title": "Polygons as WKT in EPSG:3857",
       "type": "wkt",
       "options": {
-        "projection": "EPSG:3857"
+        "drawtools": {
+          "projection": "EPSG:3857"
+        },
+        "map": {
+          "projection": "EPSG:3857"
+        }
       },
-      "format": "polygon"
+      "format": "polygons"
     }
   }
 }


### PR DESCRIPTION
## Implemented changes
this PR restructures the expected schema passed to the `SpatialEditor` to include properties and attributes of the drawtools to be passed under `options.drawtools`. In case there's no `for` property passed the editor creates an `eox-map` element which can be configured now using `options.map`

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
