### PR TITLE
feat: responsive layout (s/m/l)

### DIFF
--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -1,7 +1,7 @@
 /**
  * This element allows to quickly set up an app layout using a 12x12 grid. It consists of two elements:
  * - `eox-layout`: the container holding all the items
- * - `eox-layout-item`: the individual items placed on the grid, with a defined x/y coordinate, and a w(idth) and h(eight)
+ * - `eox-layout-item`: the individual items placed on the grid, with a defined x/y coordinate, and a w(idth) and h(eight), which can be single values or three vlaues for small/medium/large
  */
 export class EOxLayout extends HTMLElement {
   static get observedAttributes() {
@@ -9,6 +9,12 @@ export class EOxLayout extends HTMLElement {
   }
   constructor() {
     super();
+
+    /**
+     * The breakpoints for small/medium/large screens (in pixel).
+     */
+    this.mediaBreakpoints = [0, 600, 1280];
+
     this.attachShadow({ mode: "open" });
     this.render();
   }
@@ -16,8 +22,8 @@ export class EOxLayout extends HTMLElement {
     this.shadowRoot.innerHTML = `
     <style>
       :host {
-        --row-height: ${this.getAttribute("row-height")};
-        --column-width: ${this.getAttribute("column-width")};
+        --row-height: ${this.getAttribute("row-height") || "1fr"};
+        --column-width: ${this.getAttribute("column-width") || "1fr"};
         display: grid;
         padding: ${this.getAttribute("gap") || 0}px;
         height: 100%;
@@ -30,8 +36,8 @@ export class EOxLayout extends HTMLElement {
           grid-template-rows: repeat(auto-fill, minmax(var(--row-height, 300px), 1fr));
           `
             : `
-          grid-template-columns: repeat(12, var(--column-width, 1fr));
-          grid-template-rows: repeat(12, var(--row-height, 1fr));
+          grid-template-columns: repeat(12, ${this.getAttribute("column-width") ? "var(--column-width)" : "minmax(0, var(--column-width))"});
+          grid-template-rows: repeat(12, ${this.getAttribute("row-height") ? "var(--row-height)" : "minmax(0, var(--row-height))"});
           `
         }
         overflow: auto;
@@ -58,28 +64,53 @@ export class EOxLayoutItem extends HTMLElement {
     this.render();
   }
   render() {
+    // Check if attribute includes "/" for "s/m/l", if not return original
+    const withMediaBreakpoints = (attribute, breakpointIndex = 0) => {
+      if (attribute?.toString().includes("/")) {
+        const sizes = attribute.split("/");
+        let currentBreakpoint = sizes[breakpointIndex];
+        return currentBreakpoint;
+      }
+      return attribute;
+    };
+
     this.shadowRoot.innerHTML = `
       <style>
         :host {
           overflow: hidden;
-
-          ${
-            this.parentElement &&
-            this.parentElement.getAttribute("fill-grid") !== null
-              ? `
-            grid-column: span ${this.getAttribute("w")};
-            grid-row: span ${this.getAttribute("h")};
-            `
-              : `
-            grid-column: ${
-              parseInt(this.getAttribute("x")) + 1
-            } / span ${this.getAttribute("w")};
-            grid-row: ${
-              parseInt(this.getAttribute("y")) + 1
-            } / span ${this.getAttribute("h")};
-          `
-          }
         }
+          ${
+            /**@type EOxLayout */ (this.parentElement)?.mediaBreakpoints
+              .map(
+                (bp, index) => `
+              @media (min-width: ${bp}px) {
+                :host {
+                          ${
+                            this.parentElement &&
+                            this.parentElement.getAttribute("fill-grid") !==
+                              null
+                              ? `
+                          grid-column: span ${withMediaBreakpoints(this.getAttribute("w"), index)};
+                          grid-row: span ${withMediaBreakpoints(this.getAttribute("h"), index)};
+                          `
+                              : `            
+                            grid-column: ${parseInt(withMediaBreakpoints(this.getAttribute("x"), index)) + 1} / span ${withMediaBreakpoints(this.getAttribute("w"), index)};
+                            grid-row: ${parseInt(withMediaBreakpoints(this.getAttribute("y"), index)) + 1} / span ${withMediaBreakpoints(this.getAttribute("h"), index)};
+                        `
+                          }
+                  display: ${
+                    withMediaBreakpoints(this.getAttribute("w"), index) ===
+                      "0" ||
+                    withMediaBreakpoints(this.getAttribute("h"), index) === "0"
+                      ? `none`
+                      : `block`
+                  }
+                }
+              }
+              `,
+              )
+              .join("\n")
+          }
       </style>
       <slot></slot>
     `;

--- a/elements/layout/stories/index.js
+++ b/elements/layout/stories/index.js
@@ -6,3 +6,4 @@ export { default as GridStory } from "./grid";
 export { default as GapStory } from "./gap";
 export { default as ScrollStory } from "./scroll";
 export { default as FillGridStory } from "./fill-grid";
+export { default as ResponsiveStory } from "./responsive";

--- a/elements/layout/stories/layout.stories.js
+++ b/elements/layout/stories/layout.stories.js
@@ -8,6 +8,7 @@ import {
   GapStory,
   ScrollStory,
   FillGridStory,
+  ResponsiveStory,
 } from "./index";
 
 export default {
@@ -45,3 +46,8 @@ export const Scroll = ScrollStory;
  * The `row-height` and `column-width` attributes define the minimum size of the grid slots.
  */
 export const FillGrid = FillGridStory;
+
+/**
+ * By providing three values instead of one for `x`, `y`, `w` or `h`, items can be rendered differently on different screen sizes (small/medium/large).
+ */
+export const Responsive = ResponsiveStory;

--- a/elements/layout/stories/responsive.js
+++ b/elements/layout/stories/responsive.js
@@ -5,11 +5,11 @@ export const Responsive = {
   args: {},
   render: () => html`
     <!-- Render eox-layout component -->
-    <eox-layout style="${STORIES_LAYOUT_STYLE}">
+    <eox-layout style="${STORIES_LAYOUT_STYLE}" gap="8">
       <eox-layout-item x="0" y="0" w="12/1/1" h="1/11/12">
         x="0" y="0" w="12/1/1" h="1/11/12"
       </eox-layout-item>
-      <eox-layout-item x="0/1/1" y="1/0/0" w="12/11/11" h="11/11/12">
+      <eox-layout-item x="0/1/1" y="1/0/0" w="12/11/10" h="10/11/12">
         x="0/1/1" y="1/0/0" w="12/11/11" h="11/11/12"
       </eox-layout-item>
       <eox-layout-item x="0/0/11" y="11/11/0" w="12/12/1" h="1/1/12">

--- a/elements/layout/stories/responsive.js
+++ b/elements/layout/stories/responsive.js
@@ -1,0 +1,27 @@
+import { html } from "lit";
+import { STORIES_LAYOUT_STYLE, STORIES_LAYOUT_ITEM_STYLE } from "../src/enums";
+
+export const Responsive = {
+  args: {},
+  render: () => html`
+    <!-- Render eox-layout component -->
+    <eox-layout style="${STORIES_LAYOUT_STYLE}">
+      <eox-layout-item x="0" y="0" w="12/1/1" h="1/11/12">
+        x="0" y="0" w="12/1/1" h="1/11/12"
+      </eox-layout-item>
+      <eox-layout-item x="0/1/1" y="1/0/0" w="12/11/11" h="11/11/12">
+        x="0/1/1" y="1/0/0" w="12/11/11" h="11/11/12"
+      </eox-layout-item>
+      <eox-layout-item x="0/0/11" y="11/11/0" w="12/12/1" h="1/1/12">
+        x="0/0/11" y="11/11/0" w="12/12/1" h="1/1/12"
+      </eox-layout-item>
+    </eox-layout>
+    <style>
+      eox-layout-item {
+        ${STORIES_LAYOUT_ITEM_STYLE}
+      }
+    </style>
+  `,
+};
+
+export default Responsive;


### PR DESCRIPTION
## Implemented changes

This PR adds support for different screen sizes. By default, the breakpoints are `[0, 600, 1280]` (pixels) and each layout item can have 3 values (e.g. `w="2/4/6"`). This way, completely different layouts for different screen sizes can be created.

## Screenshots/Videos


https://github.com/user-attachments/assets/c5a78c87-b4e2-4771-97a9-dcb68a23da94



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
