### PR TITLE
chore: remove barrel files

### DIFF
--- a/elements/drawtools/test/_mockMap.js
+++ b/elements/drawtools/test/_mockMap.js
@@ -1,4 +1,4 @@
-import { Polygon } from "ol/geom";
+import Polygon from "ol/geom/Polygon.js";
 import Feature from "ol/Feature";
 
 // Defining a MockMap class extending HTMLElement

--- a/elements/map/src/controls/controls.js
+++ b/elements/map/src/controls/controls.js
@@ -1,4 +1,12 @@
-import * as olControls from "ol/control";
+import Zoom from "ol/control/Zoom";
+import Rotate from "ol/control/Rotate";
+import ScaleLine from "ol/control/ScaleLine";
+import FullScreen from "ol/control/FullScreen";
+import ZoomSlider from "ol/control/ZoomSlider";
+import Attribution from "ol/control/Attribution";
+import OverviewMap from "ol/control/OverviewMap";
+import ZoomToExtent from "ol/control/ZoomToExtent";
+import MousePosition from "ol/control/MousePosition";
 import { generateLayers } from "../helpers/generate";
 import Geolocation from "./geo-location";
 import LoadingIndicator from "./loading-indicator";
@@ -9,7 +17,17 @@ import LoadingIndicator from "./loading-indicator";
  */
 
 const availableControls = {
-  ...olControls,
+  ...{
+    Zoom,
+    Rotate,
+    ScaleLine,
+    FullScreen,
+    ZoomSlider,
+    Attribution,
+    OverviewMap,
+    ZoomToExtent,
+    MousePosition,
+  },
   Geolocation,
   LoadingIndicator,
 };

--- a/elements/map/src/controls/geo-location.js
+++ b/elements/map/src/controls/geo-location.js
@@ -1,10 +1,12 @@
-import { Control } from "ol/control";
+import Control from "ol/control/Control.js";
 import Feature from "ol/Feature";
 import Geolocation from "ol/Geolocation";
 import Point from "ol/geom/Point";
-import { Vector as VectorSource } from "ol/source";
-import { Vector as VectorLayer } from "ol/layer";
-import { Fill, Stroke, Style } from "ol/style";
+import VectorSource from "ol/source/Vector.js";
+import VectorLayer from "ol/layer/Vector.js";
+import Fill from "ol/style/Fill.js";
+import Stroke from "ol/style/Stroke.js";
+import Style from "ol/style/Style.js";
 
 /**
  * @typedef {import("../types").GeolocationOptions} GeolocationOptions

--- a/elements/map/src/controls/loading-indicator.js
+++ b/elements/map/src/controls/loading-indicator.js
@@ -1,4 +1,4 @@
-import { Control } from "ol/control.js";
+import Control from "ol/control/Control.js";
 
 /**
  * @typedef {import("../types").LoadingIndicatorOptions} LoadingIndicatorOptions

--- a/elements/map/src/custom/sources/FlatGeoBuf.js
+++ b/elements/map/src/custom/sources/FlatGeoBuf.js
@@ -1,6 +1,6 @@
 import { transformExtent } from "ol/proj";
 import { deserialize } from "flatgeobuf/lib/mjs/geojson";
-import { Vector } from "ol/source";
+import Vector from "ol/source/Vector.js";
 import GeoJSON from "ol/format/GeoJSON";
 import { bbox } from "ol/loadingstrategy";
 

--- a/elements/map/src/custom/sources/WMTSCapabilities.js
+++ b/elements/map/src/custom/sources/WMTSCapabilities.js
@@ -1,4 +1,4 @@
-import { TileImage } from "ol/source";
+import TileImage from "ol/source/TileImage.js";
 import { optionsFromCapabilities } from "ol/source/WMTS";
 import WMTSCapabilitiesFormat from "ol/format/WMTSCapabilities";
 import { createFromTileUrlFunctions } from "ol/tileurlfunction";

--- a/elements/map/src/helpers/add-new-feature.js
+++ b/elements/map/src/helpers/add-new-feature.js
@@ -1,8 +1,9 @@
 // Import necessary OpenLayers formats
 import GeoJSON from "ol/format/GeoJSON";
-import { LineString, Polygon } from "ol/geom";
+import LineString from "ol/geom/LineString.js";
+import Polygon from "ol/geom/Polygon.js";
 import { getArea, getLength } from "ol/sphere";
-import { getUid } from "ol";
+import { getUid } from "ol/util.js";
 import { READ_FEATURES_OPTIONS } from "../enums";
 
 /**

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -1,22 +1,19 @@
-import { GeoJSON, MVT } from "ol/format";
-import {
-  Group,
-  Image,
-  Tile as TileLayer,
-  Vector as VectorLayer,
-  VectorTile as VectorTileLayer,
-} from "ol/layer";
-import {
-  ImageWMS,
-  OSM,
-  Tile as TileSource,
-  TileWMS,
-  Vector as VectorSource,
-  VectorTile as VectorTileSource,
-  WMTS,
-  XYZ,
-} from "ol/source";
-import { Collection } from "ol";
+import GeoJSON from "ol/format/GeoJSON.js";
+import MVT from "ol/format/MVT.js";
+import Group from "ol/layer/Group.js";
+import Image from "ol/layer/Image.js";
+import TileLayer from "ol/layer/Tile.js";
+import VectorLayer from "ol/layer/Vector.js";
+import VectorTileLayer from "ol/layer/VectorTile.js";
+import ImageWMS from "ol/source/ImageWMS.js";
+import OSM from "ol/source/OSM.js";
+import TileSource from "ol/source/Tile.js";
+import TileWMS from "ol/source/TileWMS.js";
+import VectorSource from "ol/source/Vector.js";
+import VectorTileSource from "ol/source/VectorTile.js";
+import WMTS from "ol/source/WMTS.js";
+import XYZ from "ol/source/XYZ.js";
+import Collection from "ol/Collection.js";
 import { addDraw, addSelect, generateTileGrid } from "./";
 import { get as getProjection } from "ol/proj";
 

--- a/elements/map/src/helpers/interactions.js
+++ b/elements/map/src/helpers/interactions.js
@@ -1,4 +1,5 @@
-import { DragPan, MouseWheelZoom } from "ol/interaction";
+import DragPan from "ol/interaction/DragPan.js";
+import MouseWheelZoom from "ol/interaction/MouseWheelZoom.js";
 import { platformModifierKeyOnly } from "ol/events/condition";
 
 /**

--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -1,4 +1,4 @@
-import { Overlay } from "ol";
+import Overlay from "ol/Overlay.js";
 import "../components/tooltip";
 import { createLayer } from "./generate";
 import Feature from "ol/Feature";

--- a/elements/map/src/methods/map/setters.js
+++ b/elements/map/src/methods/map/setters.js
@@ -349,7 +349,7 @@ export function setSyncMethod(sync, EOxMap) {
     // Use a timeout to ensure the target map is ready before syncing views
     setTimeout(() => {
       const originMap = /** @type {import("../../main").EOxMap} **/ (
-        /** @type {any} **/ getElement(sync)
+        /** @type {any} **/ (getElement(sync))
       );
 
       // Set the view of the current map to match the view of the origin map

