### PR TITLE
chore: Revert "chore(deps): bump the vega group with 3 updates (#1646)"

### DIFF
--- a/elements/chart/package.json
+++ b/elements/chart/package.json
@@ -36,8 +36,8 @@
     "@eox/elements-utils": "^0.1.5",
     "deepmerge-ts": "^7.1.3",
     "lit": "^3.2.0",
-    "vega": "^6.1.2",
-    "vega-embed": "^7.0.2",
-    "vega-lite": "^6.1.0"
+    "vega": "^5.30.0",
+    "vega-embed": "^6.26.0",
+    "vega-lite": "^5.21.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
         "@eox/elements-utils": "^0.1.5",
         "deepmerge-ts": "^7.1.3",
         "lit": "^3.2.0",
-        "vega": "^6.1.2",
-        "vega-embed": "^7.0.2",
-        "vega-lite": "^6.1.0"
+        "vega": "^5.30.0",
+        "vega-embed": "^6.26.0",
+        "vega-lite": "^5.21.0"
       },
       "devDependencies": {
         "vite": "^6.0.3"
@@ -3888,13 +3888,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.40.0",
@@ -7247,15 +7245,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -8056,29 +8045,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -8283,18 +8249,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fromentries": {
@@ -10107,42 +10061,46 @@
         "path-to-regexp": "^6.2.1"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
+        "whatwg-url": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "4.x || >=6.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-preload": {
@@ -13012,99 +12970,91 @@
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/vega": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-6.1.2.tgz",
-      "integrity": "sha512-d5GT7wRoRnK+bsQWgauOHyPFY4td52PTuX5IzMXr9PXHkz2OKXpVti7LeK5evAoyhNxVenkT1ptpRQKU2MRJdw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.0.tgz",
+      "integrity": "sha512-jNAGa7TxLojOpMMMrKMXXBos4K6AaLJbCgGDOw1YEkLRjUkh12pcf65J2lMSdEHjcEK47XXjKiOUVZ8L+MniBA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-crossfilter": "~5.0.0",
-        "vega-dataflow": "~6.0.0",
-        "vega-encode": "~5.0.0",
-        "vega-event-selector": "~4.0.0",
-        "vega-expression": "~6.0.0",
-        "vega-force": "~5.0.0",
-        "vega-format": "~2.0.0",
-        "vega-functions": "~6.0.0",
-        "vega-geo": "~5.0.0",
-        "vega-hierarchy": "~5.0.0",
-        "vega-label": "~2.0.0",
-        "vega-loader": "~5.0.0",
-        "vega-parser": "~7.0.0",
-        "vega-projection": "~2.0.0",
-        "vega-regression": "~2.0.0",
-        "vega-runtime": "~7.0.0",
-        "vega-scale": "~8.0.0",
-        "vega-scenegraph": "~5.0.0",
-        "vega-statistics": "~2.0.0",
-        "vega-time": "~3.0.0",
-        "vega-transforms": "~5.0.0",
-        "vega-typings": "~2.0.0",
-        "vega-util": "~2.0.0",
-        "vega-view": "~6.0.0",
-        "vega-view-transforms": "~5.0.0",
-        "vega-voronoi": "~5.0.0",
-        "vega-wordcloud": "~5.0.0"
-      },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+        "vega-crossfilter": "~4.1.3",
+        "vega-dataflow": "~5.7.7",
+        "vega-encode": "~4.10.2",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.2.0",
+        "vega-force": "~4.2.2",
+        "vega-format": "~1.1.3",
+        "vega-functions": "~5.18.0",
+        "vega-geo": "~4.4.3",
+        "vega-hierarchy": "~4.1.3",
+        "vega-label": "~1.3.1",
+        "vega-loader": "~4.5.3",
+        "vega-parser": "~6.6.0",
+        "vega-projection": "~1.6.2",
+        "vega-regression": "~1.3.1",
+        "vega-runtime": "~6.2.1",
+        "vega-scale": "~7.4.2",
+        "vega-scenegraph": "~4.13.1",
+        "vega-statistics": "~1.9.0",
+        "vega-time": "~2.1.3",
+        "vega-transforms": "~4.12.1",
+        "vega-typings": "~1.5.0",
+        "vega-util": "~1.17.2",
+        "vega-view": "~5.16.0",
+        "vega-view-transforms": "~4.6.1",
+        "vega-voronoi": "~4.2.4",
+        "vega-wordcloud": "~4.1.6"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
-      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-crossfilter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.0.0.tgz",
-      "integrity": "sha512-9PnDXpoLY4rWBubTjtAxEmEdSLq4pg1OyyucugnGNX6HsaAuF5fXYmXdpe4UB4SMMHMnWM3ZBA2wkkycct11sQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.3.tgz",
+      "integrity": "sha512-nyPJAXAUABc3EocUXvAL1J/IWotZVsApIcvOeZaUdEQEtZ7bt8VtP2nj3CLbHBA8FZZVV+K6SmdwvCOaAD4wFQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.0.0",
-        "vega-util": "^2.0.0"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.0.0.tgz",
-      "integrity": "sha512-/6Cl06lqTPDiGwwRgRJ6osAy/qwgeelwK4+tZ4QS/aNJhoEAJU5xPXuWl6U0trabUT2Pe0+Qpo1+/u0oAOmmCg==",
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.7.tgz",
+      "integrity": "sha512-R2NX2HvgXL+u4E6u+L5lKvvRiCtnE6N6l+umgojfi53suhhkFP+zB+2UAQo4syxuZ4763H1csfkKc4xpqLzKnw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-format": "^2.0.0",
-        "vega-loader": "^5.0.0",
-        "vega-util": "^2.0.0"
+        "vega-format": "^1.1.3",
+        "vega-loader": "^4.5.3",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-embed": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.0.2.tgz",
-      "integrity": "sha512-ZHQPWSs9mUTGJPZ5yQVhHV+OLDCoTIjR//De93vG6igZX1MQCVo03ePWlfWCUAnPV1IsKfeJLqA3K/Qd11bAFQ==",
-      "license": "BSD-3-Clause",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.29.0.tgz",
+      "integrity": "sha512-PmlshTLtLFLgWtF/b23T1OwX53AugJ9RZ3qPE2c01VFAbgt3/GSNI/etzA/GzdrkceXFma+FDHNXUppKuM0U6Q==",
       "dependencies": {
         "fast-json-patch": "^3.1.1",
         "json-stringify-pretty-compact": "^4.0.0",
-        "semver": "^7.7.1",
+        "semver": "^7.6.3",
         "tslib": "^2.8.1",
-        "vega-interpreter": "^2.0.0",
-        "vega-schema-url-parser": "^3.0.2",
-        "vega-themes": "3.0.0",
-        "vega-tooltip": "1.0.0"
-      },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+        "vega-interpreter": "^1.0.5",
+        "vega-schema-url-parser": "^2.2.0",
+        "vega-themes": "^2.15.0",
+        "vega-tooltip": "^0.35.2"
       },
       "peerDependencies": {
-        "vega": "*",
+        "vega": "^5.21.0",
         "vega-lite": "*"
       }
     },
     "node_modules/vega-embed/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -13113,136 +13063,140 @@
       }
     },
     "node_modules/vega-encode": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.0.0.tgz",
