### PR TITLE
feat: support enabling/disabling scroll indicator

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -540,7 +540,10 @@ export function parseNavWithAddSection(
     html = [sectionWrap];
   }
 
-  if (html[0].classList.contains("hero")) {
+  if (
+    html[0].classList.contains("hero") &&
+    EOxStoryTelling.showHeroScrollIndicator
+  ) {
     const sectionWraps =
       html.filter((el) => el.classList?.contains("section-wrap")) || [];
 

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -47,6 +47,10 @@ export class EOxStoryTelling extends LitElement {
       nav: { state: true, attribute: false, type: Array },
       showNav: { attribute: "show-nav", type: Boolean },
       showEditor: { attribute: "show-editor", type: String },
+      showHeroScrollIndicator: {
+        attribute: "show-hero-scroll-indicator",
+        type: Boolean,
+      },
       noShadow: { attribute: "no-shadow", type: Boolean },
       disableAutosave: { attribute: "disable-autosave", type: Boolean },
       unstyled: { type: Boolean },
@@ -122,6 +126,13 @@ export class EOxStoryTelling extends LitElement {
      * @type {Boolean}
      */
     this.showNav = false;
+
+    /**
+     * Enable or disable hero scroll indicator
+     *
+     * @type {Boolean}
+     */
+    this.showHeroScrollIndicator = false;
 
     /**
      * List of items in navigation

--- a/elements/storytelling/stories/markdown-editor.js
+++ b/elements/storytelling/stories/markdown-editor.js
@@ -131,6 +131,7 @@ More features will be added soon, so feel free to follow progress at the [EOxEle
       id="markdown-editor"
       show-nav
       show-editor="closed"
+      show-hero-scroll-indicator
       markdown=${args.markdown}
       @upload:file=${(e) => {
         const detail = e.detail;


### PR DESCRIPTION
## Implemented changes

This PR makes the "scroll down" indicator in the storytelling hero optional by setting the `show-hero-scroll-indicator` attribute or `showHeroScrollIndicator` property.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
