### PR TITLE
feat: forward editor ready event

### DIFF
--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -130,6 +130,13 @@ export class EOxJSONForm extends LitElement {
   }
 
   /**
+   * Editor has loaded schema and API is ready to be used
+   */
+  #emitReady() {
+    this.dispatchEvent(new Event("ready"));
+  }
+
+  /**
    * Value object has been changed
    */
   #emitValue() {
@@ -150,6 +157,9 @@ export class EOxJSONForm extends LitElement {
 
     events.map((evt) => {
       this.#editor.on(evt, () => {
+        if (evt === "ready") {
+          this.#emitReady();
+        }
         this._value = this.#editor.getValue();
         this.#emitValue();
       });

--- a/elements/jsonform/stories/external.js
+++ b/elements/jsonform/stories/external.js
@@ -13,6 +13,7 @@ const External = {
   args: {
     schema: externalSchema,
     value: externalValue,
+    onReady: () => console.log("Schema loading finished, editor ready!"),
   },
 };
 export default External;

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -33,6 +33,7 @@ export default {
       .noShadow=${args.noShadow}
       .unstyled=${args.unstyled}
       @change=${args.onChange}
+      @ready=${args.onReady}
       @submit=${args.onSubmit}
     ></eox-jsonform>
   `,


### PR DESCRIPTION
## Implemented changes

This PR forwards the editor "ready" event. This event fires once the editor has finished loading the (remote) schema and has built the form, and thus the internal editor API is ready to be used.
In the past, we emitted the "ready" and "change" event all as "change", which made it hard to distinguish between a real "change" event and the "ready" event.

This now allows such things as
```js
const jsonForm = document.querySelector("eox-jsonform");
jsonForm.addEventListener("ready", () => {
  // Now the api methods will be available
  jsonForm.editor.validate();
});
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