-      "integrity": "sha512-3YdnCGDMNppicdzyaawP1fYYyJhMUMREwgQmQvF//NFRMY3bzI59Rjhq4v+tIMXXSvnTztJ1Chm9eSvZGiNs+g==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.2.tgz",
+      "integrity": "sha512-fsjEY1VaBAmqwt7Jlpz0dpPtfQFiBdP9igEefvumSpy7XUxOJmDQcRDnT3Qh9ctkv3itfPfI9g8FSnGcv2b4jQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^6.0.0",
-        "vega-scale": "^8.0.0",
-        "vega-util": "^2.0.0"
+        "vega-dataflow": "^5.7.7",
+        "vega-scale": "^7.4.2",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
-      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
-      "license": "BSD-3-Clause"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "node_modules/vega-expression": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.0.0.tgz",
-      "integrity": "sha512-aw6hGpTSiakAe5KqCsnpXNsBgN823IMq84x2Gg1pJj+H6zxlEfN4FCibPAC0PYWOmSvCRUoXMr7b/wWiwsiPIg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.2.tgz",
+      "integrity": "sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.6",
-        "vega-util": "^2.0.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-force": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.0.0.tgz",
-      "integrity": "sha512-j3HNCrngjuFvOmBl2gg2NNgDys5q6i+v6pliIt9grSAcgzStNNuxcVp+OjNeWP4NSa0Hc7efEGmYvmBqTP/HpQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.2.tgz",
+      "integrity": "sha512-cHZVaY2VNNIG2RyihhSiWniPd2W9R9kJq0znxzV602CgUVgxEfTKtx/lxnVCn8nNrdKAYrGiqIsBzIeKG1GWHw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^6.0.0",
-        "vega-util": "^2.0.0"
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.0.0.tgz",
-      "integrity": "sha512-RrMI/HedVEb4PDFyiNjzbJtOLt/H7aan1Fs3sQQamOdSAj5gcq6r9IavzKy7dC4XaovEjdStJL6JSAfTW53CiQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.3.tgz",
+      "integrity": "sha512-wQhw7KR46wKJAip28FF/CicW+oiJaPAwMKdrxlnTA0Nv8Bf7bloRlc+O3kON4b4H1iALLr9KgRcYTOeXNs2MOA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^3.0.0",
-        "vega-util": "^2.0.0"
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-functions": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.0.0.tgz",
-      "integrity": "sha512-1Qy7VOUIa3GzbfLXYYpTDPQMyJVV27a7U8xCqXtMPozXQo4cKQRb/OKAqMk7A/0eCTs3E08pc41kFa/tYSOIag==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.0.tgz",
+      "integrity": "sha512-+D+ey4bDAhZA2CChh7bRZrcqRUDevv05kd2z8xH+il7PbYQLrhi6g1zwvf8z3KpgGInFf5O13WuFK5DQGkz5lQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "vega-dataflow": "^6.0.0",
-        "vega-expression": "^6.0.0",
-        "vega-scale": "^8.0.0",
-        "vega-scenegraph": "^5.0.0",
-        "vega-selections": "^6.0.0",
-        "vega-statistics": "^2.0.0",
-        "vega-time": "^3.0.0",
-        "vega-util": "^2.0.0"
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.7",
+        "vega-expression": "^5.2.0",
+        "vega-scale": "^7.4.2",
+        "vega-scenegraph": "^4.13.1",
+        "vega-selections": "^5.6.0",
+        "vega-statistics": "^1.9.0",
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-functions/node_modules/vega-expression": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.0.tgz",
+      "integrity": "sha512-WRMa4ny3iZIVAzDlBh3ipY2QUuLk2hnJJbfbncPgvTF7BUgbIbKq947z+JicWksYbokl8n1JHXJoqi3XvpG0Zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-geo": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.0.0.tgz",
-      "integrity": "sha512-cr7Tjktgq0cuYwqhz5Mak6tv7BeaRBz1HaojNLJxJzQtNw1oBdT8gXxSYN1PA61OExHP2mG8GZRF+XdjbnN3LQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.3.tgz",
+      "integrity": "sha512-+WnnzEPKIU1/xTFUK3EMu2htN35gp9usNZcC0ZFg2up1/Vqu6JyZsX0PIO51oXSIeXn9bwk6VgzlOmJUcx92tA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.0.0",
-        "vega-projection": "^2.0.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.0.0"
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.7",
+        "vega-projection": "^1.6.2",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.0.0.tgz",
-      "integrity": "sha512-W2nVICp5946eG5zf5jenHo4Q+LBcYmDQjFt7/7HyRzvZT8IIdhBEuotb2MwmgJ9GeOsmt/DRb53DNZbXMSB9ww==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.3.tgz",
+      "integrity": "sha512-0Z+TYKRgOEo8XYXnJc2HWg1EGpcbNAhJ9Wpi9ubIbEyEHqIgjCIyFVN8d4nSfsJOcWDzsSmRqohBztxAhOCSaw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-hierarchy": "^3.1.2",
-        "vega-dataflow": "^6.0.0",
-        "vega-util": "^2.0.0"
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-interpreter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.0.0.tgz",
-      "integrity": "sha512-ZjA7AC+xjfi4k9vgA49N5F/bS4fzf9E1KC0ljey4uMgHbmtKR53BWyOOzxHk+btfS9bEJ5gUvuoZzfqG3wIWEg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "vega-util": "^2.0.0"
-      }
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.0.5.tgz",
+      "integrity": "sha512-po6oTOmeQqr1tzTCdD15tYxAQLeUnOVirAysgVEemzl+vfmvcEP7jQmlc51jz0jMA+WsbmE6oJywisQPu/H0Bg=="
     },
     "node_modules/vega-label": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.0.0.tgz",
