### PR TITLE
feat: introduce eox-feedback element

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,6 @@
   "elements/storytelling": "1.7.2",
   "elements/geosearch": "0.5.2",
   "elements/chart": "0.4.0",
+  "elements/feedback": "0.0.0",
   "utils": "0.1.5"
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,6 +4,7 @@ import DocumentationTemplate from "./DocumentationTemplate.mdx";
 
 import "@eox/chart";
 import "@eox/drawtools";
+import "@eox/feedback";
 import "@eox/geosearch";
 import "@eox/itemfilter";
 import "@eox/jsonform";
@@ -14,6 +15,8 @@ import "@eox/map/src/plugins/advancedLayersAndSources";
 import "@eox/stacinfo";
 import "@eox/storytelling";
 import "@eox/timecontrol";
+import "@eox/ui";
+import "@eox/ui/style.css";
 
 /**
  * A custom wrapper for the default setCustomElementsManifest function.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Please find [descriptions, API docs and interactive examples here](https://eox-a
     <td>🟡</td>
   </tr>
   <tr>
+    <td><a href="./elements/feedback/">eox-feedback</a></td>
+    <td>Quick and easy feedback widget</td>
+    <td><a href="https://eox-a.github.io/EOxElements/index.html?path=/docs/elements-eox-feedback--docs">Docs & Examples</a></td>
+    <td><a href="elements/feedback/CHANGELOG.md"><img src="https://img.shields.io/npm/v/@eox/feedback.svg?label=%20" /></a></td>
+    <td>🟡</td>
+  </tr>
+  <tr>
     <td><a href="./elements/geosearch/">eox-geosearch</a></td>
     <td>An autocompleted search input for geographic locations</td>
     <td><a href="https://eox-a.github.io/EOxElements/index.html?path=/docs/elements-eox-geosearch--docs">Docs & Examples</a></td>

--- a/elements/feedback/README.md
+++ b/elements/feedback/README.md
@@ -1,0 +1,35 @@
+# Feedback
+
+## Usage
+
+```
+npm install @eox/feedback
+```
+
+```
+// for setups with bundlers e.g. Vite
+import "@eox/feedback"
+
+// or, for e.g. single HTML files without bundler
+import "@eox/feedback/dist/eox-feedback.js"
+
+<eox-feedback></eox-feedback>
+```
+
+// TODO: add documentation
+
+## Contribute
+
+```
+npm watch
+(on root) npm run cypress
+(on root) npm run format
+
+npm version <new version>
+npm run build
+npm publish (requires OTP)
+```
+
+## Changelog
+
+Created automatically [here](./CHANGELOG.md)

--- a/elements/feedback/package.json
+++ b/elements/feedback/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@eox/feedback",
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": {
+    "vite": "^6.0.3"
+  },
+  "dependencies": {
+    "@eox/ui": "^0.1.11",
+    "region-screenshot-js": "^1.1.0"
+  },
+  "files": [
+    "types",
+    "dist",
+    "src"
+  ],
+  "main": "./src/main.js",
+  "types": "./types/main.d.ts",
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./types/main.d.ts"
+      ],
+      "src/*": [
+        "./types/*"
+      ]
+    }
+  },
+  "scripts": {
+    "types:generate": "tsc --project tsconfig.build.json || true",
+    "prepack": "npm run types:generate",
+    "build": "vite build",
+    "watch": "vite build --watch"
+  }
+}

--- a/elements/feedback/src/css.d.ts
+++ b/elements/feedback/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css?inline";

--- a/elements/feedback/src/enums/index.js
+++ b/elements/feedback/src/enums/index.js
@@ -1,0 +1,1 @@
+export { TEST_SELECTORS } from "./test";

--- a/elements/feedback/src/enums/test.js
+++ b/elements/feedback/src/enums/test.js
@@ -1,0 +1,4 @@
+export const TEST_SELECTORS = {
+  feedbackElement: "eox-feedback",
+  feedbackButtonElement: "eox-feedback-button",
+};

--- a/elements/feedback/src/feedback-button.js
+++ b/elements/feedback/src/feedback-button.js
@@ -12,7 +12,7 @@ export class EOxFeedbackButton extends HTMLElement {
     super();
     this.attachShadow({ mode: "open" });
 
-    this.modal;
+    this.modal = null;
 
     this.position = "top-right";
   }

--- a/elements/feedback/src/feedback-button.js
+++ b/elements/feedback/src/feedback-button.js
@@ -1,0 +1,82 @@
+import { style } from "./style";
+import { styleEOX } from "./style.eox";
+
+/**
+ * @attr {string} [position=top-right] - The position of the button. Can be "top-left", "top-right", "bottom-left", or "bottom-right".
+ * @attr {string|null} [unstyled=undefined] - If set, the button will not be styled with EOX styles.
+ */
+export class EOxFeedbackButton extends HTMLElement {
+  static observedAttributes = ["position", "unstyled"];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+
+    this.modal;
+
+    this.position = "top-right";
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (newValue !== oldValue) {
+      if (name === "position" && newValue !== this.position) {
+        this.position = newValue;
+        this.render();
+      }
+    }
+  }
+
+  connectedCallback() {
+    this.render();
+    this.shadowRoot
+      .querySelector("button")
+      .addEventListener("click", () => this.onButtonClick());
+  }
+
+  disconnectedCallback() {
+    this.shadowRoot
+      .querySelector("button")
+      .removeEventListener("click", () => this.onButtonClick());
+  }
+
+  onButtonClick() {
+    if (!this.modal) {
+      this.modal = document.createElement("eox-feedback");
+      if (this.getAttribute("unstyled") !== null) {
+        this.modal.setAttribute("unstyled", this.getAttribute("unstyled"));
+      }
+      document.body.appendChild(this.modal);
+      this.modal.addEventListener("close", () => (this.modal = null));
+    } else {
+      this.modal.remove();
+      this.modal = null;
+    }
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        ${style}
+        ${this.getAttribute("unstyled") === null && styleEOX}
+        :host {
+          position: fixed !important;
+          margin: 0px 20px !important;
+          ${this.position.includes("top") ? "top: 0px;" : ""}
+          ${this.position.includes("right") ? "right: 0px;" : ""}
+          ${this.position.includes("bottom") ? "bottom: 0px;" : ""}
+          ${this.position.includes("left") ? "left: 0px;" : ""}
+        }
+      </style>
+      <button
+        class="${this.position.includes("top") ? "bottom" : ""}${this.position.includes("bottom") ? "top" : ""}-round small-round"
+      >
+        <i>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>send-circle-outline</title><path d="M8,7.71L18,12L8,16.29V12.95L15.14,12L8,11.05V7.71M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4Z" /></svg>
+        </i>
+        <span>Feedback</span>
+      </button>
+    `;
+  }
+}
+
+customElements.define("eox-feedback-button", EOxFeedbackButton);

--- a/elements/feedback/src/main.js
+++ b/elements/feedback/src/main.js
@@ -1,0 +1,282 @@
+import RegionScreenshot from "region-screenshot-js";
+import { style } from "./style";
+import { styleEOX } from "./style.eox";
+import { EOxFeedbackButton } from "./feedback-button.js";
+
+/**
+ * @attr {string} endpoint - The endpoint to send the feedback to as POST message.
+ * @attr {string|null} [unstyled=undefined] - If provided, the element will not be styled with EOX styles.
+ *
+ * @fires close - The modal was closed.
+ * @fires submit - The feedback was submitted. The `CustomEvent.detail` contains the FormData object.
+ */
+export class EOxFeedback extends HTMLElement {
+  static observedAttributes = ["endpoint", "unstyled"];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+
+    this.includeScreenshot;
+    this.areaSelection;
+
+    this.regionScreenshot;
+
+    this.screenShotFile;
+
+    this.endpoint =
+      this.getAttribute("endpoint") ||
+      document.querySelector("eox-feedback-button")?.getAttribute("endpoint");
+  }
+
+  connectedCallback() {
+    this.render();
+    this.shadowRoot
+      .querySelector("input[type=checkbox]")
+      .addEventListener("click", (e) => this.onToggleScreenshot(e));
+    this.shadowRoot
+      .querySelector("button#submit")
+      .addEventListener("click", () => this.onSubmit());
+    this.shadowRoot
+      .querySelector("button#cancel")
+      .addEventListener("click", () => this.onCancel());
+    this.shadowRoot
+      .querySelector("textarea")
+      .addEventListener("input", (e) => this.onTextInput(e));
+    document.addEventListener("keyup", (e) => this.onKeyboardInput(e));
+  }
+
+  disconnectedCallback() {
+    this.shadowRoot
+      .querySelector("input[type=checkbox]")
+      .removeEventListener("click", (e) => this.onToggleScreenshot(e));
+    this.shadowRoot
+      .querySelector("button#submit")
+      .removeEventListener("click", () => this.onSubmit());
+    this.shadowRoot
+      .querySelector("button#cancel")
+      .removeEventListener("click", () => this.onCancel());
+    this.shadowRoot
+      .querySelector("textarea")
+      .removeEventListener("input", (e) => this.onTextInput(e));
+    document.removeEventListener("keyup", (e) => this.onKeyboardInput(e));
+  }
+
+  onKeyboardInput(e) {
+    if (e.keyCode === 27) {
+      this.onCancel();
+    }
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      if (this.shadowRoot.querySelector("textarea").value.length > 0) {
+        this.onSubmit();
+      }
+    }
+  }
+
+  onOverlayDraw(e) {
+    this.areaSelection = e.detail;
+  }
+
+  onTextInput(e) {
+    const submitButton = this.shadowRoot.querySelector("button#submit");
+    if (e.target.value.length > 0) {
+      submitButton.classList.remove("disabled");
+    } else {
+      submitButton.classList.add("disabled");
+    }
+  }
+
+  async onToggleScreenshot(e) {
+    this.includeScreenshot = e.target.checked;
+
+    this.shadowRoot
+      .querySelector("#screenshot-info")
+      .classList.toggle("hidden");
+
+    const existingScreenshot =
+      this.shadowRoot.querySelector("#screenshot > img");
+
+    if (!e.target.checked) {
+      this.regionScreenshot.close();
+
+      if (existingScreenshot) {
+        existingScreenshot.remove();
+      }
+      return;
+    }
+
+    const inputField = this.shadowRoot.querySelector("textarea");
+    const submitButton = this.shadowRoot.querySelector("button#submit");
+    submitButton.classList.add("disabled");
+
+    this.regionScreenshot = new RegionScreenshot();
+
+    ["closed", "errorCreated", "screenshotDownload"].forEach((event) => {
+      this.regionScreenshot.on(event, () => {
+        const checkbox = this.shadowRoot.querySelector("input[type=checkbox]");
+        if (!(checkbox instanceof HTMLInputElement)) return;
+        checkbox.checked = false;
+        this.includeScreenshot = false;
+        if (inputField.value.length > 0) {
+          submitButton.classList.remove("disabled");
+        }
+      });
+    });
+
+    this.regionScreenshot.on("screenshotGenerated", (dataUrl) => {
+      const screenshot = document.createElement("img");
+      screenshot.src = dataUrl;
+      screenshot.classList.add("border");
+      this.shadowRoot.querySelector("#screenshot").appendChild(screenshot);
+
+      function dataURLtoFile(dataurl, filename) {
+        var arr = dataurl.split(","),
+          mime = arr[0].match(/:(.*?);/)[1],
+          bstr = atob(arr[arr.length - 1]),
+          n = bstr.length,
+          u8arr = new Uint8Array(n);
+        while (n--) {
+          u8arr[n] = bstr.charCodeAt(n);
+        }
+        return new File([u8arr], filename, { type: mime });
+      }
+      this.screenShotFile = dataURLtoFile(dataUrl, "screenshot.png");
+      submitButton.classList.remove("disabled");
+    });
+  }
+
+  async onSubmit() {
+    const container = this.shadowRoot.querySelector("article > div");
+    const form = this.shadowRoot.querySelector("#form");
+    const progress = this.shadowRoot.querySelector("progress");
+
+    container.classList.add("disabled");
+    progress.classList.remove("hidden");
+
+    const requestBody = new FormData();
+    if (this.includeScreenshot) {
+      requestBody.append("file", this.screenShotFile);
+    }
+
+    requestBody.append(
+      "message",
+      this.shadowRoot.querySelector("textarea").value,
+    );
+
+    requestBody.append("userAgent", window.navigator.userAgent);
+
+    requestBody.append("location", window.location.href);
+
+    if (!this.endpoint) {
+      throw new Error("No endpoint attribute defined!");
+    }
+
+    const message = document.createElement("div");
+    try {
+      await fetch(this.endpoint, {
+        method: "POST",
+        body: requestBody,
+      });
+      message.innerHTML = `
+        <p class="green-text middle-align center-align">Thank you for submitting your feedback!</p>
+        `;
+    } catch (error) {
+      message.innerHTML = `
+        <p class="red-text middle-align center-align">Oh no - something went wrong! Apologies, we'll try to find out what happened.</p>
+        `;
+    }
+    this.dispatchEvent(new CustomEvent("submit", { detail: requestBody }));
+
+    form.classList.add("hidden");
+    container.appendChild(message);
+
+    container.classList.remove("disabled");
+    progress.classList.add("hidden");
+    setTimeout(() => {
+      this.onCancel();
+    }, 4000);
+  }
+
+  onCancel() {
+    if (this.regionScreenshot) {
+      this.regionScreenshot.close();
+    }
+    this.remove();
+    this.dispatchEvent(new Event("close"));
+  }
+
+  render() {
+    /**
+     * @type {EOxFeedbackButton}
+     */
+    const feedbackButton = document.querySelector("eox-feedback-button");
+    this.shadowRoot.innerHTML = `
+      <style>
+        ${style}
+        ${this.getAttribute("unstyled") === null && styleEOX}
+        :host {
+          display: block;
+          position: fixed !important;
+          width: 320px;
+          ${
+            feedbackButton
+              ? `
+            margin: 50px 27px !important;
+            ${feedbackButton.position?.includes("top") ? "top: 0px;" : ""}
+            ${feedbackButton.position?.includes("right") ? "right: 0px;" : ""}
+            ${feedbackButton.position?.includes("bottom") ? "bottom: 0px;" : ""}
+            ${feedbackButton.position?.includes("left") ? "left: 0px;" : ""}
+          `
+              : ``
+          }
+          z-index: 10000;
+        }
+        .hidden {
+          display: none !important;
+        }
+        .disabled {
+          opacity: .5;
+          pointer-events: none;
+        }
+        .field > :is(input, textarea, select) {
+          font-size: 0.875rem !important;
+        }
+        #screenshot > img {
+          max-width: 100%;
+          max-height: 100px;
+        }
+        .region-screenshot_tools {
+          z-index: 10001;
+        }
+      </style>
+      <article class="no-margin small-round">
+        <div ${!this.endpoint ? 'class="disabled"' : ""}>
+          <div id="form">
+            <nav>
+              <label class="switch">
+                <input type="checkbox">
+                <span></span>
+              </label>
+              <div class="max">
+                <div>Include a screenshot</div>
+                <small id="screenshot-info" class="italic hidden">Drag to highlight part of the page</small>
+              </div>
+            </nav>
+            <div id="screenshot" class="middle-align center-align"></div>
+            <div class="field textarea border">
+              <textarea placeholder="${!this.endpoint ? "Missing endpoint attribute!" : "Type your feedback here! Also include some contact info if you'd like us to reach out to you."}"></textarea>
+            </div>
+            <nav>
+              <progress class="circle small hidden"></progress>
+              <div class="max"></div>
+              <button id="cancel" class="border">Cancel</button>
+              <button id="submit" class="disabled">Submit</button>
+            </nav>
+          </div>
+        </div>
+      </article>
+    `;
+  }
+}
+
+customElements.define("eox-feedback", EOxFeedback);

--- a/elements/feedback/src/main.js
+++ b/elements/feedback/src/main.js
@@ -1,7 +1,7 @@
 import RegionScreenshot from "region-screenshot-js";
 import { style } from "./style";
 import { styleEOX } from "./style.eox";
-import { EOxFeedbackButton } from "./feedback-button.js";
+import "./feedback-button.js";
 
 /**
  * @attr {string} endpoint - The endpoint to send the feedback to as POST message.
@@ -17,12 +17,12 @@ export class EOxFeedback extends HTMLElement {
     super();
     this.attachShadow({ mode: "open" });
 
-    this.includeScreenshot;
-    this.areaSelection;
+    this.includeScreenshot = null;
+    this.areaSelection = null;
 
-    this.regionScreenshot;
+    this.regionScreenshot = null;
 
-    this.screenShotFile;
+    this.screenShotFile = null;
 
     this.endpoint =
       this.getAttribute("endpoint") ||
@@ -180,7 +180,7 @@ export class EOxFeedback extends HTMLElement {
       message.innerHTML = `
         <p class="green-text middle-align center-align">Thank you for submitting your feedback!</p>
         `;
-    } catch (error) {
+    } catch (_) {
       message.innerHTML = `
         <p class="red-text middle-align center-align">Oh no - something went wrong! Apologies, we'll try to find out what happened.</p>
         `;
@@ -207,7 +207,7 @@ export class EOxFeedback extends HTMLElement {
 
   render() {
     /**
-     * @type {EOxFeedbackButton}
+     * @type {import("./feedback-button").EOxFeedbackButton}
      */
     const feedbackButton = document.querySelector("eox-feedback-button");
     this.shadowRoot.innerHTML = `

