### PR TITLE
fix: prevent applying section styling to steps

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -316,9 +316,9 @@ ${slider}
   .story-telling .tour.center {
     justify-items: center;
   }
-  .story-telling .tour eox-map,
-  .story-telling .tour img,
-  .story-telling .tour video {
+  .story-telling .tour eox-map:not(section-step eox-map),
+  .story-telling .tour img:not(section-step img),
+  .story-telling .tour video:not(section-step video) {
     width: 100%;
     height: 100vh;
     position: sticky;

--- a/elements/storytelling/stories/markdown-editor.js
+++ b/elements/storytelling/stories/markdown-editor.js
@@ -114,6 +114,10 @@ It allows you to have different sources for each tour "step".
 #### Second tour step.
 Each tour step is described as an *h3* (*###*) heading.
 
+### <!--{ src="https://picsum.photos/900/800" }-->
+#### Third tour step.
+![](https://placehold.co/200x100)
+
 ## Final Words
 Hopefully, this was a good introduction to the story writing possibilities using EOxStorytelling - get started writing your own story!
 More features will be added soon, so feel free to follow progress at the [EOxElements GitHub repository](https://github.com/EOX-A/EOxElements).


### PR DESCRIPTION
## Implemented changes

This fixes an issue introduced by https://github.com/EOX-A/EOxElements/pull/1476, where the styling of the section (full scren image, etc.) was also wrongly applied to the content inside tour steps.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
