### PR TITLE
fix: making sure time string is returned as UTC and not localized

### DIFF
--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -7,11 +7,13 @@ import { styleEOX } from "./style.eox.js";
 import "./sliderticks.js";
 
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import dayOfYear from "dayjs/plugin/dayOfYear";
 import isoWeek from "dayjs/plugin/isoWeek";
 
 dayjs.extend(dayOfYear);
 dayjs.extend(isoWeek);
+dayjs.extend(utc);
 
 /**
  * @element eox-timecontrol
@@ -338,7 +340,7 @@ export class EOxTimeControl extends LitElement {
             : nothing}
           <small part="current">
             ${this.displayFormat
-              ? dayjs(this.controlValues[this._newStepIndex]).format(
+              ? dayjs(this.controlValues[this._newStepIndex]).utc().format(
                   this.displayFormat,
                 )
               : this.controlValues[this._newStepIndex]}

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -340,9 +340,9 @@ export class EOxTimeControl extends LitElement {
             : nothing}
           <small part="current">
             ${this.displayFormat
-              ? dayjs(this.controlValues[this._newStepIndex]).utc().format(
-                  this.displayFormat,
-                )
+              ? dayjs(this.controlValues[this._newStepIndex])
+                  .utc()
+                  .format(this.displayFormat)
               : this.controlValues[this._newStepIndex]}
           </small>
           ${this.navigation


### PR DESCRIPTION
## Implemented changes

Added UTC to displayformat creation to make sure UTC time string is returned and not localized string.

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
