### PR TITLE
feat: implement tooltips and extent limits in `eox-geosearch`

### DIFF
--- a/elements/geosearch/README.md
+++ b/elements/geosearch/README.md
@@ -24,6 +24,33 @@ import "@eox/geosearch/dist/eox-geosearch.js"
 
 ## Configuration
 
+### Geographic Extent
+
+You can limit search results to a specific geographic area using the `extent` attribute. This is particularly useful when your application only supports specific regions. The format is `minLon,minLat,maxLon,maxLat`:
+
+```html
+<eox-geosearch extent="-125.0,24.0,-66.0,49.0"></eox-geosearch>
+```
+
+This example would limit results to approximately North America.
+
+### Tooltip
+
+Add a BeerCSS tooltip to the search button using the `tooltip` attribute (only works in button mode). You can also control the tooltip direction with `tooltip-direction`:
+
+```html
+<eox-geosearch
+  tooltip="Search for locations"
+  tooltip-direction="bottom"
+  button
+  small
+></eox-geosearch>
+```
+
+Supported tooltip directions: `left` (default), `top`, `bottom`, `right`
+
+### Alignment
+
 Furthermore, the alignment of the input and search results can be configured to align straight or in a 90-degree angle in any direction with the `input-direction` and `results-direction` attributes and the following directions:
 
 - `left`

--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -137,6 +137,29 @@ class EOxGeoSearch extends LitElement {
         type: String,
         attribute: "loader-svg",
       },
+      /**
+       * Geographic extent to limit search results in the format "minLon,minLat,maxLon,maxLat".
+       * This corresponds to OpenCage API's bounds parameter.
+       * Example: "-0.563160,51.280430,0.278970,51.683979"
+       */
+      extent: {
+        type: String,
+      },
+      /**
+       * Tooltip text to display on the search button/input (uses BeerCSS tooltip).
+       */
+      tooltip: {
+        type: String,
+      },
+      /**
+       * Direction of the tooltip relative to the button.
+       * Options: "top", "bottom", "left", "right"
+       * Default: "left"
+       */
+      tooltipDirection: {
+        type: String,
+        attribute: "tooltip-direction",
+      },
     };
   }
 
