### PR TITLE
chore(deps): update stac-fields version

### DIFF
--- a/elements/stacinfo/package.json
+++ b/elements/stacinfo/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@eox/elements-utils": "^0.1.5",
-    "@radiantearth/stac-fields": "1.5.2",
+    "@radiantearth/stac-fields": "^1.5.4",
     "lit": "^3.2.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -278,7 +278,7 @@
       "version": "0.6.2",
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
-        "@radiantearth/stac-fields": "1.5.2",
+        "@radiantearth/stac-fields": "^1.5.4",
         "lit": "^3.2.0"
       },
       "devDependencies": {
@@ -287,22 +287,6 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=8.0.0"
-      }
-    },
-    "elements/stacinfo/node_modules/@radiantearth/stac-fields": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.5.2.tgz",
-      "integrity": "sha512-lGGgMNApg0vjvc/WOSIqBW1RTewVpXLTdrNZueOZFS+jvlTbTAaMr4ET2hFLNIQm+7QGBYfYqp1bspbCxDL9dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@musement/iso-duration": "^1.0.0",
-        "commonmark": "^0.29.3",
-        "content-type": "^1.0.4",
-        "multihashes": "^3.1.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/m-mohr"
       }
     },
     "elements/storytelling": {
@@ -3545,6 +3529,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@radiantearth/stac-fields": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.5.4.tgz",
+      "integrity": "sha512-rVPDLxBukc6nhg/5BZyzsVwuY9ujI6lN0nUjWvNrrYgg5CYprKTeE7G9tCxa15P1soc0oqhKkzFL6/skVwX3HA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@musement/iso-duration": "^1.0.0",
+        "commonmark": "^0.29.3",
+        "content-type": "^1.0.4",
+        "multihashes": "^3.1.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/m-mohr"
       }
     },
     "node_modules/@radiantearth/stac-migrate": {


### PR DESCRIPTION
## Implemented changes

This undos https://github.com/EOX-A/EOxElements/pull/1612 after a fix update by `stac-fields` (see https://github.com/stac-utils/stac-fields/pull/33).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
