### PR TITLE
fix: suggestion filter if passed via filterKeys

### DIFF
--- a/elements/itemfilter/src/components/filters/selector.js
+++ b/elements/itemfilter/src/components/filters/selector.js
@@ -196,7 +196,7 @@ export class EOxSelector extends LitElement {
         }
       </style>
       ${when(
-        this.suggestions.length > 10,
+        (this.filterObject.filterKeys || this.suggestions).length >= 10,
         () =>
           html`<div class="autocomplete-container">
             <div

--- a/elements/itemfilter/stories/external.js
+++ b/elements/itemfilter/stories/external.js
@@ -42,7 +42,7 @@ function ExternalStory() {
           title: "User ID",
           type: "multiselect",
           expanded: true,
-          filterKeys: [1, 2, 3],
+          filterKeys: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         },
       ],
     },


### PR DESCRIPTION
## Implemented changes
- Fixed `number` and `boolean` based filter with same `fuse` function as used in `items`.
- Uniformed `suggestion` function same for `items` and `filterKeys`

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos


https://github.com/user-attachments/assets/778315c1-6340-4069-b4dd-4d16b23f26e5


<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
