### PR TITLE
feat: support fixed row height/column widths

### DIFF
--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -5,7 +5,7 @@
  */
 export class EOxLayout extends HTMLElement {
   static get observedAttributes() {
-    return ["gap"];
+    return ["column-width", "gap", "row-height"];
   }
   constructor() {
     super();
@@ -16,13 +16,16 @@ export class EOxLayout extends HTMLElement {
     this.shadowRoot.innerHTML = `
     <style>
       :host {
+        --row-height: ${this.getAttribute("row-height")};
+        --column-width: ${this.getAttribute("column-width")};
         display: grid;
         padding: ${this.getAttribute("gap") || 0}px;
         height: 100%;
         box-sizing: border-box;
         gap: ${this.getAttribute("gap") || "0"}px;
-        grid-template-columns: repeat(12, 1fr);
-        grid-template-rows: repeat(12, 1fr);
+        grid-template-columns: repeat(12, var(--column-width, 1fr));
+        grid-template-rows: repeat(12, var(--row-height, 1fr));
+        overflow: auto;
       }
     </style>
     <slot></slot>

--- a/elements/layout/stories/index.js
+++ b/elements/layout/stories/index.js
@@ -4,3 +4,4 @@
 export { default as PrimaryStory } from "./primary";
 export { default as GridStory } from "./grid";
 export { default as GapStory } from "./gap";
+export { default as ScrollStory } from "./scroll";

--- a/elements/layout/stories/layout.stories.js
+++ b/elements/layout/stories/layout.stories.js
@@ -2,7 +2,7 @@
  * Stories for eox-layout component showcasing various configurations.
  * These stories provide visual representations and usage examples for different scenarios.
  */
-import { PrimaryStory, GridStory, GapStory } from "./index";
+import { PrimaryStory, GridStory, GapStory, ScrollStory } from "./index";
 
 export default {
   title: "Elements/eox-layout",
@@ -27,3 +27,9 @@ export const Grid = GridStory;
  * created between the individual items. A 1px border was added to demonstrate the padding.
  */
 export const Gap = GapStory;
+
+/**
+ * By using `row-height` or `column-width` attributes, the total width and/or height can be larger than the grid.
+ * In this case, the items will overflow the grid.
+ */
+export const Scroll = ScrollStory;

--- a/elements/layout/stories/scroll.js
+++ b/elements/layout/stories/scroll.js
@@ -1,0 +1,39 @@
+import { html } from "lit";
+import { STORIES_LAYOUT_STYLE, STORIES_LAYOUT_ITEM_STYLE } from "../src/enums";
+
+export const Scroll = {
+  args: {},
+  render: () => html`
+    <!-- Render eox-layout component -->
+    <eox-layout gap="8" row-height="3rem" style="${STORIES_LAYOUT_STYLE}">
+      <eox-layout-item x="0" y="0" w="4" h="4">
+        x="0" y="0" w="4" h="4"
+      </eox-layout-item>
+      <eox-layout-item x="4" y="0" w="4" h="4">
+        x="4" y="0" w="4" h="4"
+      </eox-layout-item>
+      <eox-layout-item x="8" y="0" w="4" h="4">
+        x="8" y="0" w="4" h="4"
+      </eox-layout-item>
+      <eox-layout-item x="0" y="4" w="4" h="4">
+        x="0" y="4" w="4" h="4"
+      </eox-layout-item>
+      <eox-layout-item x="4" y="4" w="4" h="4">
+        x="4" y="4" w="4" h="4"
+      </eox-layout-item>
+      <eox-layout-item x="8" y="4" w="4" h="4">
+        x="8" y="4" w="4" h="4"
+      </eox-layout-item>
+      <eox-layout-item x="0" y="8" w="4" h="4">
+        x="0" y="8" w="4" h="4"
+      </eox-layout-item>
+    </eox-layout>
+    <style>
+      eox-layout-item {
+        ${STORIES_LAYOUT_ITEM_STYLE}
+      }
+    </style>
+  `,
+};
+
+export default Scroll;


### PR DESCRIPTION
## Implemented changes

This PR adds the attributes `row-height` and `column-width` to the parent layout element. This allows setting a fixed dimension; note that if the total height/width is larger than the parents height/width, overflow scrolling is automatically enabled.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
