### PR TITLE
feat: allow setting feature name for rendered list

### DIFF
--- a/elements/drawtools/src/components/list.js
+++ b/elements/drawtools/src/components/list.js
@@ -174,7 +174,9 @@ export class EOxDrawToolsList extends LitElement {
                   @click="${() =>
                     this._handleFeatureSelectAndDeselect(feature)}"
                 >
-                  <span class="title">${this.featureName} ${featureNumber}</span>
+                  <span class="title"
+                    >${this.featureName} ${featureNumber}</span
+                  >
                   <button
                     index=${i}
                     class="icon smallest discard"

--- a/elements/drawtools/src/components/list.js
+++ b/elements/drawtools/src/components/list.js
@@ -20,6 +20,7 @@ export class EOxDrawToolsList extends LitElement {
     draw: { attribute: false, state: true },
     drawLayer: { attribute: false, state: true },
     drawnFeatures: { attribute: false, state: true, type: Array },
+    featureName: { attribute: false, state: true, type: String },
     modify: { attribute: false, state: true },
     unstyled: { type: Boolean },
   };
@@ -78,6 +79,11 @@ export class EOxDrawToolsList extends LitElement {
      * @type Array<import("ol").Feature>
      */
     this.drawnFeatures = [];
+
+    /**
+     * Default display name for features
+     */
+    this.featureName = "Feature";
 
     /**
      * The current native OpenLayers `modify` interaction
@@ -168,7 +174,7 @@ export class EOxDrawToolsList extends LitElement {
                   @click="${() =>
                     this._handleFeatureSelectAndDeselect(feature)}"
                 >
-                  <span class="title">Feature #${featureNumber}</span>
+                  <span class="title">${this.featureName} ${featureNumber}</span>
                   <button
                     index=${i}
                     class="icon smallest discard"

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -33,6 +33,7 @@ export class EOxDrawTools extends LitElement {
       draw: { attribute: false, state: true },
       drawLayer: { attribute: false, state: true },
       drawnFeatures: { attribute: false, state: true, type: Array },
+      featureName: { attribute: "feature-name", type: String },
       layerId: { attribute: "layer-id", type: String },
       featureStyles: { attribute: false },
       modify: { attribute: false, state: true },
@@ -116,6 +117,11 @@ export class EOxDrawTools extends LitElement {
      * @type Array<import("ol").Feature>
      */
     this.drawnFeatures = [];
+
+    /**
+     * The display name of drawn features, shown e.g. in the feature list.
+     */
+    this.featureName = "Feature";
 
     /**
      * Flat styles for the drawn/selected features
@@ -369,6 +375,7 @@ export class EOxDrawTools extends LitElement {
             .draw=${this.draw}
             .drawLayer=${this.drawLayer}
             .drawnFeatures=${this.drawnFeatures}
+            .featureName=${this.featureName}
             .modify=${this.modify}
             .unstyled=${this.unstyled}
             @changed=${() => {

--- a/elements/drawtools/stories/multi-feature-select.js
+++ b/elements/drawtools/stories/multi-feature-select.js
@@ -11,6 +11,7 @@ export const MuliFeatureSelect = {
     type: "Box",
     layerId: "regions",
     showList: true,
+    featureName: "Selection",
     featureStyles: {
       layer: {
         "fill-color": "#16A105A0",
@@ -49,6 +50,7 @@ export const MuliFeatureSelect = {
       layer-id=${args.layerId}
       ?show-list=${args.showList}
       .featureStyles=${args.featureStyles}
+      .featureName=${args.featureName}
       @drawupdate=${args.drawUpdate}
     />
   `,

--- a/elements/drawtools/stories/multi-polygon-list.js
+++ b/elements/drawtools/stories/multi-polygon-list.js
@@ -20,6 +20,7 @@ export const MultiPolygonWithList = {
       for="eox-map#list"
       multiple-features
       show-list
+      feature-name="Polygon"
     ></eox-drawtools>
   `,
 };


### PR DESCRIPTION
## Implemented changes

This PR introduces a `featureName` property that can be used to set the name of features in the rendered list (before it was hardcoded to "Feature").

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/26b982d2-152a-478e-985c-4d48b2aefd5f)
![image](https://github.com/user-attachments/assets/94ceb277-c2f5-4bbf-809e-771805a56493)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
