### PR TITLE
feat: on/off toggle for object property editing

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -158,6 +158,35 @@ export const createEditor = (element) => {
       aceUsed.ace_editor_instance.renderer.attachToShadowRoot();
       aceUsed.ace_editor_instance.resize();
     }
+
+    // Shows a switch/toggle for all the object editing buttons
+    // If unchecked, the editing buttons are not shown, if checked, they are shown
+    if (
+      element.options?.disable_properties === false &&
+      element.propertiesToggle
+    ) {
+      const propertiesToggle = document.createElement("label");
+      propertiesToggle.classList.add("switch");
+      Object.assign(propertiesToggle.style, {
+        position: "absolute",
+        top: 0,
+        right: 0,
+        marginTop: "var(--eox-panel-spacing, 10px)",
+      });
+      propertiesToggle.innerHTML = `
+        <input type="checkbox">
+        <span class="left-padding small-padding">Object properties editing</span>
+      `;
+      const checkBox = propertiesToggle.querySelector("input");
+      checkBox.addEventListener("change", () => {
+        element.renderRoot
+          .querySelectorAll(".json-editor-btn-edit_properties")
+          .forEach((b) => b.classList.toggle("hidden"));
+      });
+      element.renderRoot
+        .querySelector(".je-object__container")
+        .appendChild(propertiesToggle);
+    }
   });
 
   editor.on("change", () => {
@@ -169,7 +198,8 @@ export const createEditor = (element) => {
         const parent = input.parentElement;
         if (
           parent.tagName === "LABEL" &&
-          !parent.classList.contains("checkbox")
+          !parent.classList.contains("checkbox") &&
+          !parent.classList.contains("switch")
         ) {
           input.parentElement.classList.add("checkbox");
           input.parentElement.classList.add("small");
@@ -261,6 +291,9 @@ export const createEditor = (element) => {
           </i>`;
         }
         if (button.classList.contains("json-editor-btn-edit_properties")) {
+          if (element.propertiesToggle) {
+            button.classList.add("hidden");
+          }
           button.innerHTML = `
           <i class="small">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>format-list-bulleted</title><path d="M7,5H21V7H7V5M7,13V11H21V13H7M4,4.5A1.5,1.5 0 0,1 5.5,6A1.5,1.5 0 0,1 4,7.5A1.5,1.5 0 0,1 2.5,6A1.5,1.5 0 0,1 4,4.5M4,10.5A1.5,1.5 0 0,1 5.5,12A1.5,1.5 0 0,1 4,13.5A1.5,1.5 0 0,1 2.5,12A1.5,1.5 0 0,1 4,10.5M7,19V17H21V19H7M4,16.5A1.5,1.5 0 0,1 5.5,18A1.5,1.5 0 0,1 4,19.5A1.5,1.5 0 0,1 2.5,18A1.5,1.5 0 0,1 4,16.5Z" /></svg>

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -21,6 +21,7 @@ export class EOxJSONForm extends LitElement {
     options: { attribute: false, type: Object },
     customEditorInterfaces: { attribute: false, type: Array },
     noShadow: { attribute: "no-shadow", type: Boolean },
+    propertiesToggle: { attribute: "properties-toggle", type: Boolean },
     unstyled: { type: Boolean },
   };
 
@@ -60,6 +61,14 @@ export class EOxJSONForm extends LitElement {
      * @type {Boolean}
      */
     this.noShadow = false;
+
+    /**
+     * Shows a toggle for showing/hiding object properties editing buttons
+     * To be used in combination with `options.disable_properties = false`
+     *
+     * @type {Boolean}
+     */
+    this.propertiesToggle = false;
 
     /**
      * Render the element without additional styles

--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -20,6 +20,9 @@ export const styleEOX = `
     --background-color: var(--eox-background-color, transparent);
     background-color: var(--background-color, transparent);
   }
+  .hidden {
+    visibility: hidden;
+  }
   .editor-toolbar, .CodeMirror {
     border-color: var(--outline-variant) !important;
   }

--- a/elements/jsonform/stories/collection.js
+++ b/elements/jsonform/stories/collection.js
@@ -13,6 +13,7 @@ const Collection = {
       disable_edit_json: false,
       disable_properties: false,
     },
+    propertiesToggle: true,
   },
 };
 export default Collection;

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -33,6 +33,7 @@ export default {
       .schema=${args.schema}
       .value=${args.value}
       .options=${args.options}
+      .propertiesToggle=${args.propertiesToggle}
       .noShadow=${args.noShadow}
       .unstyled=${args.unstyled}
       @change=${args.onChange}


### PR DESCRIPTION
## Implemented changes

This adds an on/off switch for object properties editing, to be used in combination with editor option `disable_properties === false`.

If the property `propertiesToggle` / attribute `properties-toggle` is set on `eox-jsonform`, then a switch will render to show/hide the object property editing buttons:

## Screenshots/Videos

https://github.com/user-attachments/assets/e8915855-b8ff-4249-b085-66f8ebdd2312

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
