### PR TITLE
feat: show number of validation errors per tab

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -190,6 +190,47 @@ export const createEditor = (element) => {
   });
 
   editor.on("change", () => {
+    // If "categories" is enabled, add error badges to tabs containing
+    // the number of validation errors per tab
+    const errorBadgesStore = {};
+    const tabs = element.renderRoot.querySelector(".je-tabholder--clear");
+    if (tabs) {
+      element.renderRoot.querySelectorAll(".je-tab--top").forEach((t) => {
+        if (t.querySelector(".badge")) {
+          t.removeChild(t.querySelector(".badge"));
+        }
+      });
+      editor.validation_results.forEach((error) => {
+        const currentTabContent = tabs
+          .querySelector(`[data-schemapath='${error.path}']`)
+          .closest(".je-tabholder--clear > .je-indented-panel");
+        const currentTab = element.renderRoot.querySelector(
+          `.je-tab--top#${currentTabContent.id}`,
+        );
+
+        if (errorBadgesStore[currentTabContent.id] === undefined) {
+          errorBadgesStore[currentTabContent.id] = 0;
+        }
+        errorBadgesStore[currentTabContent.id] =
+          errorBadgesStore[currentTabContent.id] + 1;
+
+        const currentBadge = currentTab.querySelector(".badge");
+        if (!currentBadge) {
+          const errorBadge = document.createElement("div");
+          errorBadge.classList.add("badge");
+          Object.assign(errorBadge.style, {
+            top: "0",
+            left: "calc(100% - .7rem)",
+            transform: "unset",
+          });
+          errorBadge.textContent = errorBadgesStore[currentTabContent.id];
+          currentTab.appendChild(errorBadge);
+        } else {
+          currentBadge.textContent = errorBadgesStore[currentTabContent.id];
+        }
+      });
+    }
+
     // Adaptations to DOM in order to fit EOxUI
     // Checkboxes are wrapped in a label with a span
     element.renderRoot


### PR DESCRIPTION
## Implemented changes

This PR adds small error badges for the "categories" format, displaying the current number of validation errors for each tab.

## Screenshots/Videos

https://github.com/user-attachments/assets/85f1db81-fbfd-4b10-b5b0-3f656c8dd49b

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
