### PR TITLE
fix: prevent PinchZoom if preventScroll is true

### DIFF
--- a/elements/map/src/helpers/interactions.js
+++ b/elements/map/src/helpers/interactions.js
@@ -39,8 +39,8 @@ export function addScrollInteractions(map, customInteraction = false) {
     // Disable default PinchZoom interaction
     // This is to prevent pinch zooming on touch devices when the custom interaction is active
     const pinchZoom = new PinchZoom();
-    pinchZoom.setActive(false);
     map.addInteraction(pinchZoom);
+    pinchZoom.setActive(false);
   } else {
     // Add default MouseWheelZoom, DragPan and PinchZoom interactions
     map.addInteraction(new MouseWheelZoom());

--- a/elements/map/src/helpers/interactions.js
+++ b/elements/map/src/helpers/interactions.js
@@ -38,8 +38,10 @@ export function addScrollInteractions(map, customInteraction = false) {
 
     // Disable default PinchZoom interaction
     // This is to prevent pinch zooming on touch devices when the custom interaction is active
-    const pinchZoom = new PinchZoom();
-    map.addInteraction(pinchZoom);
+    const pinchZoom = map
+      .getInteractions()
+      .getArray()
+      .find((i) => i instanceof PinchZoom);
     pinchZoom.setActive(false);
   } else {
     // Add default MouseWheelZoom, DragPan and PinchZoom interactions

--- a/elements/map/src/helpers/interactions.js
+++ b/elements/map/src/helpers/interactions.js
@@ -1,5 +1,6 @@
 import DragPan from "ol/interaction/DragPan.js";
 import MouseWheelZoom from "ol/interaction/MouseWheelZoom.js";
+import PinchZoom from "ol/interaction/PinchZoom.js";
 import { platformModifierKeyOnly } from "ol/events/condition";
 
 /**
@@ -34,10 +35,17 @@ export function addScrollInteractions(map, customInteraction = false) {
         }),
       );
     } else map.addInteraction(new DragPan()); // On non-touch devices, add the default DragPan interaction
+
+    // Disable default PinchZoom interaction
+    // This is to prevent pinch zooming on touch devices when the custom interaction is active
+    const pinchZoom = new PinchZoom();
+    pinchZoom.setActive(false);
+    map.addInteraction(pinchZoom);
   } else {
-    // Add default MouseWheelZoom and DragPan interactions
+    // Add default MouseWheelZoom, DragPan and PinchZoom interactions
     map.addInteraction(new MouseWheelZoom());
     map.addInteraction(new DragPan());
+    map.addInteraction(new PinchZoom());
   }
 }
 


### PR DESCRIPTION
## Implemented changes

This PR adds a fix to prevent PinchZoom if `preventScroll` has been set to true. In cases where the map should not be scrollable, users pinch-zoomed the map by mistake.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
