### PR TITLE
fix: add top and bottom scroll margins

### DIFF
--- a/elements/storytelling/src/helpers/misc.js
+++ b/elements/storytelling/src/helpers/misc.js
@@ -26,8 +26,14 @@ export function scrollAnchorClickEvent(that, selector) {
  */
 export function scrollIntoView(that) {
   const hash = window.parent.location.hash;
-  const element = hash ? that.shadowRoot.querySelector(hash) : null;
-  if (element) element.scrollIntoView({ behavior: "smooth" });
+  const element = hash
+    ? /**@type{HTMLElement}*/ (that.shadowRoot.querySelector(hash))
+    : null;
+  if (element) {
+    element.style.scrollMarginTop = `calc(${that.shadowRoot.querySelector(".navigation")?.clientHeight || 0}px + 1rem)`;
+    element.style.scrollMarginBottom = "1rem";
+    element.scrollIntoView({ behavior: "smooth" });
+  }
 }
 
 /**


### PR DESCRIPTION
## Implemented changes

This PR adds top and bottom scroll margins when scrolling elements into view. It is `1rem` plus optionally the height of the nav (if shown).

## Screenshots/Videos

### Before (linked content hidden behind nav)
![image](https://github.com/user-attachments/assets/61f3e85c-0295-4469-ac5d-5092653a8588)

### After (linked content under nav + `1rem`)
![image](https://github.com/user-attachments/assets/a89f8a91-a8de-48ae-87fe-83d733fc3a63)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
