### PR TITLE
feat: overlay content on top of map

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -451,6 +451,37 @@ export function parseNavWithAddSection(
       if (section.classList.contains("section-wrap"))
         containsSectionWrap = true;
 
+      const eoxMap = section.querySelector("eox-map");
+      if (eoxMap) {
+        const sectionChildren = Array.from(section.children).filter((child) => {
+          return (
+            child.tagName.toLowerCase() !== "section-step" &&
+            child.getAttribute("as") !== "eox-map"
+          );
+        });
+        const eoxMapChildren = Array.from(eoxMap.children);
+        const children = [...sectionChildren, ...eoxMapChildren];
+        if (children.length) {
+          const hasOverlayClass = Array.from(eoxMap.classList).filter(
+            (className) => className.startsWith("overlay-"),
+          );
+
+          const overlayMap = document.createElement("div");
+          overlayMap.className = "eox-map-overlay";
+          overlayMap.classList.add(
+            hasOverlayClass.length ? hasOverlayClass[0] : "overlay-br",
+          );
+
+          const overlayMapContent = document.createElement("div");
+          overlayMapContent.className = "eox-map-overlay-content";
+
+          children.forEach((child) => overlayMapContent.appendChild(child));
+          overlayMap.appendChild(overlayMapContent);
+          eoxMap.innerHTML = "";
+          section.insertBefore(overlayMap, eoxMap.nextSibling);
+        }
+      }
+
       section.classList.add("section-item");
       section.setAttribute("data-section", `${key + 1}`);
 

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -452,17 +452,20 @@ export function parseNavWithAddSection(
     const sectionStartIndex = navIndex + 1;
     html[sectionStartIndex].classList.add("section-start");
 
-    const sectionOverlayObserver = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        const intersecting = entry.isIntersecting;
+    const sectionOverlayObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const intersecting = entry.isIntersecting;
 
-        if (intersecting && entry.boundingClientRect.top <= 1) {
-          entry.target.classList.add("show-overlay");
-        } else {
-          entry.target.classList.remove("show-overlay");
-        }
-      });
-    });
+          if (intersecting) {
+            entry.target.classList.add("show-overlay");
+          } else {
+            entry.target.classList.remove("show-overlay");
+          }
+        });
+      },
+      { rootMargin: "-50% 0px" },
+    );
 
     html.slice(sectionStartIndex).forEach((section, key) => {
       if (!section.classList) return;

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -9,6 +9,7 @@ let lightboxElements = [];
 let sectionObservers = [];
 let sectionNavObservers = [];
 let stepSectionObservers = [];
+let sectionOverlayObservers = [];
 
 /**
  * Converts an HTML string into DOM nodes and processes each node.
@@ -450,6 +451,19 @@ export function parseNavWithAddSection(
   if (html.length) {
     const sectionStartIndex = navIndex + 1;
     html[sectionStartIndex].classList.add("section-start");
+
+    const sectionOverlayObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const intersecting = entry.isIntersecting;
+
+        if (intersecting && entry.boundingClientRect.top <= 1) {
+          entry.target.classList.add("show-overlay");
+        } else {
+          entry.target.classList.remove("show-overlay");
+        }
+      });
+    });
+
     html.slice(sectionStartIndex).forEach((section, key) => {
       if (!section.classList) return;
       if (section.classList.contains("section-wrap"))
@@ -457,7 +471,7 @@ export function parseNavWithAddSection(
 
       const eoxMap = section.querySelector("eox-map");
       const isTour = section.classList.contains("tour");
-      if (eoxMap && !isTour) {
+      if (eoxMap) {
         const sectionChildren = Array.from(section.children).filter((child) => {
           return (
             child.tagName.toLowerCase() !== "section-step" &&
@@ -484,6 +498,11 @@ export function parseNavWithAddSection(
           overlayMap.appendChild(overlayMapContent);
           eoxMap.innerHTML = "";
           section.insertBefore(overlayMap, eoxMap.nextSibling);
+
+          if (isTour) {
+            sectionOverlayObserver.observe(section);
+            sectionOverlayObservers.push(sectionOverlayObserver);
+          }
         }
       }
 

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -456,7 +456,8 @@ export function parseNavWithAddSection(
         containsSectionWrap = true;
 
       const eoxMap = section.querySelector("eox-map");
-      if (eoxMap) {
+      const isTour = section.classList.contains("tour");
+      if (eoxMap && !isTour) {
         const sectionChildren = Array.from(section.children).filter((child) => {
           return (
             child.tagName.toLowerCase() !== "section-step" &&

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -288,6 +288,8 @@ export class EOxStoryTelling extends LitElement {
       this.showEditor !== undefined ? "editor-enabled" : ""
     } editor-${this.showEditor}`;
 
+    const navClass = `${this.showNav && this.nav.length ? "nav-enabled" : ""}`;
+
     return html`
       <slot class="slot-hide" @slotchange=${this.handleSlotChange}></slot>
       <style>
@@ -297,7 +299,7 @@ export class EOxStoryTelling extends LitElement {
         ${!this.unstyled && mainStyle}
       </style>
 
-      <div class="story-telling ${editorClass}">
+      <div class="story-telling ${editorClass} ${navClass}">
         <div>${when(this.#html, () => html`${this.#html}`)}</div>
         ${when(
           this.showEditor !== undefined,

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -705,5 +705,50 @@ ${slider}
   .margin-view-overlays {
     background: #e6e6e6;
   }
+  .eox-map-overlay {
+    position: absolute;
+    color: white;
+    display: flex
+;
+  }
+  .eox-map-overlay-content {
+    padding: 1.5rem;
+    width: 400px;
+    height: fit-content;
+    border-radius: 10px;
+    background: #00000075;
+  }
+  .eox-map-overlay.overlay-bl {
+    align-items: end;
+    justify-content: flex-start;
+    bottom: 3rem;
+    left: 2rem;
+  }
+  .eox-map-overlay.overlay-br {
+    align-items: end;
+    justify-content: flex-end;    
+    bottom: 3rem;
+    right: 2rem;
+  }
+  .eox-map-overlay.overlay-tl {
+    align-items: start;
+    justify-content: flex-start;
+    top: 5rem;
+    left: 2rem;
+  }
+  .eox-map-overlay.overlay-tr {
+    align-items: start;
+    justify-content: flex-end;
+    top: 5rem;
+    right: 2rem;
+  }
+  .tour .eox-map-overlay {
+    position: sticky !important;
+    width: calc(100% - 2rem);
+    padding: 2rem 2rem 0px 0px;
+    top: 5rem !important;
+    right: 0px !important;
+    justify-content: flex-end;
+  }
 `;
 export default styleEOX;

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -736,51 +736,70 @@ ${slider}
   .margin-view-overlays {
     background: #e6e6e6;
   }
-  .eox-map-overlay {
+  .story-telling .eox-map-overlay {
     position: absolute;
     color: white;
-    display: flex
-;
+    display: flex;
   }
-  .eox-map-overlay-content {
+  .story-telling .eox-map-overlay-content {
     padding: 1.5rem;
     width: 400px;
     height: fit-content;
     border-radius: 10px;
     background: #00000075;
   }
-  .eox-map-overlay.overlay-bl {
+  .story-telling .eox-map-overlay.overlay-bl {
     align-items: end;
     justify-content: flex-start;
     bottom: 3rem;
     left: 2rem;
   }
-  .eox-map-overlay.overlay-br {
+  .story-telling .eox-map-overlay.overlay-br {
     align-items: end;
     justify-content: flex-end;    
     bottom: 3rem;
     right: 2rem;
   }
-  .eox-map-overlay.overlay-tl {
+  .story-telling .eox-map-overlay.overlay-tl {
     align-items: start;
     justify-content: flex-start;
     top: 5rem;
     left: 2rem;
   }
-  .eox-map-overlay.overlay-tr {
+  .story-telling .eox-map-overlay.overlay-tr {
     align-items: start;
     justify-content: flex-end;
     top: 5rem;
     right: 2rem;
   }
-  .tour .eox-map-overlay {
-    position: sticky !important;
-    width: calc(100% - 2rem);
-    padding: 2rem 2rem 0px 0px;
-    top: 5rem !important;
-    right: 0px !important;
-    justify-content: flex-end;
-    bottom: 3rem;
+  .story-telling .tour .eox-map-overlay {
+    position: fixed;
+    width: auto;
+    justify-content: center;
+    display: none;
+  }
+  .story-telling .tour.show-overlay .eox-map-overlay {
+    display: flex;
+  }
+  .story-telling .tour .eox-map-overlay.overlay-tl {
+    top: 2rem;
+    left: 2rem;
+  }
+  .story-telling .tour .eox-map-overlay.overlay-tr {
+    top: 2rem;
+    right: 2rem;
+  }
+  .story-telling.nav-enabled .tour .eox-map-overlay.overlay-tl,
+  .story-telling.nav-enabled .tour .eox-map-overlay.overlay-tr {
+    top: 7rem;
+  }
+  .story-telling .tour .eox-map-overlay.overlay-bl {
+    bottom: 2rem;
+    left: 2rem;
+  }
+  .story-telling .tour .eox-map-overlay.overlay-br {
+    bottom: 2rem;
+    right: 2rem;
   }
 `;
 export default styleEOX;

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -749,6 +749,7 @@ ${slider}
     top: 5rem !important;
     right: 0px !important;
     justify-content: flex-end;
+    bottom: 3rem;
   }
 `;
 export default styleEOX;

--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -801,5 +801,34 @@ ${slider}
     bottom: 2rem;
     right: 2rem;
   }
+  @media screen and (max-width: 768px) {
+    .story-telling .eox-map-overlay.overlay-tl,
+    .story-telling .eox-map-overlay.overlay-tr,
+    .story-telling .eox-map-overlay.overlay-bl,
+    .story-telling .eox-map-overlay.overlay-br {
+      width: calc(100% - 2rem);
+      right: unset;
+      left: unset;
+      justify-content: center;
+      align-items: end;
+    }
+    .story-telling .eox-map-overlay-content {
+      width: 80%;
+      padding: 1rem;
+    }
+    .story-telling .tour .eox-map-overlay.overlay-tr,
+    .story-telling .tour .eox-map-overlay.overlay-tl,
+    .story-telling .tour .eox-map-overlay.overlay-bl,
+    .story-telling .tour .eox-map-overlay.overlay-br {
+      top: 2rem;
+      width: 100dvw;
+      right: unset;
+      left: unset;
+    }
+    .story-telling.nav-enabled .tour .eox-map-overlay.overlay-tr,
+    .story-telling.nav-enabled .tour .eox-map-overlay.overlay-tl {
+      top: 5rem;
+    }
+  }
 `;
 export default styleEOX;

--- a/elements/storytelling/stories/markdown-editor.js
+++ b/elements/storytelling/stories/markdown-editor.js
@@ -88,9 +88,12 @@ To start a new section, use the Markdown syntax for *h2* (Header 2), so starting
 Additionally to the hero section, there are other special sections (like media, map), and the most convenient way to add them is via the "plus" icon. They use the "as" attribute, which replaces the entire section with the corresponding element. So, for example, *as="div"* will replace the entire sectioni (including the title) with a *div*.
 We will now have a more in-depth look about the map section. The map section shows a single map, with optional text underneath. It is powered by [EOxMap](https://eox-a.github.io/EOxElements/?path=/docs/elements-eox-map--docs), so you can use the same syntax as with any EOxMap.
 
-## Map section <!--{as="eox-map" style="width: 100%; height: 500px;" config='{ "controls": { "Zoom": {}, "Attribution": {}, "FullScreen": {}, "OverviewMap": { "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "OSM" } } ] } }, "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ], "view": { "center": [15,48], "zoom": 1 } }'}-->
+## Map section <!--{as="eox-map" class="overlay-br" style="width: 100%; height: 500px;" config='{ "controls": { "Zoom": {}, "Attribution": {}, "FullScreen": {}, "OverviewMap": { "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "OSM" } } ] } }, "layers": [ { "type": "Tile", "properties": { "id": "overviewMap" }, "source": { "type": "TileWMS", "url": "https://ows.mundialis.de/services/service", "params": { "LAYERS": "TOPO-WMS" } } } ], "view": { "center": [15,48], "zoom": 1 } }'}-->
+### Some title for map <!--{ style="color: white; font-size: 1.25rem;" }-->
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
 ## Map Tour section <!--{ as="eox-map" mode="tour" }-->
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
 ### <!--{ layers='[{"type":"Tile","properties":{"id":"osm"},"source":{"type":"OSM"}}]' center=[12.46,41.89] zoom="5" animationOptions="{duration:500}" }-->
 #### This is a map tour.

--- a/elements/storytelling/stories/markdown-editor.js
+++ b/elements/storytelling/stories/markdown-editor.js
@@ -92,7 +92,7 @@ We will now have a more in-depth look about the map section. The map section sho
 ### Some title for map <!--{ style="color: white; font-size: 1.25rem;" }-->
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
-## Map Tour section <!--{ as="eox-map" mode="tour" }-->
+## Map Tour section <!--{ as="eox-map" class="overlay-tr" mode="tour" }-->
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
 ### <!--{ layers='[{"type":"Tile","properties":{"id":"osm"},"source":{"type":"OSM"}}]' center=[12.46,41.89] zoom="5" animationOptions="{duration:500}" }-->

--- a/elements/storytelling/stories/markdown-editor.js
+++ b/elements/storytelling/stories/markdown-editor.js
@@ -92,7 +92,7 @@ We will now have a more in-depth look about the map section. The map section sho
 ### Some title for map <!--{ style="color: white; font-size: 1.25rem;" }-->
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
-## Map Tour section <!--{ as="eox-map" class="overlay-tr" mode="tour" }-->
+## Map Tour section <!--{ as="eox-map" class="overlay-br" mode="tour" }-->
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
 ### <!--{ layers='[{"type":"Tile","properties":{"id":"osm"},"source":{"type":"OSM"}}]' center=[12.46,41.89] zoom="5" animationOptions="{duration:500}" }-->


### PR DESCRIPTION
![CleanShot 2025-06-30 at 12 51 44@2x](https://github.com/user-attachments/assets/cf534a5a-f2a2-4db3-a39d-961797cfc3eb)

## Implemented changes
- Added overlay content on top of `eox-map`
- Any content after `## <!-- as="eox-map" -->` will be added inside overlay content section
```
## Map section <!--{as="eox-map" class="overlay-br" style="width: 100%; height: 500px;" config='{}'}-->
### Some title for map overlay content
Some random description text
Some more content 
```
- User can position it using passing the following classes - 
  - `overlay-br` Bottom Right
  - `overlay-bl` Bottom left 
  - `overlay-tr` Top Right
  - `overlay-tl` Top Left 
- By `default ` the position will be Bottom Right



<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
