### PR TITLE
fix: use dynamic imports to reduce bundle

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -121,25 +121,7 @@ export const createEditor = (element) => {
 
     // Check if any editor requires AceEditor
     const aceUsed = Object.values(editor.editors).find((e) => e?.ace_container);
-    // // console.log(editor.editors["root.code"].schema)
-    // // console.log(Object.values(editor.editors).forEach(e => console.log(e.constructor.name)))
-    // let classname
-    // JSONEditor.defaults.resolvers.find(r => {
-    //   classname = r(editor.editors["root.code"].schema) && r(editor.editors["root.code"].schema)
-    //   return classname && JSONEditor.defaults.editors[classname]
-    // })
-    // // console.log(classname)
-    // const aceUsed = classname === "ace" && JSONEditor.defaults.editors[classname]
-    // const script = document.createElement("script")
-    // script.setAttribute("src", "https://cdn.jsdelivr.net/npm/ace@1.3.0/+esm")
-    // script.setAttribute("type", "module")
-    // script.addEventListener("load", () => [
-    //   console.log("loaded!")
-    // ])
-    // document.head.appendChild(script)
     if (aceUsed && !element.noShadow) {
-      // window.ace.config.setModuleLoader('ace/mode/javascript', () => import('https://cdn.jsdelivr.net/npm/ace-builds/src-min-noconflict/mode-javascript.js'));
-
       // https://github.com/ajaxorg/ace/wiki/Configuring-Ace
       aceUsed.ace_editor_instance.setOptions({
         showPrintMargin: false,

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -2,7 +2,6 @@ import { JSONEditor } from "@json-editor/json-editor/src/core.js";
 import { SimplemdeEditor } from "@json-editor/json-editor/src/editors/simplemde.js";
 import EasyMDE from "easymde/dist/easymde.min.js";
 import AceEditor from "ace-builds";
-import "ace-builds/esm-resolver.js";
 import addCustomInputs from "../custom-inputs";
 
 // using a drop-in replacement for EasyMDE,
@@ -14,6 +13,10 @@ window.SimpleMDE = EasyMDE;
 window.ace = AceEditor;
 //@ts-expect-error - useWorker is not defined in the ace-builds config keys
 window.ace.config.set("useWorker", false);
+window.ace.config.set(
+  "basePath",
+  "https://cdn.jsdelivr.net/npm/ace-builds/src-min-noconflict/",
+);
 
 /**
  * Create the editor instance
@@ -118,7 +121,25 @@ export const createEditor = (element) => {
 
     // Check if any editor requires AceEditor
     const aceUsed = Object.values(editor.editors).find((e) => e?.ace_container);
+    // // console.log(editor.editors["root.code"].schema)
+    // // console.log(Object.values(editor.editors).forEach(e => console.log(e.constructor.name)))
+    // let classname
+    // JSONEditor.defaults.resolvers.find(r => {
+    //   classname = r(editor.editors["root.code"].schema) && r(editor.editors["root.code"].schema)
+    //   return classname && JSONEditor.defaults.editors[classname]
+    // })
+    // // console.log(classname)
+    // const aceUsed = classname === "ace" && JSONEditor.defaults.editors[classname]
+    // const script = document.createElement("script")
+    // script.setAttribute("src", "https://cdn.jsdelivr.net/npm/ace@1.3.0/+esm")
+    // script.setAttribute("type", "module")
+    // script.addEventListener("load", () => [
+    //   console.log("loaded!")
+    // ])
+    // document.head.appendChild(script)
     if (aceUsed && !element.noShadow) {
+      // window.ace.config.setModuleLoader('ace/mode/javascript', () => import('https://cdn.jsdelivr.net/npm/ace-builds/src-min-noconflict/mode-javascript.js'));
+
       // https://github.com/ajaxorg/ace/wiki/Configuring-Ace
       aceUsed.ace_editor_instance.setOptions({
         showPrintMargin: false,


### PR DESCRIPTION
## Implemented changes

This PR makes use of the dynamic import functionality in ace editor (for modes, themes etc.) in order to reduce the amount of output bundle files. This brings the number of files in the dist folder from 478 back down to 2.

Fixes #1588.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
