### PR TITLE
fix: transform external links to target "blank"

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -178,3 +178,21 @@ export async function parseProperty(property) {
   }
   return property;
 }
+
+/**
+ * Check all links in the form and set target="_blank" and rel="noopener noreferrer"
+ * for external ones
+ * 
+ @param {import("../main").EOxJSONForm} element - The eox-jsonform instance
+ */
+export const transformLinks = (element) => {
+  setTimeout(() => {
+    element.renderRoot.querySelectorAll("a").forEach((a) => {
+      if (a.getAttribute("href") === null) return;
+      if (a.getAttribute("href").startsWith("http")) {
+        a.setAttribute("target", "_blank");
+        a.setAttribute("rel", "noopener noreferrer");
+      }
+    });
+  });
+};

--- a/elements/jsonform/src/helpers/index.js
+++ b/elements/jsonform/src/helpers/index.js
@@ -1,1 +1,1 @@
-export { createEditor, parseProperty } from "./editor";
+export { createEditor, parseProperty, transformLinks } from "./editor";

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import { createEditor, parseProperty } from "./helpers";
+import { createEditor, parseProperty, transformLinks } from "./helpers";
 import { style } from "./style";
 import { styleEOX } from "./style.eox";
 import isEqual from "lodash.isequal";
@@ -179,6 +179,7 @@ export class EOxJSONForm extends LitElement {
         this.#dispatchEvent();
       }
     }
+    transformLinks(this);
   }
 
   /**


### PR DESCRIPTION
## Implemented changes

This PR forces all external links (starting with `http[...]`) to be opened in new tabs. JSONEditor uses DOM purify internally to purify HTML in titles and descriptions (see https://github.com/search?q=repo%3Ajson-editor%2Fjson-editor%20purify&type=code), but doesn't allow modifying the settings needed (see e.g. https://github.com/cure53/DOMPurify/issues/317#issuecomment-470429778). Therefore, we brute-force all links to external ones, independent of what the form creator has set as link target.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
