### PR TITLE
Feat: Show selected feature title from some property value 

### DIFF
--- a/elements/drawtools/src/components/list.js
+++ b/elements/drawtools/src/components/list.js
@@ -177,7 +177,7 @@ export class EOxDrawToolsList extends LitElement {
           const propertyName = feature.get(this.featureNameKey);
           const title = propertyName
             ? propertyName
-            : `${this.featureName || "Feature"} ${featureNumber}`;
+            : `${this.featureName} ${featureNumber}`;
 
           return keyed(
             featureNumber,

--- a/elements/drawtools/src/components/list.js
+++ b/elements/drawtools/src/components/list.js
@@ -22,6 +22,7 @@ export class EOxDrawToolsList extends LitElement {
     drawLayer: { attribute: false, state: true },
     drawnFeatures: { attribute: false, state: true, type: Array },
     featureName: { attribute: false, state: true, type: String },
+    featureNameKey: { attribute: false, state: true, type: String },
     modify: { attribute: false, state: true },
     unstyled: { type: Boolean },
   };
@@ -90,6 +91,11 @@ export class EOxDrawToolsList extends LitElement {
      * Default display name for features
      */
     this.featureName = "Feature";
+
+    /**
+     * The key of the property to display in the feature list.
+     */
+    this.featureNameKey = null;
 
     /**
      * The current native OpenLayers `modify` interaction
@@ -168,6 +174,10 @@ export class EOxDrawToolsList extends LitElement {
           const isFeatureClicked = this.clickId === featureId;
           const isSelected = isFeatureHovered || isFeatureClicked;
           const selectionClass = isSelected ? "selected" : nothing;
+          const propertyName = feature.get(this.featureNameKey);
+          const title = propertyName
+            ? propertyName
+            : `${this.featureName || "Feature"} ${featureNumber}`;
 
           return keyed(
             featureNumber,
@@ -182,9 +192,7 @@ export class EOxDrawToolsList extends LitElement {
                   @click="${() =>
                     this._handleFeatureSelectAndDeselect(feature)}"
                 >
-                  <span class="title"
-                    >${this.featureName} ${featureNumber}</span
-                  >
+                  <span class="title">${title}</span>
                   <button
                     index=${i}
                     data-cy="deleteFeatureBtn"

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -34,6 +34,7 @@ export class EOxDrawTools extends LitElement {
       drawLayer: { attribute: false, state: true },
       drawnFeatures: { attribute: false, state: true, type: Array },
       featureName: { attribute: "feature-name", type: String },
+      featureNameKey: { attribute: "feature-name-key", type: String },
       layerId: { attribute: "layer-id", type: String },
       featureStyles: { attribute: false },
       modify: { attribute: false, state: true },
@@ -122,6 +123,11 @@ export class EOxDrawTools extends LitElement {
      * The display name of drawn features, shown e.g. in the feature list.
      */
     this.featureName = "Feature";
+
+    /**
+     * The key of the property to display in the feature list.
+     */
+    this.featureNameKey = null;
 
     /**
      * Flat styles for the drawn/selected features
@@ -383,6 +389,7 @@ export class EOxDrawTools extends LitElement {
             .drawLayer=${this.drawLayer}
             .drawnFeatures=${this.drawnFeatures}
             .featureName=${this.featureName}
+            .featureNameKey=${this.featureNameKey}
             .modify=${this.modify}
             .unstyled=${this.unstyled}
             @changed=${() => {

--- a/elements/drawtools/stories/multi-feature-select.js
+++ b/elements/drawtools/stories/multi-feature-select.js
@@ -11,7 +11,8 @@ export const MuliFeatureSelect = {
     type: "Box",
     layerId: "regions",
     showList: true,
-    featureName: "Selection",
+    featureName: "Region",
+    featureNameKey: "ECO_NAME",
     featureStyles: {
       layer: {
         "fill-color": "#16A105A0",
@@ -46,6 +47,7 @@ export const MuliFeatureSelect = {
       ?show-list=${args.showList}
       .featureStyles=${args.featureStyles}
       .featureName=${args.featureName}
+      .featureNameKey=${args.featureNameKey}
       @drawupdate=${args.drawUpdate}
     />
   `,

--- a/elements/drawtools/test/cases/feature-list.js
+++ b/elements/drawtools/test/cases/feature-list.js
@@ -6,9 +6,11 @@ const { drawTools, list, deleteFeatureBtn } = TEST_SELECTORS;
 const testFeatures = [
   {
     getId: () => "0",
+    get: () => null,
   },
   {
     getId: () => "1",
+    get: () => null,
   },
 ];
 


### PR DESCRIPTION
![CleanShot 2025-06-16 at 15 14 15@2x](https://github.com/user-attachments/assets/025ebc89-9cd3-4495-8439-f9afad3189a6)

## Implemented changes
- We can now use two attribute to assign list title for each `feature`.
- `featureNameKey` can be used to get the value from `property` 
- `featureName` can be used to add an incremental title using `featureName` with `featureNumber`
- If `featureNameKey` is not available  `featureName` will be automatically taken.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