-      "integrity": "sha512-e+JIojHNiEcI/4jFoOLhtocbqoQzJqurZwyP3lFgV7nJOQPOZSZYiEUOUhbhYuMgnhz0HDBe3GDqSAeo1yUhfw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.1.tgz",
+      "integrity": "sha512-Emx4b5s7pvuRj3fBkAJ/E2snCoZACfKAwxVId7f/4kYVlAYLb5Swq6W8KZHrH4M9Qds1XJRUYW9/Y3cceqzEFA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.0.0",
-        "vega-scenegraph": "^5.0.0",
-        "vega-util": "^2.0.0"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.7",
+        "vega-scenegraph": "^4.13.1",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-lite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.1.0.tgz",
-      "integrity": "sha512-SgL/s0Ddoq2Do0GFd9pOMtJmWW1YOjht98v/fixnpnWi+7hijWRha1tAziDeQLOBwsv5NmjzrJXpYhedRAbv2A==",
-      "license": "BSD-3-Clause",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.23.0.tgz",
+      "integrity": "sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==",
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",
-        "vega-event-selector": "~4.0.0",
-        "vega-expression": "~6.0.0",
-        "vega-util": "~2.0.0",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.1.1",
+        "vega-util": "~1.17.2",
         "yargs": "~17.7.2"
       },
       "bin": {
@@ -13254,242 +13208,269 @@
       "engines": {
         "node": ">=18"
       },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
-      },
       "peerDependencies": {
-        "vega": "^6.0.0"
+        "vega": "^5.24.0"
       }
     },
     "node_modules/vega-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.0.0.tgz",
