### PR TITLE
Fix: Mirror selection interaction changes to json layers

### DIFF
--- a/elements/drawtools/src/methods/draw/on-draw-end.js
+++ b/elements/drawtools/src/methods/draw/on-draw-end.js
@@ -22,6 +22,9 @@ const onDrawEndMethod = (EoxDrawTool) => {
           const features = EoxDrawTool.drawLayer.getSource().getFeatures();
           const latest = features.at(-1);
           EoxDrawTool.drawLayer.getSource().clear();
+          if (!latest) {
+            return;
+          }
           EoxDrawTool.drawLayer.getSource().addFeature(latest);
           EoxDrawTool.drawnFeatures = [latest];
         }

--- a/elements/drawtools/stories/multi-feature-select.js
+++ b/elements/drawtools/stories/multi-feature-select.js
@@ -23,27 +23,22 @@ export const MuliFeatureSelect = {
         "stroke-color": "#19B806",
         "stroke-width": 2.5,
       },
-      click: {
-        "fill-color": "#1FD609A0",
-        "stroke-color": "#1FD609",
-        "stroke-width": 2.5,
-      },
     },
     drawUpdate: (e) => {
       console.log("drawUpdate:", e.detail);
     },
   },
   render: (args) => html`
-    <!-- Render eox-map component with ID "primary" -->
+    <!-- Render eox-map component with ID "multi-select" -->
     <eox-map
-      id="primary"
+      id="multi-select"
       style=${STORIES_MAP_STYLE}
       .layers=${STORIES_VECTOR_LAYERS}
     ></eox-map>
 
-    <!-- Initialize eox-drawtools for the eox-map with ID "primary" -->
+    <!-- Initialize eox-drawtools for the eox-map with ID "multi-select" -->
     <eox-drawtools
-      for="eox-map#primary"
+      for="eox-map#multi-select"
       .allowModify=${args.allowModify}
       .multipleFeatures=${args.multipleFeatures}
       .type=${args.type}

--- a/elements/drawtools/stories/select-feature.js
+++ b/elements/drawtools/stories/select-feature.js
@@ -14,16 +14,16 @@ export const SelectFeature = {
     },
   },
   render: (args) => html`
-    <!-- Render eox-map component with ID "primary" -->
+    <!-- Render eox-map component with ID "select" -->
     <eox-map
-      id="primary"
+      id="select"
       style=${STORIES_MAP_STYLE}
       .layers=${STORIES_VECTOR_LAYERS}
     ></eox-map>
 
-    <!-- Initialize eox-drawtools for the eox-map with ID "primary" -->
+    <!-- Initialize eox-drawtools for the eox-map with ID "select" -->
     <eox-drawtools
-      for="eox-map#primary"
+      for="eox-map#select"
       .multipleFeatures=${args.multipleFeatures}
       .type=${args.type}
       layer-id=${args.layerId}


### PR DESCRIPTION
## Implemented changes
This PR addresses the issue of losing the select interactions when users of `eox-map` update the json layer with the `layerId` passed to the drawtools. This PR mirrors the interactions to `EOxMap.layers` making up to the user to either reuse the interactions from there or remove it. Further more, there are minor error handling fixes.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
