### PR TITLE
fix(style): section spacing with/without editing mode

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -308,6 +308,7 @@ const styleEOX = `
     margin-left: auto;
     display: block;
     padding: var(--block-spacing-vertical) var(--block-spacing-horizontal);
+    border-bottom: 1px solid transparent;
   }
 
   @media (min-width: 576px) {
@@ -315,29 +316,26 @@ const styleEOX = `
       max-width: 510px;
       padding-right: 0;
       padding-left: 0;
-      --block-spacing-vertical: calc(var(--spacing)* 2.5);
-    }
+      }
   }
 
   @media (min-width: 768px) {
     .story-telling .container {
       max-width: 700px;
-      --block-spacing-vertical: calc(var(--spacing)* 3);
-    }
+      }
   }
 
   @media (min-width: 992px) {
     .story-telling .container {
       max-width: 920px;
-      --block-spacing-vertical: calc(var(--spacing)* 3.5);
-    }
+      }
   }
 
   .story-telling .section-wrap.section-item * {
     overflow-x: hidden;
   }
 
-  .story-telling.editor-enabled .section-wrap.section-item {
+  .story-telling.editor-enabled:not(.editor-closed) .section-wrap.section-item {
     position: relative;
     border-bottom: 1px solid #efefef;
   }


### PR DESCRIPTION
## Implemented changes
This fixes the spacing between sections:
- the spacing on desktop was reduced from over 3rem to 2rem
- when toggling off the editor, the separator line is removed to preview the story how it will actually look like (previously, the line was present if editing was enabled, even though the editor was switched off, resulting in a discrepancy between editing mode an viewing mode

## Screenshots/Videos
### Before
<img width="587" height="455" alt="image" src="https://github.com/user-attachments/assets/78003ed4-2ec2-4403-9e28-d8c5d2745583" />
<img width="556" height="524" alt="image" src="https://github.com/user-attachments/assets/2ba82475-12e4-4014-b2d5-5d7644eb986a" />

### After
<img width="592" height="410" alt="image" src="https://github.com/user-attachments/assets/8ba1db48-400e-4a42-aace-ca10b58b15c6" />
<img width="532" height="413" alt="image" src="https://github.com/user-attachments/assets/30efb38c-3c57-457a-9b0e-f0bf879b0376" />


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
