### PR TITLE
fix(style): small checkboxes by default

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -172,6 +172,7 @@ export const createEditor = (element) => {
           !parent.classList.contains("checkbox")
         ) {
           input.parentElement.classList.add("checkbox");
+          input.parentElement.classList.add("small");
           const span = document.createElement("span");
           if (
             input.nextSibling &&


### PR DESCRIPTION
## Implemented changes

This PR sets checkboxes as small by default

## Screenshots/Videos

### Before
![image](https://github.com/user-attachments/assets/5cf0cb1c-07e7-4054-b9ad-df8fbc59bea6)

### After
![image](https://github.com/user-attachments/assets/d057f010-18fa-4947-8a8a-468b8018c4f8)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
