### PR TITLE
Fix: discarding feature removing highlight event also for draw based drawtool

### DIFF
--- a/elements/drawtools/src/methods/draw/discard-drawing.js
+++ b/elements/drawtools/src/methods/draw/discard-drawing.js
@@ -10,7 +10,8 @@ const discardDrawingMethod = (EoxDrawTool) => {
     // Reset drawnFeatures, deactivate drawing, and clear drawLayer's source
     EoxDrawTool.drawnFeatures = [];
     EoxDrawTool.draw.setActive(false);
-    EoxDrawTool.selectionEvents.removeSelectionEvent();
+    const isSelectBased = !!EoxDrawTool.layerId;
+    if (isSelectBased) EoxDrawTool.selectionEvents.removeSelectionEvent();
     EoxDrawTool.drawLayer.getSource().clear();
     //@ts-expect-error TODO
     EoxDrawTool.geoJSON = null;


### PR DESCRIPTION
## Implemented Changes
- Added a check to prevent removal of the `event` when it's triggered by a `selection-based` interaction. Previously, this was unintentionally removing the `event` even in draw-based components, which caused issues with highlighting `draw-based` features.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
