### PR TITLE
fix: discard features cleanly on continuous drawing

### DIFF
--- a/elements/drawtools/src/methods/draw/on-draw-end.js
+++ b/elements/drawtools/src/methods/draw/on-draw-end.js
@@ -16,12 +16,12 @@ const onDrawEndMethod = (EoxDrawTool) => {
       if (EoxDrawTool.continuous) {
         // the selection event selects the feature after draw ends
         if (!EoxDrawTool.layerId) {
-          EoxDrawTool.drawLayer.getSource().clear(true);
+          EoxDrawTool.drawLayer.getSource().clear();
           EoxDrawTool.drawnFeatures = [];
         } else {
           const features = EoxDrawTool.drawLayer.getSource().getFeatures();
           const latest = features.at(-1);
-          EoxDrawTool.drawLayer.getSource().clear(true);
+          EoxDrawTool.drawLayer.getSource().clear();
           EoxDrawTool.drawLayer.getSource().addFeature(latest);
           EoxDrawTool.drawnFeatures = [latest];
         }


### PR DESCRIPTION
## Implemented changes
This stops holding on to discarded features internally when drawing continuously. Close #1572;

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