--- a/elements/map/src/plugins/advancedLayersAndSources/formats.js
+++ b/elements/map/src/plugins/advancedLayersAndSources/formats.js
@@ -1,5 +1,41 @@
-import * as olFormats from "ol/format";
+import EsriJSON from "ol/format/EsriJSON";
+import GeoJSON from "ol/format/GeoJSON";
+import GML from "ol/format/GML";
+import GPX from "ol/format/GPX";
+import IGC from "ol/format/IGC";
+import IIIFInfo from "ol/format/IIIFInfo";
+import KML from "ol/format/KML";
+import MVT from "ol/format/MVT";
+import OWS from "ol/format/OWS";
+import Polyline from "ol/format/Polyline";
+import TopoJSON from "ol/format/TopoJSON";
+import WFS from "ol/format/WFS";
+import WKB from "ol/format/WKB";
+import WKT from "ol/format/WKT";
+import WMSCapabilities from "ol/format/WMSCapabilities";
+import WMSGetFeatureInfo from "ol/format/WMSGetFeatureInfo";
+import WMTSCapabilities from "ol/format/WMTSCapabilities";
 
 // Attach all OpenLayers formats to the global `window` object under `eoxMapAdvancedOlFormats`.
 // This makes the formats accessible throughout the application and allows dynamic use of different OpenLayers formats.
-window.eoxMapAdvancedOlFormats = olFormats;
+window.eoxMapAdvancedOlFormats = {
+  ...{
+    EsriJSON,
+    GeoJSON,
+    GML,
+    GPX,
+    IGC,
+    IIIFInfo,
+    KML,
+    MVT,
+    OWS,
+    Polyline,
+    TopoJSON,
+    WFS,
+    WKB,
+    WKT,
+    WMSCapabilities,
+    WMSGetFeatureInfo,
+    WMTSCapabilities,
+  },
+};

--- a/elements/map/src/plugins/advancedLayersAndSources/formats.js
+++ b/elements/map/src/plugins/advancedLayersAndSources/formats.js
@@ -1,11 +1,9 @@
 import EsriJSON from "ol/format/EsriJSON";
-import GeoJSON from "ol/format/GeoJSON";
 import GML from "ol/format/GML";
 import GPX from "ol/format/GPX";
 import IGC from "ol/format/IGC";
 import IIIFInfo from "ol/format/IIIFInfo";
 import KML from "ol/format/KML";
