### PR TITLE
feat: add support for globally exclusive layers

### DIFF
--- a/elements/layercontrol/src/components/layer-group.js
+++ b/elements/layercontrol/src/components/layer-group.js
@@ -23,6 +23,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
     unstyled: { type: Boolean },
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
+    globallyExclusiveLayers: { type: Boolean },
   };
 
   constructor() {
@@ -91,6 +92,13 @@ export class EOxLayerControlLayerGroup extends LitElement {
      * @type {Boolean}
      */
     this.toolsAsList = false;
+
+    /**
+     * If enabled, exclusive layers (marked with the property `layerControlExclusive`) will be globally exclusive (default: exclusive within their layer group).
+     *
+     * @type {Boolean}
+     */
+    this.globallyExclusiveLayers = false;
   }
 
   /**
@@ -160,6 +168,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
                 .tools=${this.tools}
                 .unstyled=${this.unstyled}
                 .toolsAsList=${this.toolsAsList}
+                .globallyExclusiveLayers=${this.globallyExclusiveLayers}
                 @changed=${() => this.requestUpdate()}
               ></eox-layercontrol-layer>
             </summary>
@@ -175,6 +184,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
               .tools=${this.tools}
               .unstyled=${this.unstyled}
               .toolsAsList=${this.toolsAsList}
+              .globallyExclusiveLayers=${this.globallyExclusiveLayers}
               @changed=${() => this.requestUpdate()}
             ></eox-layercontrol-layer-list>
           </details>

--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -23,6 +23,7 @@ export class EOxLayerControlLayerList extends LitElement {
     unstyled: { type: Boolean },
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
+    globallyExclusiveLayers: { type: Boolean },
   };
 
   constructor() {
@@ -92,6 +93,13 @@ export class EOxLayerControlLayerList extends LitElement {
      * @type {Boolean}
      */
     this.toolsAsList = false;
+
+    /**
+     * If enabled, exclusive layers (marked with the property `layerControlExclusive`) will be globally exclusive (default: exclusive within their layer group).
+     *
+     * @type {Boolean}
+     */
+    this.globallyExclusiveLayers = false;
   }
 
   /**
@@ -150,6 +158,8 @@ export class EOxLayerControlLayerList extends LitElement {
                             .tools=${this.tools}
                             .unstyled=${this.unstyled}
                             .toolsAsList=${this.toolsAsList}
+                            .globallyExclusiveLayers=${this
+                              .globallyExclusiveLayers}
                             @changed=${() => this.requestUpdate()}
                           >
                           </eox-layercontrol-layer-group>
@@ -165,6 +175,8 @@ export class EOxLayerControlLayerList extends LitElement {
                             .tools=${this.tools}
                             .unstyled=${this.unstyled}
                             .toolsAsList=${this.toolsAsList}
+                            .globallyExclusiveLayers=${this
+                              .globallyExclusiveLayers}
                             @changed=${() => this.requestUpdate()}
                           ></eox-layercontrol-layer>
                         `

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -30,6 +30,7 @@ export class EOxLayerControlLayer extends LitElement {
     unstyled: { type: Boolean },
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
+    globallyExclusiveLayers: { type: Boolean },
   };
 
   /**
@@ -106,6 +107,13 @@ export class EOxLayerControlLayer extends LitElement {
      * @type {Boolean}
      */
     this.toolsAsList = false;
+
+    /**
+     * If enabled, exclusive layers (marked with the property `layerControlExclusive`) will be globally exclusive (default: exclusive within their layer group).
+     *
+     * @type {Boolean}
+     */
+    this.globallyExclusiveLayers = false;
   }
 
   /**

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -64,6 +64,10 @@ export class EOxLayerControl extends LitElement {
     unstyled: { type: Boolean },
     styleOverride: { type: String },
     toolsAsList: { type: Boolean },
+    globallyExclusiveLayers: {
+      attribute: "globally-exclusive-layers",
+      type: Boolean,
+    },
   };
 
   /**
@@ -148,6 +152,13 @@ export class EOxLayerControl extends LitElement {
      * @type {Boolean}
      */
     this.toolsAsList = false;
