### PR TITLE
fix: show validation errors for spatial editor

### DIFF
--- a/elements/jsonform/src/custom-inputs/spatial/editor.js
+++ b/elements/jsonform/src/custom-inputs/spatial/editor.js
@@ -286,8 +286,7 @@ export class SpatialEditor extends AbstractEditor {
   }
 
   showValidationErrors(errors) {
-    if (this.jsoneditor.options.show_errors === "always") {
-    } else if (
+    if (
       !this.is_dirty &&
       this.previous_error_setting === this.jsoneditor.options.show_errors
     )


### PR DESCRIPTION
## Implemented changes

This adds the missing validation error message for spatial editors in case they don't fulfill the schema requirements.

## Screenshots/Videos

<img width="606" height="405" alt="image" src="https://github.com/user-attachments/assets/ff0857f2-124c-42c5-8f71-9d4b82b7a361" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