--- a/elements/feedback/src/style.eox.js
+++ b/elements/feedback/src/style.eox.js
@@ -1,0 +1,5 @@
+import eoxStyle from "@eox/ui/style.css?inline";
+
+export const styleEOX = `
+  ${eoxStyle}
+`;

--- a/elements/feedback/src/style.js
+++ b/elements/feedback/src/style.js
@@ -1,0 +1,2 @@
+export const style = `
+`;

--- a/elements/feedback/stories/button.js
+++ b/elements/feedback/stories/button.js
@@ -1,0 +1,13 @@
+import { html } from "lit";
+
+export const Button = {
+  args: {},
+  render: () => html`
+    <eox-feedback-button
+      endpoint="https://git-issue-creator.hub-int.eox.at/create-issue?repo=1038"
+      position="bottom-left"
+    ></eox-feedback-button>
+  `,
+};
+
+export default Button;

--- a/elements/feedback/stories/feedback.stories.js
+++ b/elements/feedback/stories/feedback.stories.js
@@ -1,0 +1,24 @@
+/**
+ * Stories for eox-feedback component showcasing various configurations.
+ * These stories provide visual representations and usage examples for different scenarios.
+ */
+import { PrimaryStory, ButtonStory } from "./index";
+
+export default {
+  title: "Elements/eox-feedback",
+  tags: ["autodocs"],
+  component: "eox-feedback",
+};
+
+// Exporting each individual story for the eox-feedback component.
+
+/**
+ * Primary story showcasing basic usage.
+ */
+export const Primary = PrimaryStory;
+
+/**
+ * Triggering of eox-feeback modal via button. The button can be positioned using the `position` attribute.
+ * Can be `top-left`, `top-right`, `bottom-left`, or `bottom-right`.
+ */
+export const Button = ButtonStory;

