### PR TITLE
feat: support nested properties for featureNameKey

### DIFF
--- a/elements/drawtools/src/components/list.js
+++ b/elements/drawtools/src/components/list.js
@@ -183,7 +183,14 @@ export class EOxDrawToolsList extends LitElement {
             : isFeatureClicked
               ? "fill"
               : nothing;
-          const propertyName = feature.get(this.featureNameKey);
+
+          const pathParts = this.featureNameKey?.split(".");
+          const propertyName =
+            feature.get(this.featureNameKey) ||
+            pathParts?.reduce((obj, part) => obj?.[part], {
+              ...feature.getProperties(),
+            });
+
           const title = propertyName
             ? propertyName
             : `${this.featureName} ${featureNumber}`;


### PR DESCRIPTION
## Implemented changes

This adds support for nested properties / property paths for `featureNameKey`. Example:
```
[...]
.featureNameKey=${"deeply.nested.property"}
[...]
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
