### PR TITLE
feat(style): replace result cards with eox-layout

### DIFF
--- a/elements/itemfilter/package.json
+++ b/elements/itemfilter/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@eox/elements-utils": "^0.1.5",
+    "@eox/layout": "^0.4.0",
     "@floating-ui/dom": "^1.6.8",
     "@turf/boolean-intersects": "^7.0.0",
     "@turf/boolean-within": "^7.0.0",

--- a/elements/itemfilter/src/components/results.js
+++ b/elements/itemfilter/src/components/results.js
@@ -79,7 +79,7 @@ export class EOxItemFilterResults extends LitElement {
    * Creates a list of items based on the aggregation property.
    *
    * @param {string} [aggregationProperty] - The property used for aggregation.
-   * @returns {import("lit").HTMLTemplateResult} - The template result for the item list.
+   * @returns {import("lit").TemplateResult} - The template result for the item list.
    */
   #createItemList(aggregationProperty) {
     return createItemListMethod(this, aggregationProperty);

--- a/elements/itemfilter/src/components/results.js
+++ b/elements/itemfilter/src/components/results.js
@@ -1,6 +1,7 @@
 import { LitElement, html, nothing } from "lit";
 import { when } from "lit/directives/when.js";
 import { map } from "lit/directives/map.js";
+import "@eox/layout";
 import {
   aggregateResultsMethod,
   createItemDetailsMethod,

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -65,7 +65,7 @@ export function createItemListMethod(
       : nothing;
 
   return staticHtml`
-    ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout gap="16" row-height="200px" column-width="300px" fill-grid>`) : unsafeStatic(`<ul>`)}
+    ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout fill-grid>`) : unsafeStatic(`<ul>`)}
       ${repeat(
         items,
         (item) => item.id,

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { html as staticHtml, unsafeStatic } from "lit/static-html.js";
 import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
@@ -44,7 +45,7 @@ export function createItemDetailsMethod(
  *
  * @param {Object} EOxItemFilterResults - The EOxItemFilterResults component instance.
  * @param {string} [aggregationProperty] - The property used for aggregation.
- * @returns {import("lit").HTMLTemplateResult} The HTML template for the item list view.
+ * @returns {import("lit").TemplateResult} The HTML template for the item list view.
  */
 export function createItemListMethod(
   EOxItemFilterResults,
@@ -63,13 +64,13 @@ export function createItemListMethod(
       ? "highlighted"
       : nothing;
 
-  return html`
-    <ul class=${EOxItemFilterResults.resultType}>
+  return staticHtml`
+    ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout gap="16" row-height="200px" column-width="300px" fill-grid>`) : unsafeStatic(`<ul>`)}
       ${repeat(
         items,
         (item) => item.id,
-        (item) => html`
-          <li
+        (item) => staticHtml`
+        ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout-item`) : unsafeStatic(`<li`)}
             class=${className(item)}
             @click=${() => {
               if (EOxItemFilterResults.selectedResult === item) {
@@ -145,6 +146,6 @@ export function createItemListMethod(
           </li>
         `,
       )}
