### PR TITLE
fix: provide fallback schema if no schema provided

### DIFF
--- a/elements/jsonform/src/enums/editor.js
+++ b/elements/jsonform/src/enums/editor.js
@@ -1,0 +1,11 @@
+export const FALLBACK_SCHEMA = {
+  type: "object",
+  properties: {
+    fallback: {
+      format: "info",
+      title: "No schema provided",
+      description:
+        "Pass a schema to <code>eox-jsonform</code> via the <code>schema</code> property",
+    },
+  },
+};

--- a/elements/jsonform/src/enums/index.js
+++ b/elements/jsonform/src/enums/index.js
@@ -4,3 +4,4 @@ export {
   STORIES_GREY_VECTOR_LAYERS,
   STORIES_MAP_STYLE,
 } from "./stories";
+export { FALLBACK_SCHEMA } from "./editor";

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -3,6 +3,7 @@ import { SimplemdeEditor } from "@json-editor/json-editor/src/editors/simplemde.
 import EasyMDE from "easymde/dist/easymde.min.js";
 import AceEditor from "ace-builds";
 import addCustomInputs from "../custom-inputs";
+import { FALLBACK_SCHEMA } from "../enums";
 
 // using a drop-in replacement for EasyMDE,
 // see https://github.com/json-editor/json-editor/issues/1093
@@ -57,7 +58,7 @@ export const createEditor = (element) => {
   // Initialize the JSONEditor with the given schema, value, and options
   const initEditor = () =>
     new JSONEditor(formEle, {
-      schema: element.schema,
+      schema: element.schema || FALLBACK_SCHEMA,
       ...(element.value ? { startval: element.value } : {}),
       theme: "html",
       iconlib: "fontawesome5", // necessary to get information about expand/collapse state


### PR DESCRIPTION
## Implemented changes

This PR provides a default fallback schema if no `schema` property has been passed. This was causing an error since the `schema.properties` were not found by the json-editor schema resolver.

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/20646d68-dfe5-4b36-87d6-a1236dfc464d)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
