### PR TITLE
chore: downgrade stac-fields

### DIFF
--- a/elements/stacinfo/package.json
+++ b/elements/stacinfo/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@eox/elements-utils": "^0.1.5",
-    "@radiantearth/stac-fields": "^1.3.2",
+    "@radiantearth/stac-fields": "1.5.2",
     "lit": "^3.2.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
     },
     "elements/jsonform": {
       "name": "@eox/jsonform",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
         "@json-editor/json-editor": "^2.11.0",
@@ -277,7 +277,7 @@
       "version": "0.6.2",
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
-        "@radiantearth/stac-fields": "^1.3.2",
+        "@radiantearth/stac-fields": "1.5.2",
         "lit": "^3.2.0"
       },
       "devDependencies": {
@@ -286,6 +286,22 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=8.0.0"
+      }
+    },
+    "elements/stacinfo/node_modules/@radiantearth/stac-fields": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.5.2.tgz",
+      "integrity": "sha512-lGGgMNApg0vjvc/WOSIqBW1RTewVpXLTdrNZueOZFS+jvlTbTAaMr4ET2hFLNIQm+7QGBYfYqp1bspbCxDL9dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@musement/iso-duration": "^1.0.0",
+        "commonmark": "^0.29.3",
+        "content-type": "^1.0.4",
+        "multihashes": "^3.1.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/m-mohr"
       }
     },
     "elements/storytelling": {
@@ -3527,22 +3543,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@radiantearth/stac-fields": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.5.3.tgz",
-      "integrity": "sha512-fXeAIZlSYv+zU0vN+yuCK9X0ROtiiS2fDkdhf7yZQEPsr85KnYk8pxs1S26oGCT/xkUcztn4+Oii80v2K/PbjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@musement/iso-duration": "^1.0.0",
-        "commonmark": "^0.29.3",
-        "content-type": "^1.0.4",
-        "multihashes": "^3.1.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/m-mohr"
       }
     },
     "node_modules/@radiantearth/stac-migrate": {


### PR DESCRIPTION
## Implemented changes

Downgrades and fixes stac-fields to `v1.5.2` in order to fix Storybook rendering (see https://github.com/stac-utils/stac-fields/issues/32)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
