### PR TITLE
fix: hard-coded projection for features

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -253,10 +253,6 @@ export class EOxDrawTools extends LitElement {
       this.drawLayer,
       this.eoxMap,
       replaceFeatures,
-      {
-        dataProjection: this.eoxMap.projection,
-        featureProjection: this.projection,
-      },
       animate,
     );
   }

--- a/elements/map/src/helpers/add-new-feature.js
+++ b/elements/map/src/helpers/add-new-feature.js
@@ -47,11 +47,14 @@ export default function addNewFeature(
     if (geom instanceof LineString) {
       const length = getLength(geom, {
         radius: 6378137,
-        projection: "EPSG:3857",
+        projection: EOxMap.projection,
       });
       feature.set("measure", length);
     } else if (geom instanceof Polygon) {
-      const area = getArea(geom, { radius: 6378137, projection: "EPSG:3857" });
+      const area = getArea(geom, {
+        radius: 6378137,
+        projection: EOxMap.projection,
+      });
       feature.set("measure", area);
     }
 

--- a/elements/map/src/helpers/parse-feature.js
+++ b/elements/map/src/helpers/parse-feature.js
@@ -1,5 +1,4 @@
 import GeoJSON from "ol/format/GeoJSON";
-import { READ_FEATURES_OPTIONS } from "../enums";
 
 /**
  * Converts an array of OpenLayers features into a GeoJSON object.
@@ -12,5 +11,5 @@ export default function parseFeature(features) {
   const format = new GeoJSON();
 
   // Convert the OpenLayers features into a GeoJSON object using the specified options
-  return format.writeFeaturesObject(features, READ_FEATURES_OPTIONS);
+  return format.writeFeaturesObject(features);
 }


### PR DESCRIPTION
## Implemented changes
- After merging of this PR (https://github.com/EOX-A/EOxElements/pull/1356) the projection was affecting import features as we forgot to update the projection code for `parseTextToFeature` as the projection inside it was using hardcoded projection 

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

https://github.com/user-attachments/assets/0b4a64ba-eefe-4b32-b890-db8793833054



- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
