### PR TITLE
fix: set height for implicit rows/columns

### DIFF
--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -32,7 +32,7 @@ export class EOxLayout extends HTMLElement {
         ${
           this.getAttribute("fill-grid") !== null
             ? `
-          grid-template-columns: repeat(auto-fill, minmax(0, var(--column-width, 300px)));
+          grid-template-columns: repeat(auto-fill, minmax(var(--column-width, 300px), 1fr));
           grid-template-rows: repeat(auto-fill, minmax(0, var(--row-height, 300px)));
           grid-auto-columns: var(--column-width, 300px);
           grid-auto-rows: var(--row-height, 300px);

--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -32,8 +32,10 @@ export class EOxLayout extends HTMLElement {
         ${
           this.getAttribute("fill-grid") !== null
             ? `
-          grid-template-columns: repeat(auto-fill, minmax(var(--column-width, 300px), 1fr));
-          grid-template-rows: repeat(auto-fill, minmax(var(--row-height, 300px), 1fr));
+          grid-template-columns: repeat(auto-fill, minmax(0, var(--column-width, 300px)));
+          grid-template-rows: repeat(auto-fill, minmax(0, var(--row-height, 300px)));
+          grid-auto-columns: var(--column-width, 300px);
+          grid-auto-rows: var(--row-height, 300px);
           `
             : `
           grid-template-columns: repeat(12, ${this.getAttribute("column-width") ? "var(--column-width)" : "minmax(0, var(--column-width))"});


### PR DESCRIPTION
## Implemented changes

This PR adds a height/width based on the provided CSS vars also for implicit rows & columns.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