-    </ul>
+    ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`</eox-layout>`) : unsafeStatic(`</ul>`)}
   `;
 }

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -193,7 +193,7 @@ eox-layout {
 }
 eox-layout-item {
   position: relative;
-  border-radius: var(--card-border-radius, 16px);
+  border-radius: var(--card-border-radius, 8px);
 }
 eox-layout-item .image {
   width: 100%;

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -185,9 +185,15 @@ ul#results .result-action:hover {
 ul#results .highlighted .result-action > * {
   filter: invert(1);
 }
+eox-layout {
+  padding: .5rem var(--padding);
+  gap: var(--card-gap, 16px);
+  --column-width: var(--card-width, 300px);
+  --row-height: var(--card-height, 200px);
+}
 eox-layout-item {
   position: relative;
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 16px);
 }
 eox-layout-item .image {
   width: 100%;

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -54,10 +54,6 @@ li span {
   display: flex;
   align-items: center;
 }
-.cards li span {
-  display: block;
-  flex-basis: 100%;
-}
 li label {
   display: flex;
   align-items: center;
@@ -81,22 +77,10 @@ details > summary::-webkit-details-marker {
   align-items: center;
   text-transform: var(--text-transform);
 }
-.cards .title {
-  font-size: 16px;
-  font-weight: 600;
-  text-wrap: auto;
-  line-height: 19px;
-}
 .subtitle {
   font-size: 11px;
   opacity: .7;
   margin-top: 6px;
-}
-.cards .subtitle {
-  font-size: 14px;
-  color: #757575;
-  text-wrap: auto;
-  line-height: 19px;
 }
 .image {
   width: 24px;
@@ -104,20 +88,6 @@ details > summary::-webkit-details-marker {
   object-fit: cover;
   overflow: hidden;
   margin-right: 8px;
-}
-.cards .image {
-  width: 100%;
-  height: 190px;
-  margin-bottom: 8px;
-}
-.cards .result-action {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin: 10px 12px;
-  padding: 6px;
-  background: white;
-  border-radius: 50%;
 }
 .title-container {
   display: flex;
@@ -201,7 +171,7 @@ ul#results li {
   display: flex;
   justify-content: space-between;
 }
-ul#results li .result-action {
+ul#results .result-action {
   display: flex;
   align-items: center;
   height: fit-content;
@@ -209,35 +179,54 @@ ul#results li .result-action {
   opacity: .5;
   transition: opacity .3s ease-in-out;
 }
-ul#results li .result-action:hover {
+ul#results .result-action:hover {
   opacity: 1;
 }
-ul#results li.highlighted .result-action > * {
+ul#results .highlighted .result-action > * {
   filter: invert(1);
 }
-ul#results ul.cards {
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-  gap: 40px;
-  margin: 20px 0;
-  cursor: initial;
-}
-ul#results ul.cards li {
-  flex-basis: calc(33.3% - 77px);
-  min-width: 0;
-  align-self: flex-start;
+eox-layout-item {
   position: relative;
+  border-radius: 8px;
 }
-@media screen and (max-width: 768px) {
-  ul#results ul.cards li {
-    flex-basis: calc(50% - 70px);
-  }
+eox-layout-item .image {
+  width: 100%;
+  height: 100%;
+  transition: filter .3s ease-in-out;
+  margin: 0;
 }
-@media screen and (max-width: 480px) {
-  ul#results ul.cards li {
-    flex-basis: 100%;
-  }
+eox-layout-item:hover .image {
+  filter: brightness(.5);
+}
+eox-layout-item .title-container {
+  position: absolute;
+  bottom: 0;
+  color: white;
+  padding: 20px;
+  box-sizing: border-box;
+  width: 100%;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.85),
+    transparent
+  );
+  padding-top: 25px;
+}
+eox-layout-item .title {
+  font-weight: bold;
+}
+eox-layout-item .result-action {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: #ffffffbb;
+  padding: 8px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+ul#results eox-layout-item.highlighted .result-action > * {
+  filter: none;
 }
 section {
   position: relative;

--- a/elements/itemfilter/stories/card-display.js
+++ b/elements/itemfilter/stories/card-display.js
@@ -17,6 +17,7 @@ function CardDisplayStory() {
         .subTitleProperty=${args.subTitleProperty}
         .filterProperties=${args.filterProperties}
         .resultType=${args.resultType}
+        style="--card-gap: 16px; --card-width: 300px; --card-height: 200px; --card-border-radius: 8px;"
       ></eox-itemfilter>`,
     args: {
       aggregateResults: "themes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
       "version": "1.8.0",
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
+        "@eox/layout": "^0.4.0",
         "@floating-ui/dom": "^1.6.8",
         "@turf/boolean-intersects": "^7.0.0",
         "@turf/boolean-within": "^7.0.0",
@@ -127,7 +128,7 @@
     },
     "elements/jsonform": {
       "name": "@eox/jsonform",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
         "@json-editor/json-editor": "^2.11.0",
@@ -248,7 +249,7 @@
     },
     "elements/layout": {
       "name": "@eox/layout",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "vite": "^6.0.3"
       }
@@ -291,7 +292,7 @@
     },
     "elements/storytelling": {
       "name": "@eox/storytelling",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
         "@sindresorhus/slugify": "^2.2.1",


### PR DESCRIPTION
## Implemented changes

This PR introduces `eox-layout` for rendering the itemfilter result cards. It has a default max/min height/with of 300x200 for the cards and a 16px gap, and a border radius of 8px, which is configurable via CSS vars on `eox-itemfilter`:
- `--card-width`
- `--card-height`
- `--card-gap`
- `--card-border-radius`

## Screenshots/Videos


https://github.com/user-attachments/assets/f8ac7a1f-c09c-4ed8-b769-d8a3379eed19


![image](https://github.com/user-attachments/assets/ba6fc07f-498b-4923-aaf0-d2fcc7ee5c1e)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
