### PR TITLE
fix: run all tests with `npm run test:all`

### DIFF
--- a/cypress/e2e/storybook.cy.js
+++ b/cypress/e2e/storybook.cy.js
@@ -5,8 +5,11 @@ describe("Stories test", () => {
   const pathsChanged = Cypress.env("CI_PATHS_CHANGED");
   let uniqueElementFolders = [];
   let cypressChanged = false;
-  // only run stories from files that have been changed
-  if (pathsChanged) {
+  // only run stories from files that have been changed (on CI)
+  // locally we run all tests
+  if (!pathsChanged) {
+    cypressChanged = true;
+  } else {
     const changed = pathsChanged.split("\n");
     // if cypress folder changed => run all tests
     if (!changed.some((item) => item.startsWith("cypress"))) {

--- a/demo.stories.js
+++ b/demo.stories.js
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import eoxStyle from "@eox/ui/style.css?inline";
 import "@eox/ui";
+import "color-legend-element";
 import items from "./elements/itemfilter/test/testItems.json";
 
 export default {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:all": "npm run styles && npm run build --ws",
     "clean": "npm exec --workspaces -- npx rimraf node_modules && npx rimraf node_modules",
     "cypress": "cypress open",
-    "test:all": "npm run styles && npm run test:component && npm run test:e2e",
+    "test:all": "npm run styles && npm run test:component; npm run test:e2e",
     "test:component": "npm run styles && cypress run --component",
     "test:e2e": "npm run generate-manifest && npm run build:storybook && cypress run --e2e",
     "format": "prettier --write .",


### PR DESCRIPTION
## Implemented changes

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- updated `npm run test:all` to `npm run styles && npm run test:component; npm run test:e2e` to run the e2e tests even if a component test fails (doesn't affect CI but allows better testing locally)
- updated `cypress/e2e/storybook.cy.js` to run all storybook e2e tests if `CI_PATHS_CHANGED` is empty (that env variable os only available on CI, meaning this change won't affect CI but will allow storybook e2e tests to run locally)

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
