### PR TITLE
fix: emit drawupdate event when deleting single feature

### DIFF
--- a/elements/drawtools/src/components/list.js
+++ b/elements/drawtools/src/components/list.js
@@ -115,7 +115,7 @@ export class EOxDrawToolsList extends LitElement {
    * @param {Event & { target: HTMLButtonElement }} evt - Event object containing button target.
    */
   _handleDelete(evt) {
-    deleteFeatureMethod(evt, this);
+    deleteFeatureMethod(evt, this, this.eoxDrawTools);
     this.dispatchEvent(new CustomEvent("changed", { bubbles: true }));
   }
 

--- a/elements/drawtools/src/methods/list/delete-feature.js
+++ b/elements/drawtools/src/methods/list/delete-feature.js
@@ -4,7 +4,7 @@
  * @param {Event & { target: HTMLButtonElement }} evt - Event object containing button target.
  * @param {import("../../components/list").EOxDrawToolsList} EoxDrawToolList - The list of drawn features.
  */
-const deleteFeatureMethod = (evt, EoxDrawToolList) => {
+const deleteFeatureMethod = (evt, EoxDrawToolList, EoxDrawTool) => {
   evt.stopPropagation();
 
   // Extract the index of the feature to delete from the button's attribute
@@ -16,6 +16,7 @@ const deleteFeatureMethod = (evt, EoxDrawToolList) => {
   // Remove the feature from the draw layer and update the drawnFeatures array
   EoxDrawToolList.drawLayer.getSource().removeFeature(feature);
   EoxDrawToolList.drawnFeatures.splice(index, 1);
+  EoxDrawTool.emitDrawnFeatures();
 
   // Request an update to reflect the changes
   EoxDrawToolList.requestUpdate();

--- a/elements/drawtools/test/cases/feature-list.js
+++ b/elements/drawtools/test/cases/feature-list.js
@@ -19,6 +19,7 @@ const testFeatures = [
  */
 const featureListTest = () => {
   cy.get(drawTools).and(($el) => {
+    $el[0].addEventListener("drawupdate", cy.stub().as("drawUpdateStub"));
     $el[0].drawnFeatures = testFeatures;
   });
 
@@ -29,9 +30,19 @@ const featureListTest = () => {
         // Verify the list renders to features
         cy.get("li").should("have.length", testFeatures.length);
 
+        const oneLess = testFeatures.length - 1;
+
         // Click the delete feature button and verify the list only shows one feature
         cy.get(deleteFeatureBtn).first().click();
-        cy.get("li").should("have.length", testFeatures.length - 1);
+        cy.get("li").should("have.length", oneLess);
+
+        cy.get("@drawUpdateStub")
+          .should("be.called")
+          .its("lastCall.args.0.detail")
+          .should("be.an", "array")
+          .and((val) => {
+            expect(val).to.have.length(oneLess);
+          });
       });
     });
 };


### PR DESCRIPTION
## Implemented changes

This PR adds a small fix that ensures the `drawupdate` event is also triggered when a single feature is deleted from the list. Previously it only triggered after drawing and discarding all features.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] I have added a test
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
