### PR TITLE
fix: set prevent-scroll true as default for map tours

### DIFF
--- a/elements/storytelling/src/enums/plugin.js
+++ b/elements/storytelling/src/enums/plugin.js
@@ -27,7 +27,10 @@ export const TAGS_SELF_CLOSING = {
 
 export const DEFAULT_MODE_ATTRS = {
   "eox-map": {
-    tour: [["style", "pointer-events: none"]],
+    tour: [
+      ["style", "pointer-events: none"],
+      ["prevent-scroll", "true"],
+    ],
   },
   img: {
     hero: [

--- a/elements/storytelling/stories/markdown-editor.js
+++ b/elements/storytelling/stories/markdown-editor.js
@@ -92,7 +92,7 @@ We will now have a more in-depth look about the map section. The map section sho
 ### Some title for map <!--{ style="color: white; font-size: 1.25rem;" }-->
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
-## Map Tour section <!--{ as="eox-map" prevent-scroll="true" class="overlay-br" mode="tour" }-->
+## Map Tour section <!--{ as="eox-map" class="overlay-br" mode="tour" }-->
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->
 
 ### <!--{ layers='[{"type":"Tile","properties":{"id":"osm"},"source":{"type":"OSM"}}]' center=[12.46,41.89] zoom="5" animationOptions="{duration:500}" }-->


### PR DESCRIPTION
## Implemented changes

Fixes a regression caused by https://github.com/EOX-A/EOxElements/pull/1805, as mentioned in #1819.
The `prevent-scroll` attribute is now set by default, unless the story creator explicitly wants to remove it.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
