### PR TITLE
feat: change default hero height, allow CSS override

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -77,6 +77,7 @@ const styleEOX = `
 
   :host {
     overflow: unset !important;
+    --eox-storytelling-hero-height: 76dvh;
   }
 
   iframe,
@@ -382,7 +383,8 @@ const styleEOX = `
   .story-telling .hero {
     position: relative;      
     width: 100%;
-    height: 100dvh;
+    height: var(--eox-storytelling-hero-height);
+    padding: 10rem 2rem;
     overflow: hidden;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Implemented changes

This PR changes the default hero height in stories to `76dvh` instead of previously `100dvh`. It was reported multiple times that full-height heroes are not optimal for displaying stories, narratives, blog posts etc.

In order to still be able to modify the hero height, a CSS variable `--eox-storytelling-hero-height` has been introduced that can be used to override this default, e.g.:

```
<eox-storytelling style="--eox-storytelling-hero-height: calc(100dvh - var(--nav-height));" ... </>
```

This PR supersedes https://github.com/EOX-A/EOxElements/pull/1733.

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/f68dab42-5fbd-49dc-afd8-1f13460b700d)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