-      "integrity": "sha512-THLOtcbL0gQjv3GunKWutUiELdLc74nQOfIWNL/kx2qXtM2kYhE5FcCKQNTA9aZzklY3oN8Bt4siJ22ugO0WyA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.3.tgz",
+      "integrity": "sha512-dUfIpxTLF2magoMaur+jXGvwMxjtdlDZaIS8lFj6N7IhUST6nIvBzuUlRM+zLYepI5GHtCLOnqdKU4XV0NggCA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-dsv": "^3.0.1",
-        "node-fetch": "^3.3.2",
+        "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^2.0.0",
-        "vega-util": "^2.0.0"
+        "vega-format": "^1.1.3",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.0.0.tgz",
-      "integrity": "sha512-820pladvhez0SQBZ8Yohou0fpWd4Vl+AbekGG0eu+mh2BhjJmIDaNC/5j/5sZ/A+ufHO2GPCAt4DSiM/X2jWqg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.0.tgz",
+      "integrity": "sha512-jltyrwCTtWeidi/6VotLCybhIl+ehwnzvFWYOdWNUP0z/EskdB64YmawNwjCjzTBMemeiQtY6sJPPbewYqe3Vg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^6.0.0",
-        "vega-event-selector": "^4.0.0",
-        "vega-functions": "^6.0.0",
-        "vega-scale": "^8.0.0",
-        "vega-util": "^2.0.0"
+        "vega-dataflow": "^5.7.7",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.18.0",
+        "vega-scale": "^7.4.2",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-projection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.0.0.tgz",
-      "integrity": "sha512-oeNTNKD5iwDImiSTjNqxGrDGACxVmF+1XWxKgplgHsnoB0k4wtcGm0Lc6cZ0rwC6zyJ/4WRVxjUeOVGKpNCpxA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.2.tgz",
+      "integrity": "sha512-3pcVaQL9R3Zfk6PzopLX6awzrQUeYOXJzlfLGP2Xd93mqUepBa6m/reVrTUoSFXA3v9lfK4W/PS2AcVzD/MIcQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-geo": "^3.1.1",
+        "d3-geo": "^3.1.0",
         "d3-geo-projection": "^4.0.0",
