### PR TITLE
fix: handle not existing tabs

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -203,7 +203,10 @@ export const createEditor = (element) => {
       editor.validation_results.forEach((error) => {
         const currentTabContent = tabs
           .querySelector(`[data-schemapath='${error.path}']`)
-          .closest(".je-tabholder--clear > .je-indented-panel");
+          ?.closest(".je-tabholder--clear > .je-indented-panel");
+        if (!currentTabContent) {
+          return;
+        }
         const currentTab = element.renderRoot.querySelector(
           `.je-tab--top#${currentTabContent.id}`,
         );


### PR DESCRIPTION
## Implemented changes

This PR includes a small fix for handling non-existing DOM elements when searching for the current tab when displaying errors in "categories" format.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
