### PR TITLE
Fix: Prevent redundant `min/max` zoom setting when the current `min/max` zoom level is already the same

### DIFF
--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -261,7 +261,10 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
   if (newLayerDefinition.visible !== existingJsonDefinition.visible) {
     existingLayer.setVisible(newLayerDefinition.visible);
   }
-  if (newLayerDefinition.opacity !== existingJsonDefinition.opacity) {
+  if (
+    newLayerDefinition.opacity &&
+    newLayerDefinition.opacity !== existingJsonDefinition.opacity
+  ) {
     existingLayer.setOpacity(newLayerDefinition.opacity);
   }
 

--- a/elements/map/src/methods/map/setters.js
+++ b/elements/map/src/methods/map/setters.js
@@ -230,9 +230,17 @@ export function setLayersMethod(layers, oldLayers, EOxMap) {
     .getLayers()
     .getArray()
     .map((layer) => layer.setMinZoom(layer.get("minZoom") - 1e-12));
-  // set the min/max zoom of the scene accordingly
-  EOxMap.map.getView().setMaxZoom(minMax.maxZoom);
-  EOxMap.map.getView().setMinZoom(minMax.minZoom >= 0 ? minMax.minZoom : 0);
+
+  const currentMinZoom = EOxMap.map.getView().getMinZoom();
+  const currentMaxZoom = EOxMap.map.getView().getMaxZoom();
+
+  // set the min zoom of the scene accordingly
+  if (currentMinZoom !== minMax.minZoom)
+    EOxMap.map.getView().setMinZoom(minMax.minZoom >= 0 ? minMax.minZoom : 0);
+
+  // set the max zoom of the scene accordingly
+  if (currentMaxZoom !== minMax.maxZoom)
+    EOxMap.map.getView().setMaxZoom(minMax.maxZoom);
 
   // disable zoom in/out when the max/min zoom level is reached
   EOxMap.map.on("moveend", () => {


### PR DESCRIPTION
## Implemented changes
- Prevent reduntant `min/max` zoom level when the current value is already the same and which was causing some weird setting issue in `storytelling`
- And one minor `null` check in opacity setter

### The issue occurred due to the  merging of PR #1633 
- https://github.com/EOX-A/EOxElements/pull/1633

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/user-attachments/assets/486134d6-0d1b-40ba-b21f-584e572852ea



<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
