### PR TITLE
fix(style): overflow on storytelling and editor

### DIFF
--- a/elements/storytelling/src/helpers/editor.js
+++ b/elements/storytelling/src/helpers/editor.js
@@ -342,12 +342,17 @@ export function preventEditorOutsideScroll(StoryTellingEditor) {
       "wheel",
       function (event) {
         const deltaY = /**@type {WheelEvent}*/ (event).deltaY;
-        const contentHeight = StoryTellingEditor.scrollHeight; // Total scrollable content height
-        const visibleHeight = StoryTellingEditor.clientHeight; // Visible portion of the textarea
-
+        const contentHeight =
+          StoryTellingEditor.querySelector(".CodeMirror-sizer").scrollHeight; // Total scrollable content height
+        const visibleHeight =
+          StoryTellingEditor.querySelector(".CodeMirror-scroll").clientHeight; // Visible portion of the textarea
         if (
-          (StoryTellingEditor.scrollTop === 0 && deltaY < 0) ||
-          (StoryTellingEditor.scrollTop + visibleHeight >= contentHeight &&
+          (StoryTellingEditor.querySelector(".CodeMirror-scroll").scrollTop <=
+            0 &&
+            deltaY < 0) ||
+          (StoryTellingEditor.querySelector(".CodeMirror-scroll").scrollTop +
+            visibleHeight >=
+            contentHeight &&
             deltaY > 0)
         )
           event.preventDefault(); // Prevent scrolling

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -8,6 +8,9 @@ ${button}
 ${checkbox}
 ${radio}
 ${slider}
+  :host {
+    overflow: unset !important;
+  }
 
   iframe,
   img,


### PR DESCRIPTION
## Implemented changes

This PR fixes the broken overflow introduced to scrollytelling element and the editor by the recent jsonform updates.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
