### PR TITLE
fix: rename switch class/id to prevent conflicts with other elements

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -323,7 +323,9 @@ export const createEditor = (element) => {
             element.propertiesToggle &&
             !(
               /**@type {HTMLInputElement}*/ (
-                element.renderRoot.querySelector(".switch-button input")
+                element.renderRoot.querySelector(
+                  "#properties-editing-switch input",
+                )
               ).checked
             )
           ) {

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -224,19 +224,19 @@ export class EOxJSONForm extends LitElement {
           input[type="checkbox"].json-editor-opt-in {
           display: none !important;
         }
-        .switch-button {
+        #properties-editing-switch {
           position: absolute;
           bottom: 2rem;
           right: 3rem;
           z-index: 5;
           transform: scale(1.25);
         }
-        .switch-button i > svg {
+        #properties-editing-switch i > svg {
           padding: 0.3rem;
           border-radius: 0;
         }
         @media screen and (max-width: 1024px) {
-          .switch-button {
+          #properties-editing-switch {
             right: 20px;
           }
         }
@@ -249,7 +249,7 @@ export class EOxJSONForm extends LitElement {
       ${when(
         this.options?.disable_properties === false && this.propertiesToggle,
         () => html`
-          <label class="switch icon switch-button">
+          <label class="switch icon" id="properties-editing-switch">
             <input
               type="checkbox"
               @input=${(e) => {


### PR DESCRIPTION
## Implemented changes

This PR changes the class/id of the editing toggle switch from `.switch-button` to `#properties-editing-switch`, since it was causing conflicts with another `.switch-button` in eox-storytelling.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