-        "vega-scale": "^8.0.0"
+        "vega-scale": "^7.4.2"
       }
     },
     "node_modules/vega-regression": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.0.0.tgz",
-      "integrity": "sha512-0OW2+Pp0VQJXkNxpI+a3b3kUdqJacbmHoOKl0frGYtrJzB4GsebBsdd7N2WSztrzPh5cP3oHaYJeQSHgj9P9xw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.1.tgz",
+      "integrity": "sha512-AmccF++Z9uw4HNZC/gmkQGe6JsRxTG/R4QpbcSepyMvQN1Rj5KtVqMcmVFP1r3ivM4dYGFuPlzMWvuqp0iKMkQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.0.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.0.0"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.0.0.tgz",
-      "integrity": "sha512-bFMqxaYwOYVoXIjI3GCZstgjoXI3lvjtRSKMN3n8ASVGbakiGjtUPRcpueYQqrpGFXR8UoQcGeXtIyyHRC68mw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.1.tgz",
+      "integrity": "sha512-b4eot3tWKCk++INWqot+6sLn3wDTj/HE+tRSbiaf8aecuniPMlwJEK7wWuhVGeW2Ae5n8fI/8TeTViaC94bNHA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^6.0.0",
-        "vega-util": "^2.0.0"
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-scale": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.0.0.tgz",
-      "integrity": "sha512-9jEVbxi7NXVYYF2l+2PB2UcvAX/RxBMzOam7afP+68w2DeGJz43AF/8NGc9tjZZAE5SYTERotxKki31PkAPOFg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.2.tgz",
+      "integrity": "sha512-o6Hl76aU1jlCK7Q8DPYZ8OGsp4PtzLdzI6nGpLt8rxoE78QuB3GBGEwGAQJitp4IF7Lb2rL5oAXEl3ZP6xf9jg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
-        "vega-time": "^3.0.0",
-        "vega-util": "^2.0.0"
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.0.0.tgz",
-      "integrity": "sha512-BkE4n+mgMpEcHF2EKo+27Sjso0x/zPqgZjoP5dngjSkeyJqKfyxi93lDEJNylWBJqcyjNEmOrAkQQi3B4RNtKA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.1.tgz",
+      "integrity": "sha512-LFY9+sLIxRfdDI9ZTKjLoijMkIAzPLBWHpPkwv4NPYgdyx+0qFmv+puBpAUGUY9VZqAZ736Uj5NJY9zw+/M3yQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-path": "^3.1.0",
         "d3-shape": "^3.2.0",
-        "vega-canvas": "^2.0.0",
-        "vega-loader": "^5.0.0",
-        "vega-scale": "^8.0.0",
-        "vega-util": "^2.0.0"
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.3",
+        "vega-scale": "^7.4.2",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-schema-url-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
-      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
-      "license": "BSD-3-Clause"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
+      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw=="
     },
     "node_modules/vega-selections": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.0.0.tgz",