--- a/elements/feedback/stories/index.js
+++ b/elements/feedback/stories/index.js
@@ -1,0 +1,5 @@
+// Global import of eox-elements in .storybook/preview.js!
+// Export different stories
+
+export { default as PrimaryStory } from "./primary";
+export { default as ButtonStory } from "./button";

--- a/elements/feedback/stories/primary.js
+++ b/elements/feedback/stories/primary.js
@@ -1,0 +1,15 @@
+import { html } from "lit";
+
+export const Primary = {
+  args: {},
+  render: () => html`
+    <div style="height: 250px;">
+      <eox-feedback
+        endpoint="/fake/endpoint"
+        style="position: relative !important;"
+      ></eox-feedback>
+    </div>
+  `,
+};
+
+export default Primary;

--- a/elements/feedback/test/cases/click-button.js
+++ b/elements/feedback/test/cases/click-button.js
@@ -1,0 +1,21 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { feedbackElement, feedbackButtonElement } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the layout component loads successfully.
+ */
+const clickFeedbackButtonTest = () => {
+  // Mounting eox-layout element
+  cy.mount(`<eox-feedback-button></eox-feedback-button>`).as(
+    feedbackButtonElement,
+  );
+
+  // Find the feedback element and access its shadow DOM
+  cy.get(feedbackButtonElement).shadow();
+  cy.get(feedbackButtonElement).click();
+  cy.get(feedbackElement).should("exist");
+};
+
+export default clickFeedbackButtonTest;

