### PR TITLE
feat: fill-grid mode

### DIFF
--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -5,7 +5,7 @@
  */
 export class EOxLayout extends HTMLElement {
   static get observedAttributes() {
-    return ["column-width", "gap", "row-height"];
+    return ["column-width", "fill-grid", "gap", "row-height"];
   }
   constructor() {
     super();
@@ -23,8 +23,17 @@ export class EOxLayout extends HTMLElement {
         height: 100%;
         box-sizing: border-box;
         gap: ${this.getAttribute("gap") || "0"}px;
-        grid-template-columns: repeat(12, var(--column-width, 1fr));
-        grid-template-rows: repeat(12, var(--row-height, 1fr));
+        ${
+          this.getAttribute("fill-grid") !== null
+            ? `
+          grid-template-columns: repeat(auto-fill, minmax(var(--column-width, 300px), 1fr));
+          grid-template-rows: repeat(auto-fill, minmax(var(--row-height, 300px), 1fr));
+          `
+            : `
+          grid-template-columns: repeat(12, var(--column-width, 1fr));
+          grid-template-rows: repeat(12, var(--row-height, 1fr));
+          `
+        }
         overflow: auto;
       }
     </style>
@@ -54,12 +63,22 @@ export class EOxLayoutItem extends HTMLElement {
         :host {
           overflow: hidden;
 
-          grid-column: ${
-            parseInt(this.getAttribute("x")) + 1
-          } / span ${this.getAttribute("w")};
-          grid-row: ${
-            parseInt(this.getAttribute("y")) + 1
-          } / span ${this.getAttribute("h")};
+          ${
+            this.parentElement &&
+            this.parentElement.getAttribute("fill-grid") !== null
+              ? `
+            grid-column: span ${this.getAttribute("w")};
+            grid-row: span ${this.getAttribute("h")};
+            `
+              : `
+            grid-column: ${
+              parseInt(this.getAttribute("x")) + 1
+            } / span ${this.getAttribute("w")};
+            grid-row: ${
+              parseInt(this.getAttribute("y")) + 1
+            } / span ${this.getAttribute("h")};
+          `
+          }
         }
       </style>
       <slot></slot>

--- a/elements/layout/stories/fill-grid.js
+++ b/elements/layout/stories/fill-grid.js
@@ -1,0 +1,28 @@
+import { html } from "lit";
+import { STORIES_LAYOUT_STYLE, STORIES_LAYOUT_ITEM_STYLE } from "../src/enums";
+
+export const FillGrid = {
+  args: {},
+  render: () => html`
+    <!-- Render eox-layout component -->
+    <eox-layout
+      fill-grid
+      row-height="100px"
+      column-width="200px"
+      style="${STORIES_LAYOUT_STYLE}"
+    >
+      <eox-layout-item w="2" h="2"> w="2" h="2" </eox-layout-item>
+      <eox-layout-item w="1"> w="1" </eox-layout-item>
+      <eox-layout-item w="1"> w="1" </eox-layout-item>
+      <eox-layout-item w="3"> w="3" </eox-layout-item>
+      <eox-layout-item w="1"> w="1" </eox-layout-item>
+    </eox-layout>
+    <style>
+      eox-layout-item {
+        ${STORIES_LAYOUT_ITEM_STYLE}
+      }
+    </style>
+  `,
+};
+
+export default FillGrid;

--- a/elements/layout/stories/index.js
+++ b/elements/layout/stories/index.js
@@ -5,3 +5,4 @@ export { default as PrimaryStory } from "./primary";
 export { default as GridStory } from "./grid";
 export { default as GapStory } from "./gap";
 export { default as ScrollStory } from "./scroll";
+export { default as FillGridStory } from "./fill-grid";

--- a/elements/layout/stories/layout.stories.js
+++ b/elements/layout/stories/layout.stories.js
@@ -2,7 +2,13 @@
  * Stories for eox-layout component showcasing various configurations.
  * These stories provide visual representations and usage examples for different scenarios.
  */
-import { PrimaryStory, GridStory, GapStory, ScrollStory } from "./index";
+import {
+  PrimaryStory,
+  GridStory,
+  GapStory,
+  ScrollStory,
+  FillGridStory,
+} from "./index";
 
 export default {
   title: "Elements/eox-layout",
@@ -33,3 +39,9 @@ export const Gap = GapStory;
  * In this case, the items will overflow the grid.
  */
 export const Scroll = ScrollStory;
+
+/**
+ * By using the `fill-grid` attribute on `eox-layout`, the grid will automatically fill the available space.
+ * The `row-height` and `column-width` attributes define the minimum size of the grid slots.
+ */
+export const FillGrid = FillGridStory;


### PR DESCRIPTION
## Implemented changes

By adding the `fill-grid` attribute to `eox-layout`, the individual items fill the available space without gaps. The `w` and `h` attributes on items can be used to determine the relative width/height, whereas the  `row-height` and `column-width` attributes on the layout determine the minimum height/width of the grid items.

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/14f7e17d-e7f4-46ec-a6f5-f3e1bf443c9d)

https://github.com/user-attachments/assets/4ffa88b0-0888-4469-a598-82cb11088cc3



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