-      "integrity": "sha512-ig2NHIV+ZWeQJAD3T+cIJ13qM583an7NvHaDkmuOPPIRvtnrO9CbXCqQ84yHhLrJSzxLwO2h8ExSGkoOmzPUaw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.0.tgz",
+      "integrity": "sha512-UE2w78rUUbaV3Ph+vQbQDwh8eywIJYRxBiZdxEG/Tr/KtFMLdy2BDgNZuuDO1Nv8jImPJwONmqjNhNDYwM0VJQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "3.2.4",
-        "vega-expression": "^6.0.0",
-        "vega-util": "^2.0.0"
+        "vega-expression": "^5.2.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-selections/node_modules/vega-expression": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.0.tgz",
+      "integrity": "sha512-WRMa4ny3iZIVAzDlBh3ipY2QUuLk2hnJJbfbncPgvTF7BUgbIbKq947z+JicWksYbokl8n1JHXJoqi3XvpG0Zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-statistics": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
-      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4"
+        "d3-array": "^3.2.2"
       }
     },
     "node_modules/vega-themes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
-      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
-      "license": "BSD-3-Clause",
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
-      },
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
+      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
       "peerDependencies": {
         "vega": "*",
         "vega-lite": "*"
       }
     },
     "node_modules/vega-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.0.0.tgz",
-      "integrity": "sha512-Ifs95YXaQ6/3NCJ7l9jdda74uovwLodUHFYQqqXPanjUtF9e5juw4/VurbgIPYnB76w4ye6/q19OdlUeUdVQuw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.3.tgz",
+      "integrity": "sha512-hFcWPdTV844IiY0m97+WUoMLADCp+8yUQR1NStWhzBzwDDA7QEGGwYGxALhdMOaDTwkyoNj3V/nox2rQAJD/vQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-time": "^3.1.0",
-        "vega-util": "^2.0.0"
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-tooltip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
-      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
-      "license": "BSD-3-Clause",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.35.2.tgz",
+      "integrity": "sha512-kuYcsAAKYn39ye5wKf2fq1BAxVcjoz0alvKp/G+7BWfIb94J0PHmwrJ5+okGefeStZnbXxINZEOKo7INHaj9GA==",
       "dependencies": {
-        "vega-util": "^2.0.0"
+        "vega-util": "^1.17.2"
       },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.24.4"
       }
     },
     "node_modules/vega-transforms": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.0.0.tgz",
