### PR TITLE
fix: disconnect/connect drawtools

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -317,7 +317,10 @@ export class EOxDrawTools extends LitElement {
    * It then calls requestUpdate to trigger a re-render.
    */
   firstUpdated() {
-    const { EoxMap, OlMap, reset } = initLayerMethod(this, this.multipleFeatures);
+    const { EoxMap, OlMap, reset } = initLayerMethod(
+      this,
+      this.multipleFeatures,
+    );
     this.resetLayer = reset;
     this.eoxMap = EoxMap;
     this.#olMap = OlMap;

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -357,7 +357,7 @@ export class EOxDrawTools extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.eoxMap?.map.removeLayer(this.drawLayer);
+    this.resetLayer?.(this);
   }
   // Render method for UI display
   render() {

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -317,7 +317,8 @@ export class EOxDrawTools extends LitElement {
    * It then calls requestUpdate to trigger a re-render.
    */
   firstUpdated() {
-    const { EoxMap, OlMap } = initLayerMethod(this, this.multipleFeatures);
+    const { EoxMap, OlMap, reset } = initLayerMethod(this, this.multipleFeatures);
+    this.resetLayer = reset;
     this.eoxMap = EoxMap;
     this.#olMap = OlMap;
     this.selectionEvents = createSelectHandler(this);
@@ -346,9 +347,17 @@ export class EOxDrawTools extends LitElement {
     this.requestUpdate("eoxMap", oldValue);
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.drawLayer && this.eoxMap) {
+      const { reset } = initLayerMethod(this, this.multipleFeatures);
+      this.resetLayer = reset;
+    }
+  }
+
   disconnectedCallback() {
-    this.eoxMap?.map.removeLayer(this.drawLayer);
     super.disconnectedCallback();
+    this.eoxMap?.map.removeLayer(this.drawLayer);
   }
   // Render method for UI display
   render() {

--- a/elements/drawtools/src/methods/draw/create-select-handler.js
+++ b/elements/drawtools/src/methods/draw/create-select-handler.js
@@ -26,7 +26,7 @@ const createSelectHandler = (EoxDrawTool) => {
     if (EoxDrawTool.layerId) {
       const hoverInteraction =
         EoxDrawTool.eoxMap.selectInteractions["SelectLayerHoverInteraction"];
-      hoverInteraction.setActive(true);
+      hoverInteraction?.setActive(true);
       EoxDrawTool.eoxMap.addEventListener("select", selectHandler);
     }
   };
@@ -39,7 +39,7 @@ const createSelectHandler = (EoxDrawTool) => {
       EoxDrawTool.eoxMap.selectInteractions?.["SelectLayerHoverInteraction"];
     if (hoverInteraction) {
       hoverInteraction.selectedFids = [];
-      hoverInteraction.setActive(false);
+      hoverInteraction?.setActive(false);
     }
     EoxDrawTool.eoxMap.removeEventListener("select", selectHandler);
   };

--- a/elements/drawtools/src/methods/draw/discard-drawing.js
+++ b/elements/drawtools/src/methods/draw/discard-drawing.js
@@ -9,7 +9,7 @@ const discardDrawingMethod = (EoxDrawTool) => {
   const discardDrawingActions = () => {
     // Reset drawnFeatures, deactivate drawing, and clear drawLayer's source
     EoxDrawTool.drawnFeatures = [];
-    EoxDrawTool.draw.setActive(false);
+    EoxDrawTool.draw?.setActive(false);
     EoxDrawTool.selectionEvents.removeSelectionEvent();
     EoxDrawTool.drawLayer.getSource().clear();
     //@ts-expect-error TODO

--- a/elements/drawtools/src/methods/draw/handle-layer-id.js
+++ b/elements/drawtools/src/methods/draw/handle-layer-id.js
@@ -38,7 +38,7 @@ export default handleLayerId;
  * @param {import("../../main").EOxDrawTools} EoxDrawTool
  * @param {import("@eox/map").EOxMap} EoxMap
  */
-function exitSelection(EoxDrawTool, EoxMap) {
+export function exitSelection(EoxDrawTool, EoxMap) {
   if (!EoxMap) {
     return;
   }

--- a/elements/drawtools/src/methods/draw/handle-layer-id.js
+++ b/elements/drawtools/src/methods/draw/handle-layer-id.js
@@ -38,7 +38,7 @@ export default handleLayerId;
  * @param {import("../../main").EOxDrawTools} EoxDrawTool
  * @param {import("@eox/map").EOxMap} EoxMap
  */
-export function exitSelection(EoxDrawTool, EoxMap) {
+function exitSelection(EoxDrawTool, EoxMap) {
   if (!EoxMap) {
     return;
   }

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -95,8 +95,8 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
 
   // Initialize selection interactions
   initSelection(EoxDrawTool, EoxMap, EoxDrawTool.layerId);
-  const onModifyEnd = () => EoxDrawTool.onModifyEnd()
-  const onAddFeatures =  () => onDrawEndMethod(EoxDrawTool)
+  const onModifyEnd = () => EoxDrawTool.onModifyEnd();
+  const onAddFeatures = () => onDrawEndMethod(EoxDrawTool);
 
   EoxDrawTool.modify?.on("modifyend", onModifyEnd);
 
@@ -105,17 +105,17 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
   if (EoxDrawTool.drawnFeatures) {
     EoxDrawTool.drawLayer.getSource().addFeatures(EoxDrawTool.drawnFeatures);
   }
-  
+
   /**
    * Resets the draw layer, cleaning up interactions and listeners.
-  *
-  * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
-  */
- const reset = (EoxDrawTool) => {
-   if (!EoxDrawTool.eoxMap || !EoxDrawTool.drawLayer) {
-     return;
+   *
+   * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
+   */
+  const reset = (EoxDrawTool) => {
+    if (!EoxDrawTool.eoxMap || !EoxDrawTool.drawLayer) {
+      return;
     }
-    
+
     // Remove the layer from the map
     EoxDrawTool.drawLayer.getSource().clear();
     EoxDrawTool.eoxMap.map.removeLayer(EoxDrawTool.drawLayer);
@@ -129,8 +129,8 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
     if (EoxDrawTool.layerId) {
       exitSelection(EoxDrawTool, EoxDrawTool.eoxMap);
     }
-  }
-
-    return { EoxMap, OlMap, reset };
   };
+
+  return { EoxMap, OlMap, reset };
+};
 export default initLayerMethod;

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -102,6 +102,9 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
 
   EoxMap.addEventListener("addfeatures", onAddFeatures);
 
+  if (EoxDrawTool.drawnFeatures) {
+    EoxDrawTool.drawLayer.getSource().addFeatures(EoxDrawTool.drawnFeatures);
+  }
   
   /**
    * Resets the draw layer, cleaning up interactions and listeners.
@@ -115,7 +118,7 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
     
     // Remove the layer from the map
     EoxDrawTool.eoxMap.map.removeLayer(EoxDrawTool.drawLayer);
-    EoxDrawTool.modify.un("modifyend", onModifyEnd);
+    EoxDrawTool.modify?.un("modifyend", onModifyEnd);
     EoxDrawTool.eoxMap.removeEventListener("addfeatures", onAddFeatures);
 
     // Clean up references

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -1,13 +1,13 @@
 import { onDrawEndMethod, initSelection } from "./";
 
 import { getElement } from "@eox/elements-utils";
+import { exitSelection } from "./handle-layer-id";
 
 /**
  * Initializes the draw layer, interacts with the map, and returns map instances.
  *
  * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
  * @param {Boolean} multipleFeatures - Allow adding more than one feature at a time
- * @returns {{EoxMap: import("@eox/map").EOxMap, OlMap: import("ol").Map}} - The map instances.
  */
 const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
   const mapQuery = getElement(EoxDrawTool.for);
@@ -95,12 +95,38 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
 
   // Initialize selection interactions
   initSelection(EoxDrawTool, EoxMap, EoxDrawTool.layerId);
+  const onModifyEnd = () => EoxDrawTool.onModifyEnd()
+  const onAddFeatures =  () => onDrawEndMethod(EoxDrawTool)
 
-  EoxDrawTool.modify?.on("modifyend", () => EoxDrawTool.onModifyEnd());
+  EoxDrawTool.modify?.on("modifyend", onModifyEnd);
 
-  EoxMap.addEventListener("addfeatures", () => onDrawEndMethod(EoxDrawTool));
+  EoxMap.addEventListener("addfeatures", onAddFeatures);
 
-  return { EoxMap, OlMap };
-};
+  
+  /**
+   * Resets the draw layer, cleaning up interactions and listeners.
+  *
+  * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
+  */
+ const reset = (EoxDrawTool) => {
+   if (!EoxDrawTool.eoxMap || !EoxDrawTool.drawLayer) {
+     return;
+    }
+    
+    // Remove the layer from the map
+    EoxDrawTool.eoxMap.map.removeLayer(EoxDrawTool.drawLayer);
+    EoxDrawTool.modify.un("modifyend", onModifyEnd);
+    EoxDrawTool.eoxMap.removeEventListener("addfeatures", onAddFeatures);
 
+    // Clean up references
+    // EoxDrawTool.drawLayer = null;
+    EoxDrawTool.draw = null;
+    EoxDrawTool.modify = null;
+    if (EoxDrawTool.layerId) {
+      exitSelection(EoxDrawTool, EoxDrawTool.eoxMap);
+    }
+  }
+
+    return { EoxMap, OlMap, reset };
+  };
 export default initLayerMethod;

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -117,6 +117,7 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
     }
     
     // Remove the layer from the map
+    EoxDrawTool.drawLayer.getSource().clear();
     EoxDrawTool.eoxMap.map.removeLayer(EoxDrawTool.drawLayer);
     EoxDrawTool.modify?.un("modifyend", onModifyEnd);
     EoxDrawTool.eoxMap.removeEventListener("addfeatures", onAddFeatures);

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -1,7 +1,6 @@
 import { onDrawEndMethod, initSelection } from "./";
 
 import { getElement } from "@eox/elements-utils";
-import { exitSelection } from "./handle-layer-id";
 
 /**
  * Initializes the draw layer, interacts with the map, and returns map instances.
@@ -123,12 +122,10 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
     EoxDrawTool.eoxMap.removeEventListener("addfeatures", onAddFeatures);
 
     // Clean up references
-    // EoxDrawTool.drawLayer = null;
-    EoxDrawTool.draw = null;
-    EoxDrawTool.modify = null;
-    if (EoxDrawTool.layerId) {
-      exitSelection(EoxDrawTool, EoxDrawTool.eoxMap);
+    if (!EoxDrawTool.layerId) {
+      EoxDrawTool.draw = null;
     }
+    EoxDrawTool.modify = null;
   };
 
   return { EoxMap, OlMap, reset };

--- a/elements/drawtools/src/methods/draw/init-selection.js
+++ b/elements/drawtools/src/methods/draw/init-selection.js
@@ -63,9 +63,9 @@ const initSelection = (EoxDrawTool, EoxMap, layerId) => {
   const oldDrawInteraction = EoxDrawTool.draw;
   EoxDrawTool.draw = EoxMap.selectInteractions["SelectLayerClickInteraction"];
 
-  oldDrawInteraction.setActive(false);
-  EoxMap.selectInteractions["SelectLayerClickInteraction"].setActive(false);
-  EoxMap.selectInteractions["SelectLayerHoverInteraction"].setActive(false);
+  oldDrawInteraction?.setActive(false);
+  EoxMap.selectInteractions["SelectLayerClickInteraction"]?.setActive(false);
+  EoxMap.selectInteractions["SelectLayerHoverInteraction"]?.setActive(false);
 };
 
 export default initSelection;

--- a/elements/drawtools/src/methods/draw/on-draw-end.js
+++ b/elements/drawtools/src/methods/draw/on-draw-end.js
@@ -9,7 +9,7 @@ const onDrawEndMethod = (EoxDrawTool) => {
   const handleDrawEnd = () => {
     EoxDrawTool.emitDrawnFeatures(); // Emit drawn features
     if (!EoxDrawTool.multipleFeatures) {
-      EoxDrawTool.draw.setActive(false); // Deactivate drawing
+      EoxDrawTool.draw?.setActive(false); // Deactivate drawing
       EoxDrawTool.selectionEvents.removeSelectionEvent();
       EoxDrawTool.currentlyDrawing = false; // Update drawing status flag
     } else {

--- a/elements/drawtools/src/methods/draw/start-drawing.js
+++ b/elements/drawtools/src/methods/draw/start-drawing.js
@@ -8,7 +8,7 @@ const startDrawingMethod = (EoxDrawTool) => {
   // Function to initialize the drawing process
   const initializeDrawing = () => {
     EoxDrawTool.drawLayer.set("isDrawingEnabled", true);
-    EoxDrawTool.draw.setActive(true);
+    EoxDrawTool.draw?.setActive(true);
     // Add selection
     EoxDrawTool.selectionEvents.addSelectionEvent();
   };
@@ -27,7 +27,7 @@ const startDrawingMethod = (EoxDrawTool) => {
   // Abort drawing on Esc key
   document.addEventListener("keydown", ({ key }) => {
     if (key === "Escape" && EoxDrawTool.currentlyDrawing) {
-      EoxDrawTool.draw.setActive(false);
+      EoxDrawTool.draw?.setActive(false);
       EoxDrawTool.currentlyDrawing = false;
       EoxDrawTool.requestUpdate();
     }

--- a/elements/drawtools/test/_mockMap.js
+++ b/elements/drawtools/test/_mockMap.js
@@ -30,6 +30,7 @@ export class MockMap extends HTMLElement {
                 this.features = [];
               },
               // Simulating getFeatures method
+              addFeatures: (features) => this.features.concat(features),
               getFeatures: () => this.features,
               removeFeature: () => this.features.splice(0, 1),
             }),

--- a/elements/jsonform/src/custom-inputs/spatial/editor.js
+++ b/elements/jsonform/src/custom-inputs/spatial/editor.js
@@ -275,6 +275,15 @@ export class SpatialEditor extends AbstractEditor {
     this.container.appendChild(this.control);
   }
 
+  refreshValue() {
+    if (this.input.currentlyDrawing) {
+      this.input.updateComplete.then(() => {
+        this.input.startDrawing();
+      });
+    }
+    super.refreshValue();
+  }
+
   // Destroy the editor and remove all associated elements
   destroy() {
     if (this.label && this.label.parentNode)

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
     },
     "elements/drawtools": {
       "name": "@eox/drawtools",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@eox/elements-utils": "^1.0.0",
         "@eox/ui": "^0.3.6",
@@ -118,7 +118,7 @@
     },
     "elements/itemfilter": {
       "name": "@eox/itemfilter",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@eox/elements-utils": "^1.0.0",
         "@eox/ui": "^0.3.6",
@@ -149,7 +149,7 @@
     },
     "elements/jsonform": {
       "name": "@eox/jsonform",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@eox/elements-utils": "^1.0.0",
         "@eox/ui": "^0.3.6",
@@ -173,7 +173,7 @@
     },
     "elements/layercontrol": {
       "name": "@eox/layercontrol",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "@eox/elements-utils": "^1.0.0",
         "@eox/ui": "^0.3.6",
@@ -209,7 +209,7 @@
     },
     "elements/map": {
       "name": "@eox/map",
-      "version": "1.22.0",
+      "version": "1.24.0",
       "dependencies": {
         "@eox/elements-utils": "^1.0.0",
         "@eox/ui": "^0.3.6",
@@ -261,7 +261,7 @@
     },
     "elements/storytelling": {
       "name": "@eox/storytelling",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@eox/elements-utils": "^1.0.0",
         "@eox/ui": "^0.3.6",


### PR DESCRIPTION
## Implemented changes

This PR attempts to solve an issue with disconnecting and then (re-)connecting the `eox-drawtools`, as it is done e.g. in `eox-jsonform`. When the jsonform is updated and the drawtools are disconnected, they previously were left in a broken state that could not be reconnected properly, causing issues with using the drawtools inside a jsonform.

Here, a `resetLayer` method is added inside drawtools which resets the drawLayer on connection if it already exists; also a check is added to `eox-jsonform` to re-enable drawing if the user was currently drawing before the reset.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