+
+    /**
+     * If enabled, exclusive layers (marked with the property `layerControlExclusive`) will be globally exclusive (default: exclusive within their layer group).
+     *
+     * @type {Boolean}
+     */
+    this.globallyExclusiveLayers = false;
   }
 
   /**
@@ -253,6 +264,7 @@ export class EOxLayerControl extends LitElement {
             .tools=${this.tools}
             .unstyled=${this.unstyled}
             .toolsAsList=${this.toolsAsList}
+            .globallyExclusiveLayers=${this.globallyExclusiveLayers}
             @changed=${this.#handleLayerControlLayerListChange}
             @datetime:updated=${this.#handleDatetimeUpdate}
             @layerConfig:change=${this.#handleLayerConfigChange}

--- a/elements/layercontrol/src/methods/layer/input-click.js
+++ b/elements/layercontrol/src/methods/layer/input-click.js
@@ -16,7 +16,7 @@ const inputClickMethod = (evt, EOxLayerControlLayer) => {
      * @type NodeListOf<Element & {layer: any, requestUpdate: function}>
      */
     const siblings = EOxLayerControlLayer.closest(
-      ".layers > ul",
+      `${EOxLayerControlLayer.globallyExclusiveLayers ? ".layers" : "eox-layercontrol-layer-list"} > ul`,
     ).querySelectorAll("eox-layercontrol-layer");
 
     // Loop through the sibling layers to handle exclusive visibility.

--- a/elements/layercontrol/test/cases/general/exclusive-layers.js
+++ b/elements/layercontrol/test/cases/general/exclusive-layers.js
@@ -15,7 +15,16 @@ const exclusiveLayers = () => {
           layerControlExclusive: true,
           layerControlExpand: true,
         },
-        layers: [{ properties: { id: "d", visible: true } }],
+        layers: [
+          {
+            properties: { id: "d", layerControlExclusive: true },
+            visible: false,
+          },
+          {
+            properties: { id: "e", layerControlExclusive: true },
+            visible: true,
+          },
+        ],
         visible: false,
       },
     ]);
@@ -26,12 +35,31 @@ const exclusiveLayers = () => {
     .shadow()
     .within(() => {
       // Checking the number of checked radio inputs in the LayerControl
-      cy.get("ul").find("input[type=radio]:checked").should("have.length", 1);
+      cy.get("ul").find("input[type=radio]:checked").should("have.length", 2);
+      cy.get("ul").find("input[type=radio]").last().should("not.be.checked");
       cy.get("ul")
         .find("input[type=radio]:not(:checked)")
         .last()
         .click({ force: true });
+      cy.get("ul").find("input[type=radio]").last().should("be.checked");
+      cy.get("ul").find("input[type=radio]:checked").should("have.length", 2);
+    });
+
+  // Verify the effect on the LayerControl for globallyExclusiveLayers property
+  cy.get("eox-layercontrol")
+    .and(($el) => {
+      const layerControl = $el[0];
+      layerControl.globallyExclusiveLayers = true;
+    })
+    .shadow()
+    .within(() => {
+      // Checking the number of checked radio inputs in the LayerControl
+      cy.get("ul")
+        .find("input[type=radio]:not(:checked)")
+        .first()
+        .click({ force: true });
       cy.get("ul").find("input[type=radio]:checked").should("have.length", 1);
+      cy.get("ul").find("input[type=radio]").last().should("not.be.checked");
     });
 };
 


### PR DESCRIPTION
## Implemented changes

This PR adds support for globally exclusive layers with the `globallyExclusiveLayers` property / `globally-exclusive-layers` attribute. If this is set to `true` on the `eox-layercontrol`, then all layers marked with the `layerControlExclusive` layer property will globally be exclusive, meaning there can be only one layer visible at a time.

By default (or if set to `false`), layers are only exclusive with their respective group.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