@@ -173,6 +196,9 @@ class EOxGeoSearch extends LitElement {
      */
     this.unstyled = false;
     this.loaderSvg = loaderSvg;
+    this.extent = undefined;
+    this.tooltip = undefined;
+    this.tooltipDirection = "left";
 
     /**
      * @private
@@ -181,9 +207,15 @@ class EOxGeoSearch extends LitElement {
       if (this._query.length < 2) return;
       this._isLoading = true;
       try {
-        const uri = `${this.endpoint}${
+        let uri = `${this.endpoint}${
           this.endpoint.includes("?") ? "&" : "?"
         }${this.queryParameter ?? "q"}=${this._query}`;
+
+        // Add bounds parameter if extent is defined
+        if (this.extent) {
+          uri += `&bounds=${this.extent}`;
+        }
+
         const response = await fetch(encodeURI(uri));
         const json = await response.json();
         this._data = json.results;
@@ -333,6 +365,7 @@ class EOxGeoSearch extends LitElement {
         }}
         >
         ${!this.unstyled ? html`<i class="front small">${searchIcon}</i>` : ""}
+        ${this.tooltip && this.button && !this._isListVisible ? html`<div class="tooltip ${this.tooltipDirection}">${this.tooltip}</div>` : ""}
 
   ${this.button || this.unstyled ? "" : html`<input placeholder="Type to search" />`}
   <menu id="search" class="surface ${this.button ? `no-wrap ${this.direction} ${this.resultsDirection === "up" ? "top" : "bottom"}` : ""} min${this._isListVisible ? " active" : ""}">

--- a/elements/geosearch/stories/extent-limit.js
+++ b/elements/geosearch/stories/extent-limit.js
@@ -1,0 +1,40 @@
+import { html } from "lit";
+
+const ExtentLimit = {
+  args: {
+    endpoint: "/opencage-mock-data.json",
+    extent: "-125.0,24.0,-66.0,49.0", // North America extent
+    tooltip: "Search within North America",
+    tooltipDirection: "right",
+  },
+  render: (args) => {
+    return html`
+      <eox-geosearch
+        label="Search"
+        button
+        small
+        style="position: absolute; top: 36px; left: 32px; z-index: 12;"
+        .endpoint="${args.endpoint}"
+        .extent="${args.extent}"
+        .tooltip="${args.tooltip}"
+        .tooltipDirection="${args.tooltipDirection}"
+      ></eox-geosearch>
+
+      <eox-map
+        id="geosearch-map-extent"
+        .animationOptions=${{
+          duration: 400,
+          padding: [10, 10, 10, 10],
+        }}
+        .config=${{
+          layers: [{ type: "Tile", source: { type: "OSM" } }],
+          view: { center: [-95, 38], zoom: 4 },
+        }}
+        style="width: 100%; height: 500px;"
+      >
+      </eox-map>
+    `;
+  },
+};
+
+export default ExtentLimit;

--- a/elements/geosearch/stories/geosearch.stories.js
+++ b/elements/geosearch/stories/geosearch.stories.js
@@ -2,7 +2,9 @@ import {
   ButtonModeStory,
   CustomAlignmentsStory,
   CustomLoaderStory,
+  ExtentLimitStory,
   PrimaryStory,
+  RealAPIStory,
 } from "./index.js";
 
 export default {
@@ -18,3 +20,7 @@ export const ButtonMode = ButtonModeStory;
 export const CustomAlignments = CustomAlignmentsStory;
 
 export const CustomLoader = CustomLoaderStory;
+
+export const ExtentLimit = ExtentLimitStory;
+
+export const RealAPI = RealAPIStory;

--- a/elements/geosearch/stories/index.js
+++ b/elements/geosearch/stories/index.js
@@ -2,3 +2,5 @@ export { default as PrimaryStory } from "./primary";
 export { default as ButtonModeStory } from "./button-mode";
 export { default as CustomAlignmentsStory } from "./custom-alignments";
 export { default as CustomLoaderStory } from "./custom-loader";
+export { default as ExtentLimitStory } from "./extent-limit";
+export { default as RealAPIStory } from "./real-api";

--- a/elements/geosearch/stories/real-api.js
+++ b/elements/geosearch/stories/real-api.js
@@ -1,0 +1,47 @@
+import { html } from "lit";
+
+// IMPORTANT: Replace YOUR_API_KEY with a real OpenCage API key
+// Get one free at: https://opencagedata.com/api
+const RealAPI = {
+  args: {
+    endpoint: "https://api.opencagedata.com/geocode/v1/json?key=YOUR_API_KEY",
+    extent: "-125.0,24.0,-66.0,49.0", // North America extent
+    tooltip: "Search within North America",
+    tooltipDirection: "right",
+  },
+  render: (args) => {
+    return html`
+      <div style="padding: 20px;">
+        <p style="margin-bottom: 20px;">
+          ⚠️ To test with real API: Replace YOUR_API_KEY in the endpoint with your OpenCage API key
+        </p>
+        <eox-geosearch
+          label="Search"
+          button
+          small
+          style="position: absolute; top: 100px; left: 32px; z-index: 12;"
+          .endpoint="${args.endpoint}"
+          .extent="${args.extent}"
+          .tooltip="${args.tooltip}"
+          .tooltipDirection="${args.tooltipDirection}"
+        ></eox-geosearch>
+
+        <eox-map
+          id="geosearch-map-real"
+          .animationOptions=${{
+            duration: 400,
+            padding: [10, 10, 10, 10],
+          }}
+          .config=${{
+            layers: [{ type: "Tile", source: { type: "OSM" } }],
+            view: { center: [-95, 38], zoom: 4 },
+          }}
+          style="width: 100%; height: 500px; margin-top: 60px;"
+        >
+        </eox-map>
+      </div>
+    `;
+  },
+};
+
+export default RealAPI;

--- a/elements/geosearch/test/general.cy.js
+++ b/elements/geosearch/test/general.cy.js
@@ -23,4 +23,35 @@ describe("EOxGeoSearch", () => {
   it("should find the geosearch element", () => {
     cy.get("eox-geosearch").should("exist");
   });
+
+  it("should support extent parameter", () => {
+    cy.mount(
+      `
+        <eox-geosearch
+            label="Search"
+            button
+            endpoint="./opencage-mock-data.json"
+            extent="-125.0,24.0,-66.0,49.0"
+        ></eox-geosearch>
+      `,
+    );
+    cy.get("eox-geosearch").should("have.attr", "extent", "-125.0,24.0,-66.0,49.0");
+  });
+
+  it("should support tooltip parameter", () => {
+    cy.mount(
+      `
+        <eox-geosearch
+            label="Search"
+            button
+            small
+            endpoint="./opencage-mock-data.json"
+            tooltip="Search for locations"
+            tooltip-direction="bottom"
+        ></eox-geosearch>
+      `,
+    );
+    cy.get("eox-geosearch").should("have.attr", "tooltip", "Search for locations");
+    cy.get("eox-geosearch").should("have.attr", "tooltip-direction", "bottom");
+  });
 });


### PR DESCRIPTION
## Implemented changes

- Add support for limiting of the search area to only show locations that are within the specified bounds.
- Add `tooltip` and `tooltip-direction` props for configurable text and direction to enable the `eox-geosearch` map button to show a tooltip.
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