-      "integrity": "sha512-a4fo0tlfZFE1C/aV+IpEEl/SAyz9JnVqYCxcEeuQm6byglCz+PnjZmnqFyKFBnmVHDjQ/GP82DkqGBx52Cr0Kg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.1.tgz",
+      "integrity": "sha512-Qxo+xeEEftY1jYyKgzOGc9NuW4/MqGm1YPZ5WrL9eXg2G0410Ne+xL/MFIjHF4hRX+3mgFF4Io2hPpfy/thjLg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.0.0",
-        "vega-statistics": "^2.0.0",
-        "vega-time": "^3.0.0",
-        "vega-util": "^2.0.0"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-statistics": "^1.9.0",
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-typings": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.0.1.tgz",
-      "integrity": "sha512-Jfw2zeAv4rQ8YqfgBae3QauK0T9FUpQ+0q3NNLW24Z6nyjf8H2ucnyLhw6pIqfVytne6VB4WkvazTOgJPuv5vw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.0.tgz",
+      "integrity": "sha512-tcZ2HwmiQEOXIGyBMP8sdCnoFoVqHn4KQ4H0MQiHwzFU1hb1EXURhfc+Uamthewk4h/9BICtAM3AFQMjBGpjQA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/geojson": "7946.0.16",
-        "vega-event-selector": "^4.0.0",
-        "vega-expression": "^6.0.0",
-        "vega-util": "^2.0.0"
+        "@types/geojson": "7946.0.4",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.2.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-typings/node_modules/@types/geojson": {
+      "version": "7946.0.4",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
+      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
+      "license": "MIT"
+    },
+    "node_modules/vega-typings/node_modules/vega-expression": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.0.tgz",
+      "integrity": "sha512-WRMa4ny3iZIVAzDlBh3ipY2QUuLk2hnJJbfbncPgvTF7BUgbIbKq947z+JicWksYbokl8n1JHXJoqi3XvpG0Zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-util": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
-      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.3.tgz",
+      "integrity": "sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.0.0.tgz",
-      "integrity": "sha512-Q4bS6eEt+d8N1ZKGg/jueEFboR1CGO8olye7vz3gS/iyg4fPDwMx0sh4pDiX077OPD3UW/0NbplIiHwzQyabEg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.0.tgz",
+      "integrity": "sha512-Nxp1MEAY+8bphIm+7BeGFzWPoJnX9+hgvze6wqCAPoM69YiyVR0o0VK8M2EESIL+22+Owr0Fdy94hWHnmon5tQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^6.0.0",
-        "vega-format": "^2.0.0",
-        "vega-functions": "^6.0.0",
-        "vega-runtime": "^7.0.0",
-        "vega-scenegraph": "^5.0.0",
-        "vega-util": "^2.0.0"
+        "vega-dataflow": "^5.7.7",
+        "vega-format": "^1.1.3",
+        "vega-functions": "^5.18.0",
+        "vega-runtime": "^6.2.1",
+        "vega-scenegraph": "^4.13.1",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.0.0.tgz",
-      "integrity": "sha512-AqQStHIYZtjsm84rx43z6P18DdR4/l20q/mfWXJ2Ifts1T2gPshC24/0xUfGrnwpqM5m3X1HwkJUiyEJxzVQrQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.1.tgz",
+      "integrity": "sha512-RYlyMJu5kZV4XXjmyTQKADJWDB25SMHsiF+B1rbE1p+pmdQPlp5tGdPl9r5dUJOp3p8mSt/NGI8GPGucmPMxtw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^6.0.0",
-        "vega-scenegraph": "^5.0.0",
-        "vega-util": "^2.0.0"
+        "vega-dataflow": "^5.7.7",
+        "vega-scenegraph": "^4.13.1",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.0.0.tgz",
-      "integrity": "sha512-mmsQFo7Aj8WM/QS8Ta79QWxADU3WpvEQ0OIR20WFgY/QLJ+42FEcJkBlaSQQ+DFl2Ci5PdbpZtRFMPJoRokFMw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.4.tgz",
+      "integrity": "sha512-lWNimgJAXGeRFu2Pz8axOUqVf1moYhD+5yhBzDSmckE9I5jLOyZc/XvgFTXwFnsVkMd1QW1vxJa+y9yfUblzYw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-delaunay": "^6.0.4",
-        "vega-dataflow": "^6.0.0",
-        "vega-util": "^2.0.0"
+        "d3-delaunay": "^6.0.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.0.0.tgz",
-      "integrity": "sha512-Rm46D1ginGdunWLtsiymllU5RvJTEtpKRaWcc/pABpFiz7QHGGrZ9FhOczxW1o3n89h07gzc9n8xlWYco06Fdw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.6.tgz",
+      "integrity": "sha512-lFmF3u9/ozU0P+WqPjeThQfZm0PigdbXDwpIUCxczrCXKYJLYFmZuZLZR7cxtmpZ0/yuvRvAJ4g123LXbSZF8A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.0.0",
-        "vega-scale": "^8.0.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.0.0"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.7",
+        "vega-scale": "^7.4.2",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega/node_modules/vega-expression": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.0.tgz",
+      "integrity": "sha512-WRMa4ny3iZIVAzDlBh3ipY2QUuLk2hnJJbfbncPgvTF7BUgbIbKq947z+JicWksYbokl8n1JHXJoqi3XvpG0Zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.3"
       }
     },
     "node_modules/verror": {
@@ -13855,15 +13836,6 @@
       },
       "optionalDependencies": {
         "@zxing/text-encoding": "0.9.0"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/web-worker": {


### PR DESCRIPTION
This reverts commit 9ffa851c4117e658ab7c874fa6ed0a3152e14125.

## Implemented changes

This PR reverts the updates of the vega group since it was causing issues with typescript (see https://github.com/EOX-A/EOxElements/pull/1694)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
