### PR TITLE
fix: add possibility to pass step to minmax custom filter

### DIFF
--- a/elements/jsonform/src/custom-inputs/minmax.js
+++ b/elements/jsonform/src/custom-inputs/minmax.js
@@ -59,6 +59,8 @@ export class MinMaxEditor extends AbstractEditor {
     const attributes = {
       min: properties[minKey].minimum,
       max: properties[maxKey].maximum,
+      // only positive integer supported
+      step: properties[minKey].step || properties[maxKey].step,
       value1: startVals?.[minKey] || properties[minKey].default,
       value2: startVals?.[maxKey] || properties[maxKey].default,
       "slider-bg-fill": "#004170",

--- a/elements/jsonform/stories/public/basicSchema.json
+++ b/elements/jsonform/stories/public/basicSchema.json
@@ -7,12 +7,14 @@
         "vmin": {
           "type": "number",
           "minimum": 0,
+          "step": 2,
           "maximum": 10,
           "format": "range"
         },
         "vmax": {
           "type": "number",
           "minimum": 0,
+          "step": 2,
           "maximum": 10,
           "format": "range"
         }


### PR DESCRIPTION
## Implemented changes

added passing of step to the minmax custom input for jsonform (only possitive integer input allowed in downstream library)

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/71b22646-f699-422e-a74f-a7e3185b69c8)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] For new features: I have updated existing story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
