### PR TITLE
fix: recursively hide hidden property tabs

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -81,17 +81,29 @@ export const createEditor = (element) => {
         ".tabs.je-tabholder--top > .je-tab--top > span",
       ),
     );
-    Object.entries(editor.expandSchema(editor.schema).properties)
-      .filter(([_, property]) => property.options?.hidden)
-      .map(([key, property]) => property.title || key)
-      .forEach((title) => {
-        const tabTitle = tabsTitles.find(
-          (tabTitle) => tabTitle.textContent === title,
-        );
-        if (tabTitle) {
-          tabTitle.parentElement.dataset.hidden = "";
+    const hideTabsIfPropertiesHidden = (properties) => {
+      // Find tabs for hidden properties and set data-hidden
+      // in order to hide them with CSS
+      Object.entries(properties)
+        .filter(([_, property]) => property.options?.hidden)
+        .map(([key, property]) => property.title || key)
+        .forEach((title) => {
+          const tabTitle = tabsTitles.find(
+            (tabTitle) => tabTitle.textContent === title,
+          );
+          if (tabTitle) {
+            tabTitle.parentElement.dataset.hidden = "";
+          }
+        });
+
+      // Recursively go through nested child objects with properties
+      Object.values(properties).forEach((property) => {
+        if (property.properties) {
+          hideTabsIfPropertiesHidden(property.properties);
         }
       });
+    };
+    hideTabsIfPropertiesHidden(editor.expandSchema(editor.schema).properties);
 
     // Workaround to emit "change" event also from text inputs
     // TEMP - see https://github.com/json-editor/json-editor/issues/1445


### PR DESCRIPTION
## Implemented changes

This PR adds support for recursive "hidden" properties. When providing the `"format": "categories"` functionality in https://github.com/EOX-A/EOxElements/pull/1532, this was only implemented for the root level, whereas now it works also for nested properties.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
