### PR TITLE
fix: show select overlay also on feature borders

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -154,36 +154,36 @@ export class EOxSelectInteraction {
         { layerFilter: (candidate) => candidate === this.selectLayer },
       );
 
-        const newSelectFids = feature ? [this.getId(feature)] : [];
-        const idChanged = this.selectedFids[0] !== newSelectFids[0];
-        this.selectedFids = newSelectFids;
-        if (idChanged) {
-          this.selectStyleLayer.changed();
-          if (feature && this.panIn) this.panIntoFeature(feature);
-        }
+      const newSelectFids = feature ? [this.getId(feature)] : [];
+      const idChanged = this.selectedFids[0] !== newSelectFids[0];
+      this.selectedFids = newSelectFids;
+      if (idChanged) {
+        this.selectStyleLayer.changed();
+        if (feature && this.panIn) this.panIntoFeature(feature);
+      }
 
-        // Fetch features at the clicked pixel
-        if (overlay) {
-          const xPosition =
-            event.pixel[0] > this.eoxMap.offsetWidth / 2 ? "right" : "left";
-          const yPosition =
-            event.pixel[1] > this.eoxMap.offsetHeight / 2 ? "bottom" : "top";
-          overlay.setPositioning(`${yPosition}-${xPosition}`);
-          overlay.setPosition(feature ? event.coordinate : null);
-          if (feature && this.tooltipElement) {
-            // @ts-expect-error TODO
-            this.tooltipElement.feature = feature;
-          }
+      // Fetch features at the clicked pixel
+      if (overlay) {
+        const xPosition =
+          event.pixel[0] > this.eoxMap.offsetWidth / 2 ? "right" : "left";
+        const yPosition =
+          event.pixel[1] > this.eoxMap.offsetHeight / 2 ? "bottom" : "top";
+        overlay.setPositioning(`${yPosition}-${xPosition}`);
+        overlay.setPosition(feature ? event.coordinate : null);
+        if (feature && this.tooltipElement) {
+          // @ts-expect-error TODO
+          this.tooltipElement.feature = feature;
         }
+      }
 
-        const selectdEvt = new CustomEvent("select", {
-          detail: {
-            id: options.id,
-            originalEvent: event,
-            feature: feature,
-          },
-        });
-        this.eoxMap.dispatchEvent(selectdEvt);
+      const selectdEvt = new CustomEvent("select", {
+        detail: {
+          id: options.id,
+          originalEvent: event,
+          feature: feature,
+        },
+      });
+      this.eoxMap.dispatchEvent(selectdEvt);
     };
 
     // Set up the map event listener for the specified condition (e.g., click, pointermove)


### PR DESCRIPTION
## Implemented changes

This PR replaces `layer.getFeatures` for `map.forEachFeatureAtPixel` in order to prevent overlay/tooltip flashing while hovering on feature borders. It uses the `layerFilter` option in order to only trigger on features of the `selectLayer`.

## Screenshots/Videos
### Before
https://github.com/user-attachments/assets/89fa279b-0758-4cfb-886e-eb51d16d2560

### After
https://github.com/user-attachments/assets/3ba9f4ed-2a05-4d92-bb8a-3b00d9315c41

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