-import MVT from "ol/format/MVT";
 import OWS from "ol/format/OWS";
 import Polyline from "ol/format/Polyline";
 import TopoJSON from "ol/format/TopoJSON";
@@ -21,13 +19,11 @@ import WMTSCapabilities from "ol/format/WMTSCapabilities";
 window.eoxMapAdvancedOlFormats = {
   ...{
     EsriJSON,
-    GeoJSON,
     GML,
     GPX,
     IGC,
     IIIFInfo,
     KML,
-    MVT,
     OWS,
     Polyline,
     TopoJSON,

--- a/elements/map/src/plugins/advancedLayersAndSources/layers.js
+++ b/elements/map/src/plugins/advancedLayersAndSources/layers.js
@@ -1,4 +1,15 @@
-import * as olLayers from "ol/layer";
+import Graticule from "ol/layer/Graticule";
+import Group from "ol/layer/Group";
+import Heatmap from "ol/layer/Heatmap";
+import Image from "ol/layer/Image";
+import Layer from "ol/layer/Layer";
+import Tile from "ol/layer/Tile";
+import Vector from "ol/layer/Vector";
+import VectorImage from "ol/layer/VectorImage";
+import VectorTile from "ol/layer/VectorTile";
+import WebGLPoints from "ol/layer/WebGLPoints";
+import WebGLTile from "ol/layer/WebGLTile";
+import WebGLVector from "ol/layer/WebGLVector";
 import STAC from "ol-stac";
 import { register } from "ol/proj/proj4";
 import proj4 from "proj4";
@@ -11,6 +22,19 @@ register(proj4);
 // This includes all standard OpenLayers layers (imported as `olLayers`) and the custom `STAC` layer.
 // This setup allows for dynamic use of these layers across the application.
 window.eoxMapAdvancedOlLayers = {
-  ...olLayers,
+  ...{
+    Graticule,
+    Group,
+    Heatmap,
+    Image,
+    Layer,
+    Tile,
+    Vector,
+    VectorImage,
+    WebGLPoints,
+    VectorTile,
+    WebGLTile,
+    WebGLVector,
+  },
   STAC,
 };

--- a/elements/map/src/plugins/advancedLayersAndSources/layers.js
+++ b/elements/map/src/plugins/advancedLayersAndSources/layers.js
@@ -1,12 +1,7 @@
 import Graticule from "ol/layer/Graticule";
-import Group from "ol/layer/Group";
 import Heatmap from "ol/layer/Heatmap";
-import Image from "ol/layer/Image";
 import Layer from "ol/layer/Layer";
-import Tile from "ol/layer/Tile";
-import Vector from "ol/layer/Vector";
 import VectorImage from "ol/layer/VectorImage";
-import VectorTile from "ol/layer/VectorTile";
 import WebGLPoints from "ol/layer/WebGLPoints";
 import WebGLTile from "ol/layer/WebGLTile";
 import WebGLVector from "ol/layer/WebGLVector";
@@ -24,15 +19,11 @@ register(proj4);
 window.eoxMapAdvancedOlLayers = {
   ...{
     Graticule,
-    Group,
     Heatmap,
     Image,
     Layer,
-    Tile,
-    Vector,
     VectorImage,
     WebGLPoints,
-    VectorTile,
     WebGLTile,
     WebGLVector,
   },

--- a/elements/map/src/plugins/advancedLayersAndSources/sources.js
+++ b/elements/map/src/plugins/advancedLayersAndSources/sources.js
@@ -11,25 +11,17 @@ import ImageCanvas from "ol/source/ImageCanvas";
 import ImageMapGuide from "ol/source/ImageMapGuide";
 import ImageStatic from "ol/source/ImageStatic";
 import ImageTile from "ol/source/ImageTile";
-import ImageWMS from "ol/source/ImageWMS";
 import OGCMapTile from "ol/source/OGCMapTile";
 import OGCVectorTile from "ol/source/OGCVectorTile";
-import OSM from "ol/source/OSM";
 import Raster from "ol/source/Raster";
 import Source from "ol/source/Source";
 import StadiaMaps from "ol/source/StadiaMaps";
-import Tile from "ol/source/Tile";
 import TileArcGISRest from "ol/source/TileArcGISRest";
 import TileDebug from "ol/source/TileDebug";
 import TileImage from "ol/source/TileImage";
 import TileJSON from "ol/source/TileJSON";
-import TileWMS from "ol/source/TileWMS";
 import UrlTile from "ol/source/UrlTile";
 import UTFGrid from "ol/source/UTFGrid";
-import Vector from "ol/source/Vector";
-import VectorTile from "ol/source/VectorTile";
-import WMTS from "ol/source/WMTS";
-import XYZ from "ol/source/XYZ";
 import Zoomify from "ol/source/Zoomify";
 
 import WMTSCapabilities from "../../custom/sources/WMTSCapabilities";
@@ -53,25 +45,17 @@ window.eoxMapAdvancedOlSources = {
     ImageMapGuide,
     ImageStatic,
     ImageTile,
-    ImageWMS,
     OGCMapTile,
     OGCVectorTile,
-    OSM,
     Raster,
     Source,
     StadiaMaps,
-    Tile,
     TileArcGISRest,
     TileDebug,
     TileImage,
     TileJSON,
-    TileWMS,
     UrlTile,
     UTFGrid,
-    Vector,
-    VectorTile,
-    WMTS,
-    XYZ,
     Zoomify,
   },
   WMTSCapabilities,

--- a/elements/map/src/plugins/advancedLayersAndSources/sources.js
+++ b/elements/map/src/plugins/advancedLayersAndSources/sources.js
@@ -1,4 +1,37 @@
-import * as olSources from "ol/source";
+import BingMaps from "ol/source/BingMaps";
+import CartoDB from "ol/source/CartoDB";
+import Cluster from "ol/source/Cluster";
+import DataTile from "ol/source/DataTile";
+import GeoTIFF from "ol/source/GeoTIFF";
+import Google from "ol/source/Google";
+import IIIF from "ol/source/IIIF";
+import Image from "ol/source/Image";
+import ImageArcGISRest from "ol/source/ImageArcGISRest";
+import ImageCanvas from "ol/source/ImageCanvas";
+import ImageMapGuide from "ol/source/ImageMapGuide";
+import ImageStatic from "ol/source/ImageStatic";
+import ImageTile from "ol/source/ImageTile";
+import ImageWMS from "ol/source/ImageWMS";
+import OGCMapTile from "ol/source/OGCMapTile";
+import OGCVectorTile from "ol/source/OGCVectorTile";
+import OSM from "ol/source/OSM";
+import Raster from "ol/source/Raster";
+import Source from "ol/source/Source";
+import StadiaMaps from "ol/source/StadiaMaps";
+import Tile from "ol/source/Tile";
+import TileArcGISRest from "ol/source/TileArcGISRest";
+import TileDebug from "ol/source/TileDebug";
+import TileImage from "ol/source/TileImage";
+import TileJSON from "ol/source/TileJSON";
+import TileWMS from "ol/source/TileWMS";
+import UrlTile from "ol/source/UrlTile";
+import UTFGrid from "ol/source/UTFGrid";
+import Vector from "ol/source/Vector";
+import VectorTile from "ol/source/VectorTile";
+import WMTS from "ol/source/WMTS";
+import XYZ from "ol/source/XYZ";
+import Zoomify from "ol/source/Zoomify";
+
 import WMTSCapabilities from "../../custom/sources/WMTSCapabilities";
 import FlatGeoBuf from "../../custom/sources/FlatGeoBuf";
 
@@ -6,7 +39,41 @@ import FlatGeoBuf from "../../custom/sources/FlatGeoBuf";
 // This includes all standard OpenLayers sources (imported as `olSources`) and a custom `WMTSCapabilities` source.
 // This setup allows for dynamic use of these sources across the application.
 window.eoxMapAdvancedOlSources = {
-  ...olSources,
+  ...{
+    BingMaps,
+    CartoDB,
+    Cluster,
+    DataTile,
+    GeoTIFF,
+    Google,
+    IIIF,
+    Image,
+    ImageArcGISRest,
+    ImageCanvas,
+    ImageMapGuide,
+    ImageStatic,
+    ImageTile,
+    ImageWMS,
+    OGCMapTile,
+    OGCVectorTile,
+    OSM,
+    Raster,
+    Source,
+    StadiaMaps,
+    Tile,
+    TileArcGISRest,
+    TileDebug,
+    TileImage,
+    TileJSON,
+    TileWMS,
+    UrlTile,
+    UTFGrid,
+    Vector,
+    VectorTile,
+    WMTS,
+    XYZ,
+    Zoomify,
+  },
   WMTSCapabilities,
   FlatGeoBuf,
 };

--- a/elements/map/test/utils/events.js
+++ b/elements/map/test/utils/events.js
@@ -1,4 +1,4 @@
-import { MapBrowserEvent } from "ol";
+import MapBrowserEvent from "ol/MapBrowserEvent.js";
 
 const width = 400;
 const height = 400;


### PR DESCRIPTION
## Implemented changes

This PR removes the usage of "barrel files" (#1527), as they can be negative towards bundle size and will be removed in `ol` at some point in the future. The removal has been done using https://www.npmjs.com/package/@openlayers/codemod and manually fixing passages where the codemod failed, like when we access classes from a barrel file using the bracket notation (e.g. `sources[sourceType]`).