--- a/elements/feedback/test/cases/index.js
+++ b/elements/feedback/test/cases/index.js
@@ -1,0 +1,4 @@
+// Exported test methods
+
+export { default as loadFeedbackTest } from "./load-feedback";
+export { default as clickFeedbackButtonTest } from "./click-button";

--- a/elements/feedback/test/cases/load-feedback.js
+++ b/elements/feedback/test/cases/load-feedback.js
@@ -1,0 +1,17 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { feedbackElement } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the layout component loads successfully.
+ */
+const loadFeedbackTest = () => {
+  // Mounting eox-layout element
+  cy.mount(`<eox-feedback></eox-feedback>`).as(feedbackElement);
+
+  // Find the feedback element and access its shadow DOM
+  cy.get(feedbackElement).shadow();
+};
+
+export default loadFeedbackTest;

--- a/elements/feedback/test/general.cy.js
+++ b/elements/feedback/test/general.cy.js
@@ -1,0 +1,9 @@
+// Importing necessary modules, test cases, and enums
+import "../src/main";
+import { loadFeedbackTest, clickFeedbackButtonTest } from "./cases";
+
+describe("Feedback", () => {
+  it("loads eox-feedback", () => loadFeedbackTest());
+  it("loads eox-feedback-button and opens modal on click", () =>
+    clickFeedbackButtonTest());
+});

