### PR TITLE
fix(style): positioning of floating properties toggle inside containers

### DIFF
--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -225,9 +225,9 @@ export class EOxJSONForm extends LitElement {
           display: none !important;
         }
         .switch-button {
-          position: fixed;
-          top: calc(100dvh - 4rem);
-          right: 60px;
+          position: absolute;
+          bottom: 2rem;
+          right: 3rem;
           z-index: 5;
           transform: scale(1.25);
         }
@@ -241,7 +241,9 @@ export class EOxJSONForm extends LitElement {
           }
         }
       </style>
-      <form></form>
+      <div class="form-container">
+        <form></form>
+      </div>
       <!-- Shows a switch/toggle for all the object editing buttons
       If unchecked, the editing buttons are not shown, if checked, they are shown -->
       ${when(

--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -20,6 +20,13 @@ export const styleEOX = `
     --background-color: var(--eox-background-color, transparent);
     background-color: var(--background-color, transparent);
   }
+  :host {
+    position: relative;
+  }
+  .form-container {
+    overflow: auto;
+    height: 100%;
+  }
   .hidden {
     visibility: hidden;
   }


### PR DESCRIPTION
## Implemented changes

This fixes the positioning of the properties toggle to be at the bottom right of the container; previously it used `position: sticky` which caused it to be positioned outside the parent container.

## Screenshots/Videos

https://github.com/user-attachments/assets/5064a91b-cea0-4253-9edc-b3f2a22b0468


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
