### PR TITLE
feat: toggle editor on/off

### DIFF
--- a/elements/drawtools/src/components/controller.js
+++ b/elements/drawtools/src/components/controller.js
@@ -173,6 +173,15 @@ export class EOxDrawToolsController extends LitElement {
         d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z"
       />
     </svg>`;
+    const editIcon = html`<svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <title>pencil-outline</title>
+      <path
+        d="M14.06,9L15,9.94L5.92,19H5V18.08L14.06,9M17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3M14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z"
+      />
+    </svg>`;
     const importIcon = html`<svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
@@ -233,6 +242,29 @@ export class EOxDrawToolsController extends LitElement {
           </button>
         </div>
 
+        <!-- Editor Button -->
+        ${when(
+          this.showEditor,
+          () => html`
+            <button
+              data-cy="editorBtn"
+              class="transparent circle primary-text no-margin small"
+              title="${this.unstyled ? "Edit features" : ""}"
+              @click=${() =>
+                this.renderRoot
+                  .querySelector("#editor")
+                  .classList.toggle("hidden")}
+            >
+              ${this.unstyled
+                ? "import"
+                : html`
+                    <i class="small">${editIcon}</i>
+                    <div class="tooltip bottom">Edit features</div>
+                  `}
+            </button>
+          `,
+        )}
+
         <!-- Import Button -->
         ${when(
           this.importFeatures,
@@ -259,7 +291,7 @@ export class EOxDrawToolsController extends LitElement {
                 ? "import"
                 : html`
                     <i class="small">${importIcon}</i>
-                    <div class="tooltip left">Import features</div>
+                    <div class="tooltip bottom">Import features</div>
                   `}
             </button>
           `,
@@ -270,7 +302,7 @@ export class EOxDrawToolsController extends LitElement {
       ${when(
         this.showEditor,
         () => html`
-          <div class="field textarea border extra">
+          <div id="editor" class="field textarea border extra hidden">
             <!-- Geo JSON Editor -->
             <textarea
               style="font-family: monospace; font-size: small; line-height: 1.4; padding: 0.4rem;"

--- a/elements/drawtools/src/enums/test.js
+++ b/elements/drawtools/src/enums/test.js
@@ -2,6 +2,7 @@ export const TEST_SELECTORS = {
   drawTools: "eox-drawtools",
   controller: "eox-drawtools-controller",
   drawBtn: "[data-cy='drawBtn']",
+  editorBtn: "[data-cy='editorBtn']",
   copyBtn: "[data-cy='copyBtn']",
   discardBtn: "[data-cy='discardBtn']",
   list: "eox-drawtools-list",

--- a/elements/drawtools/src/style.eox.js
+++ b/elements/drawtools/src/style.eox.js
@@ -12,4 +12,7 @@ export const styleEOX = `
     padding-left: var(--padding);
     padding-right: var(--padding);
   }
+  .hidden {
+    display: none;
+  }
 `;

--- a/elements/drawtools/test/cases/copy-geo-json-editor.js
+++ b/elements/drawtools/test/cases/copy-geo-json-editor.js
@@ -7,7 +7,7 @@ Cypress.Commands.add("getClipboardText", () => {
 });
 
 // Destructure TEST_SELECTORS object
-const { drawTools, controller, copyBtn } = TEST_SELECTORS;
+const { drawTools, controller, editorBtn, copyBtn } = TEST_SELECTORS;
 
 /**
  * Check valid geo-json present in the clipboard after copying
@@ -22,6 +22,7 @@ const copyGeoJsonEditorTest = () => {
         });
 
         // Click copy button in geo json editor
+        cy.get(editorBtn).click();
         cy.get(copyBtn).click();
 
         // Check whether the copied json matches with `DUMMY_GEO_JSON`


### PR DESCRIPTION
## Implemented changes

This PR adds a toggle for the editor by default, in order to harmonize it with the "import features" button.

## Screenshots/Videos
https://github.com/user-attachments/assets/47fd44a5-130c-4c90-b8c3-29c2839914ac

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