--- a/elements/feedback/tsconfig.build.json
+++ b/elements/feedback/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./types",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.d.ts"]
+}

--- a/elements/feedback/vite.config.js
+++ b/elements/feedback/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "./src/main.js",
+      name: "eox-feedback",
+      // the proper extensions will be added
+      fileName: "eox-feedback",
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "elements/*",
         "utils"
       ],
+      "dependencies": {
+        "@eox/ui": "^0.2.1"
+      },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.10.2",
         "@cypress/code-coverage": "^3.12.44",
@@ -78,6 +81,23 @@
         "npm": ">=8.0.0"
       }
     },
+    "elements/feedback": {
+      "name": "@eox/feedback",
+      "version": "0.0.0",
+      "dependencies": {
+        "@eox/ui": "^0.1.11",
+        "region-screenshot-js": "^1.1.0"
+      },
+      "devDependencies": {
+        "vite": "^6.0.3"
+      }
+    },
+    "elements/feedback/node_modules/@eox/ui": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@eox/ui/-/ui-0.1.11.tgz",
+      "integrity": "sha512-UQXndo+9kr2u/onhY/V6k2n4kdIvLcPmuTvCLlUh0gBc2UF+rzT7REMJ0/Ctsf9KnjRPSe9Nz22a5gWLrPqiTA==",
+      "license": "MIT"
+    },
     "elements/geosearch": {
       "name": "@eox/geosearch",
       "version": "0.5.2",
@@ -98,7 +118,7 @@
     },
     "elements/itemfilter": {
       "name": "@eox/itemfilter",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "@eox/elements-utils": "^0.1.5",
         "@floating-ui/dom": "^1.6.8",
@@ -264,7 +284,7 @@
     },
     "elements/layout": {
       "name": "@eox/layout",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "vite": "^6.0.3"
       }
