### PR TITLE
Fix: fuzzy search matching and highlighting

### DIFF
--- a/elements/itemfilter/src/components/filters/text.js
+++ b/elements/itemfilter/src/components/filters/text.js
@@ -17,6 +17,7 @@ export class EOxItemFilterText extends LitElement {
   static get properties() {
     return {
       filterObject: { attribute: false, type: Object },
+      results: { state: true, type: Array },
       tabIndex: { attribute: false, type: Number },
       unstyled: { type: Boolean },
       isValid: { state: true, type: Boolean },
@@ -30,6 +31,11 @@ export class EOxItemFilterText extends LitElement {
      * @type Object
      */
     this.filterObject = {};
+
+    /**
+     * @type Array
+     */
+    this.results = null;
 
     /**
      * @type Boolean
@@ -52,6 +58,28 @@ export class EOxItemFilterText extends LitElement {
    */
   #inputHandler = () => {
     textInputHandlerMethod(this);
+  };
+
+  /**
+   * Handles the keydown event when enter is pressed and result is just one item
+   * then add the item to selected result by triggering the result event
+   */
+  #keydownHandler = (e) => {
+    if (
+      e.key === "Enter" &&
+      !!e.target.value &&
+      this.results &&
+      this.results.length === 1
+    ) {
+      this.dispatchEvent(
+        new CustomEvent("result", {
+          detail: this.results[0],
+        }),
+      );
+
+      e.target.value = "";
+      this.#inputHandler();
+    }
   };
 
   /**
@@ -99,6 +127,7 @@ export class EOxItemFilterText extends LitElement {
               pattern="${this.filterObject.validation?.pattern || ".*"}"
               @input="${this.debouncedInputHandler}"
               @click=${(evt) => evt.stopPropagation()}
+              @keydown=${this.#keydownHandler}
             />
           </div>
         </div>

--- a/elements/itemfilter/src/helpers/capitalize.js
+++ b/elements/itemfilter/src/helpers/capitalize.js
@@ -1,0 +1,14 @@
+/**
+ * Capitalize the first letter of each word in a string.
+ *
+ * @param {string} str - The string to capitalize.
+ * @returns {string} The capitalized string.
+ */
+function capitalize(str) {
+  return str
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export default capitalize;

--- a/elements/itemfilter/src/helpers/filter-client.js
+++ b/elements/itemfilter/src/helpers/filter-client.js
@@ -12,7 +12,7 @@ let _fuse;
  */
 export const indexItems = (items, fuseConfig) => {
   _fuse = new Fuse(items, {
-    threshold: 0.1,
+    threshold: 0.4,
     distance: 50,
     ignoreLocation: true,
     includeMatches: true,

--- a/elements/itemfilter/src/helpers/filter-client.js
+++ b/elements/itemfilter/src/helpers/filter-client.js
@@ -12,8 +12,9 @@ let _fuse;
  */
 export const indexItems = (items, fuseConfig) => {
   _fuse = new Fuse(items, {
-    threshold: 0.4,
+    threshold: 0.1,
     distance: 50,
+    ignoreLocation: true,
     includeMatches: true,
     useExtendedSearch: true,
     ...fuseConfig,

--- a/elements/itemfilter/src/helpers/highlighting.js
+++ b/elements/itemfilter/src/helpers/highlighting.js
@@ -1,3 +1,5 @@
+import { capitalize } from "./";
+
 /**
  * Highlights matched text in the Fuse.js search results.
  *
@@ -65,11 +67,11 @@ function highlight(
 
       matches.forEach((match) => {
         if (match.key !== matchKey) return; // Skip if the match key does not match
-        set(
-          highlightedItem,
-          match.key,
-          generateHighlightedText(match.value, match.indices), // Highlight the matched text
-        );
+        const value = generateHighlightedText(
+          capitalize(match.value),
+          match.indices,
+        ); // Highlight the matched text
+        highlightedItem["highlightedText"] = value;
       });
 
       return highlightedItem;

--- a/elements/itemfilter/src/helpers/highlighting.js
+++ b/elements/itemfilter/src/helpers/highlighting.js
@@ -41,9 +41,12 @@ function highlight(
   const generateHighlightedText = (inputText, regions = []) => {
     let content = "";
     let nextUnhighlightedRegionStartingIndex = 0;
+    let longestIndexValue = 0;
 
-    regions.forEach((region) => {
+    regions.forEach((region, index) => {
       const lastRegionNextIndex = region[1] + 1;
+      if (index && longestIndexValue > region[0]) return;
+      longestIndexValue = region[1];
 
       content += [
         inputText.substring(nextUnhighlightedRegionStartingIndex, region[0]),

--- a/elements/itemfilter/src/helpers/highlighting.js
+++ b/elements/itemfilter/src/helpers/highlighting.js
@@ -1,4 +1,4 @@
-import { capitalize } from "./";
+import { capitalize, mergeHighlightIndices } from "./";
 
 /**
  * Highlights matched text in the Fuse.js search results.
@@ -72,7 +72,7 @@ function highlight(
         if (match.key !== matchKey) return; // Skip if the match key does not match
         const value = generateHighlightedText(
           capitalize(match.value),
-          match.indices,
+          mergeHighlightIndices(match.indices),
         ); // Highlight the matched text
         highlightedItem["highlightedText"] = value;
       });

--- a/elements/itemfilter/src/helpers/highlighting.js
+++ b/elements/itemfilter/src/helpers/highlighting.js
@@ -14,24 +14,6 @@ function highlight(
   matchKey = "title",
 ) {
   /**
-   * Sets a value at a specified path within an object.
-   *
-   * @param {Object} obj - The object to modify.
-   * @param {string} path - The dot-separated path specifying the location within the object.
-   * @param {*} value - The value to set at the specified path.
-   */
-  const set = (obj, path, value) => {
-    const pathValue = path.split(".");
-    let i;
-
-    for (i = 0; i < pathValue.length - 1; i++) {
-      obj = obj[pathValue[i]];
-    }
-
-    obj[pathValue[i]] = value;
-  };
-
-  /**
    * Generates HTML string with highlighted regions.
    *
    * @param {string} inputText - The text to be highlighted.

--- a/elements/itemfilter/src/helpers/index.js
+++ b/elements/itemfilter/src/helpers/index.js
@@ -10,3 +10,4 @@ export { default as filterExternal } from "./filter-external";
 export { default as toggleAccordion } from "./toggle-accordion";
 export { default as getValue } from "./get-value";
 export { default as capitalize } from "./capitalize";
+export { default as mergeHighlightIndices } from "./merge-highlight-indices";

--- a/elements/itemfilter/src/helpers/index.js
+++ b/elements/itemfilter/src/helpers/index.js
@@ -9,3 +9,4 @@ export { default as isFiltersDirty } from "./is-filters-dirty";
 export { default as filterExternal } from "./filter-external";
 export { default as toggleAccordion } from "./toggle-accordion";
 export { default as getValue } from "./get-value";
+export { default as capitalize } from "./capitalize";

--- a/elements/itemfilter/src/helpers/merge-highlight-indices.js
+++ b/elements/itemfilter/src/helpers/merge-highlight-indices.js
@@ -1,0 +1,43 @@
+/**
+ * Merge highlight indices which are overlapping with existing indices and sort the range in ascending order
+ *
+ * @param {number[][]} indices
+ * @param {Object} [opts]
+ * @param {boolean} [opts.mergeAdjacent=false]
+ * @returns {number[][]}
+ */
+function mergeHighlightIndices(indices, { mergeAdjacent = false } = {}) {
+  if (!Array.isArray(indices)) return [];
+
+  // Normalize and sort
+  const sortedIndices = indices
+    .map(([startRange, endRange]) => {
+      if (startRange <= endRange) return [startRange, endRange];
+      else return [endRange, startRange];
+    })
+    .sort((range1, range2) => {
+      return range1[0] - range2[0] || range1[1] - range2[1];
+    });
+
+  // Sweep to merge & drop contained
+  const finalIndices = [];
+  for (const [startRange, endRange] of sortedIndices) {
+    if (finalIndices.length === 0) {
+      finalIndices.push([startRange, endRange]);
+      continue;
+    }
+    const lastRange = finalIndices[finalIndices.length - 1];
+    const canTwoRangeMerge = mergeAdjacent
+      ? startRange <= lastRange[1] + 1 // overlap or touching
+      : startRange <= lastRange[1]; // overlap only
+
+    if (canTwoRangeMerge) {
+      if (endRange > lastRange[1]) lastRange[1] = endRange;
+    } else {
+      finalIndices.push([startRange, endRange]);
+    }
+  }
+  return finalIndices;
+}
+
+export default mergeHighlightIndices;

--- a/elements/itemfilter/src/methods/itemfilter/create-filter.js
+++ b/elements/itemfilter/src/methods/itemfilter/create-filter.js
@@ -25,7 +25,9 @@ function createFilterMethod(filterObject, tabIndex, EOxItemFilter) {
         id="${filterId}"
         .tabIndex=${tabIndex}
         .filterObject=${filterObject}
+        .results=${EOxItemFilter.results}
         .unstyled=${EOxItemFilter.unstyled}
+        @result=${EOxItemFilter.updateResult}
         @filter=${() => EOxItemFilter.search()}
       ></eox-itemfilter-text>`;
 

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -16,11 +16,6 @@ export function createItemDetailsMethod(
   aggregationProperty,
   EOxItemFilterResults,
 ) {
-  const highlightedItems = EOxItemFilterResults.results.filter(
-    (item) => item.highlightedText,
-  );
-  const isHighlightedItems = highlightedItems.length > 0;
-
   return html`
     <details
       class="details-results"
@@ -43,9 +38,7 @@ export function createItemDetailsMethod(
             style="--_size: 1rem; padding: 0.7rem; font-size: small"
           >
             ${EOxItemFilterResults.aggregateResults(
-              isHighlightedItems
-                ? highlightedItems
-                : EOxItemFilterResults.results,
+              EOxItemFilterResults.results,
               aggregationProperty,
             ).length}
           </button>
@@ -87,7 +80,7 @@ export function createItemListMethod(
   return staticHtml`
     ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout fill-grid>`) : unsafeStatic(`<ul id="results" class="list no-space" part="results">`)}
       ${repeat(
-        highlightedItems.length ? highlightedItems : items,
+        items,
         (item) => item.id,
         (item) => staticHtml`
         ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout-item`) : unsafeStatic(`<li`)}
@@ -178,12 +171,12 @@ export function createItemListMethod(
                 () => html`
                   <div class="small-line max truncate">
                     <span
-                      class="title truncate ${isHighlightedItems
+                      class="title truncate ${item.highlightedText
                         ? "highlight-enabled"
                         : ""}"
-                      >${isHighlightedItems
-                        ? unsafeHTML(item.highlightedText)
-                        : unsafeHTML(item[config.titleProperty])}</span
+                      >${unsafeHTML(
+                        item.highlightedText || item[config.titleProperty],
+                      )}</span
                     >
                   </div>
                 `,

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -151,8 +151,13 @@ export function createItemListMethod(
                     `,
                   )}
                   <div class="title-container small-line max truncate">
-                    <span class="title truncate"
-                      >${unsafeHTML(item[config.titleProperty])}</span
+                    <span
+                      class="title truncate ${item.highlightedText
+                        ? "highlight-enabled"
+                        : ""}"
+                      >${unsafeHTML(
+                        item.highlightedText || item[config.titleProperty],
+                      )}</span
                     >
                     ${when(
                       !!item[config.subTitleProperty],

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -16,6 +16,11 @@ export function createItemDetailsMethod(
   aggregationProperty,
   EOxItemFilterResults,
 ) {
+  const highlightedItems = EOxItemFilterResults.results.filter(
+    (item) => item.highlightedText,
+  );
+  const isHighlightedItems = highlightedItems.length > 0;
+
   return html`
     <details
       class="details-results"
@@ -38,7 +43,9 @@ export function createItemDetailsMethod(
             style="--_size: 1rem; padding: 0.7rem; font-size: small"
           >
             ${EOxItemFilterResults.aggregateResults(
-              EOxItemFilterResults.results,
+              isHighlightedItems
+                ? highlightedItems
+                : EOxItemFilterResults.results,
               aggregationProperty,
             ).length}
           </button>
@@ -68,6 +75,8 @@ export function createItemListMethod(
     : results;
 
   const config = EOxItemFilterResults.config;
+  const highlightedItems = items.filter((item) => item.highlightedText);
+  const isHighlightedItems = highlightedItems.length > 0;
 
   const className = (item) =>
     EOxItemFilterResults.selectedResult?.[config.idProperty] ===
@@ -78,7 +87,7 @@ export function createItemListMethod(
   return staticHtml`
     ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout fill-grid>`) : unsafeStatic(`<ul id="results" class="list no-space" part="results">`)}
       ${repeat(
-        items,
+        highlightedItems.length ? highlightedItems : items,
         (item) => item.id,
         (item) => staticHtml`
         ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout-item`) : unsafeStatic(`<li`)}
@@ -168,8 +177,13 @@ export function createItemListMethod(
                 `,
                 () => html`
                   <div class="small-line max truncate">
-                    <span class="title truncate"
-                      >${unsafeHTML(item[config.titleProperty])}</span
+                    <span
+                      class="title truncate ${isHighlightedItems
+                        ? "highlight-enabled"
+                        : ""}"
+                      >${isHighlightedItems
+                        ? unsafeHTML(item.highlightedText)
+                        : unsafeHTML(item[config.titleProperty])}</span
                     >
                   </div>
                 `,

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -68,8 +68,6 @@ export function createItemListMethod(
     : results;
 
   const config = EOxItemFilterResults.config;
-  const highlightedItems = items.filter((item) => item.highlightedText);
-  const isHighlightedItems = highlightedItems.length > 0;
 
   const className = (item) =>
     EOxItemFilterResults.selectedResult?.[config.idProperty] ===

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -80,6 +80,9 @@ li label {
 .title {
   text-transform: var(--text-transform);
 }
+.title.highlight-enabled {
+  text-transform: inherit;
+}
 .subtitle {
   opacity: .7;
 }


### PR DESCRIPTION
## Implemented changes
- Added functionality to select the item which exactly matches the indicator when pressing the `return`.
-  Improved the `fuse` options so that it works on long strings
- Removed weird `text-transform` issue on highlight text 
- Improved the logic of `duplicate` string creation based on cleaning highlight indices. 

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->


https://github.com/user-attachments/assets/8d9c992d-7572-42b1-9595-85adc03effa2



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
