### PR TITLE
fix: check if parentElement exists before rendering

### DIFF
--- a/elements/layout/src/main.js
+++ b/elements/layout/src/main.js
@@ -63,7 +63,17 @@ export class EOxLayoutItem extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
-    this.render();
+
+    // Check if the parent element is already defined
+    // since in Vue.js the parent element is not defined initially
+    // and the render function is called before the parent element is ready
+    if (!this.parentElement) {
+      setTimeout(() => {
+        this.render();
+      });
+    } else {
+      this.render();
+    }
   }
   render() {
     // Check if attribute includes "/" for "s/m/l", if not return original


### PR DESCRIPTION
## Implemented changes

In Vue.js (and potentially other frameworks that rely on virtual DOM), initially `parentElement` is `null` for the `eox-layout-item`, causing the layout to break on first render (subsequent updates were working correctly).

This PR introduces a check if `parentElement` is defined, and if not, triggers the rendering only after one tick (after a `setTimeout`).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