@@ -2494,6 +2514,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@eox/feedback": {
+      "resolved": "elements/feedback",
+      "link": true
+    },
     "node_modules/@eox/geosearch": {
       "resolved": "elements/geosearch",
       "link": true
@@ -2529,6 +2553,15 @@
     "node_modules/@eox/timecontrol": {
       "resolved": "elements/timecontrol",
       "link": true
+    },
+    "node_modules/@eox/ui": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eox/ui/-/ui-0.2.1.tgz",
+      "integrity": "sha512-YQYeR/p9F0rYL6hdp4B11lZiGFLeD3QLEF4rlMZ4X/MIXtbGCSAKOdADCAi6R07XH9nuDEtY97frIiC8+FQPNA==",
+      "license": "MIT",
+      "dependencies": {
+        "beercss": "^3.9.7"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -3470,6 +3503,12 @@
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
+    },
+    "node_modules/@material/material-color-utilities": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@material/material-color-utilities/-/material-color-utilities-0.2.7.tgz",
+      "integrity": "sha512-0FCeqG6WvK4/Cc06F/xXMd/pv4FeisI0c1tUpBbfhA2n9Y8eZEv4Karjbmf2ZqQCPUWMrGp8A571tCjizxoTiQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@mdx-js/react": {
       "version": "3.1.0",
@@ -5924,6 +5963,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/beercss": {
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/beercss/-/beercss-3.10.4.tgz",
+      "integrity": "sha512-aYgH1DesZkqixT7JswJYnWZlMoxx1d3xWzuVX27emFMS2iPFxdagnZ4jBc3GA4qFbv6zwu8J5DRcuI1j7UhpQA==",
+      "license": "MIT",
+      "dependencies": {
+        "material-dynamic-colors": "^1.1.2"
       }
     },
     "node_modules/better-opn": {
@@ -9701,6 +9749,18 @@
         "node": ">= 12"
       }
     },
