### PR TITLE
fix: handle array values in update-url helper

### DIFF
--- a/elements/layercontrol/src/helpers/update-url.js
+++ b/elements/layercontrol/src/helpers/update-url.js
@@ -16,7 +16,15 @@ export default function updateUrl(url, values) {
       Object.keys(value).forEach((k) => {
         searchParams.set(k, value[k]);
       });
-    } else searchParams.set(key, value); // Set the key-value pair as a search parameter
+    } else if (Array.isArray(value)) {
+      searchParams.delete(key);
+      value.forEach((v) => {
+        searchParams.append(key, v);
+      });
+    } else {
+      // Set the key-value pair as a search parameter
+      searchParams.set(key, value);
+    }
   });
 
   // Extract the URL without query parameters


### PR DESCRIPTION
## Implemented changes

Ensure that array values (`{ key: [1,2,3]}`) in url parameters are encoded as `key=1&key=2&key=3` instead of `key=1,2,3`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
  - Didn't find any test file where this behaviour was tested. Please let me know where a test should be added.
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
