### PR TITLE
feat: support nested properties for titleProperty and subTitleProperty

### DIFF
--- a/elements/itemfilter/src/methods/itemfilter/sort-results.js
+++ b/elements/itemfilter/src/methods/itemfilter/sort-results.js
@@ -1,3 +1,5 @@
+import { getValue } from "../../helpers";
+
 /**
  * Sorts the provided items based on the title property specified in the configuration.
  *
@@ -7,7 +9,10 @@
  */
 function sortResultsMethod(items, config) {
   return [...items].sort((a, b) =>
-    a[config.titleProperty].localeCompare(b[config.titleProperty]),
+    getValue(config.titleProperty, a)
+      .toString()
+      .localeCompare(getValue(config.titleProperty, b))
+      .toString(),
   );
 }
 

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -156,15 +156,16 @@ export function createItemListMethod(
                         ? "highlight-enabled"
                         : ""}"
                       >${unsafeHTML(
-                        item.highlightedText || item[config.titleProperty],
+                        item.highlightedText ||
+                          getValue(config.titleProperty, item).toString(),
                       )}</span
                     >
                     ${when(
-                      !!item[config.subTitleProperty],
+                      !!getValue(config.subTitleProperty, item),
                       () => html`
                         <small class="subtitle no-line truncate"
                           >${unsafeHTML(
-                            item[config.subTitleProperty].toString(),
+                            getValue(config.subTitleProperty, item).toString(),
                           )}</small
                         >
                       `,


### PR DESCRIPTION
## Implemented changes

This adds nested property support to `titleProeprty` and `subTitleProperty` as it was already implemented in `imageProperty`. It also fixes sorting and localeCompare by supporting non-string values as property.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