+    "node_modules/material-dynamic-colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/material-dynamic-colors/-/material-dynamic-colors-1.1.2.tgz",
+      "integrity": "sha512-8KD0jrPTFs2x06UJWbvkg6E0HyzFjrvS5oOc2DsXzIEOqZTbb3ruLMUhNuPSl8WeHA/O/RTAlTLcxqYXJzYwPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/material-color-utilities": "^0.2.7"
+      },
+      "bin": {
+        "material-dynamic-colors": "cli.js"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11165,6 +11225,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/region-screenshot-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/region-screenshot-js/-/region-screenshot-js-1.1.0.tgz",
+      "integrity": "sha512-dJJNBhgeJk2XhUdvszWZ9UJeo1xp3v0/KF+1iwyqxjz/HeicUSxxGCLecCOOLs3H3fZXNpfwgBTX2ia/ADQXZw==",
+      "license": "MIT"
     },
     "node_modules/regjsgen": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "@eox/ui": "^0.2.1"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,9 @@
     "elements/drawtools": {
       "exclude-paths": ["elements/drawtools/stories", "elements/drawtools/test"]
     },
+    "elements/feedback": {
+      "exclude-paths": ["elements/feedback/stories", "elements/feedback/test"]
+    },
     "elements/geosearch": {
       "exclude-paths": ["elements/geosearch/stories", "elements/geosearch/test"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
       "@eox/chart/src/*": ["./elements/chart/src/*"],
       "@eox/drawtools": ["./elements/drawtools/src/main.js"],
       "@eox/drawtools/src/*": ["./elements/drawtools/src/*"],
+      "@eox/feedback/src/*": ["./elements/feedback/src/*"],
       "@eox/geosearch": ["./elements/geosearch/src/main.js"],
       "@eox/geosearch/src/*": ["./elements/geosearch/src/*"],
       "@eox/itemfilter": ["./elements/itemfilter/src/main.js"],


### PR DESCRIPTION
## Implemented changes

This PR introduces the new `eox-feedback` element, an easy way to provide feedback in UIs. It does a POST request to a provided server endpoint including the user-typed `message`, `userAgent`, window `location` and (optionally) a screenshot.

The screenshot tool allows the user to select an area of the screen, add annotations etc.

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/c887cbd4-a769-43ab-8b40-527f2edb7516)
## Checklist before requesting a review
![image](https://github.com/user-attachments/assets/7146ea82-1639-470c-9994-1aaa7bebce63)


- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
