### PR TITLE
feat: support callback functions for title, subTitle and image properties

### DIFF
--- a/elements/itemfilter/src/helpers/get-value.js
+++ b/elements/itemfilter/src/helpers/get-value.js
@@ -1,11 +1,14 @@
 /**
  * Get value based on nested key or individual key
  *
- * @param {string} key - Key to identify the value
+ * @param {string|Function} key - Key to identify the value
  * @param {Object} items - Items contain list of key & it's value
  * @returns {any}
  */
 export default function getValue(key, items) {
+  if (typeof key === "function") {
+    return key(items);
+  }
   return key?.includes(".")
     ? key.split(".").reduce((acc, key) => acc && acc[key], items)
     : items[key];

--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -190,22 +190,25 @@ export class EOxItemFilter extends LitElement {
 
     /**
      * The property of the result items used for display
+     * Supports passing a function which recieves the current item as parameter and is expected to return a string
      *
-     * @type String
+     * @type String|Function
      */
     this.titleProperty = "title";
 
     /**
      * The property of the result items used for a subtitle
+     * Supports passing a function which recieves the current item as parameter and is expected to return a string
      *
-     * @type String
+     * @type String|Function
      */
     this.subTitleProperty = undefined;
 
     /**
      * The property of the result items used for an image
+     * Supports passing a function which recieves the current item as parameter and is expected to return a string
      *
-     * @type String
+     * @type String|Function
      */
     this.imageProperty = undefined;
 


### PR DESCRIPTION
## Implemented changes

This PR adds support for functions additonal to property paths for `titleProeprty`, `subTitleProperty`, `imageProperty`.

Example:
```js
// itemfilter config
titleProperty: "id",
subTitleProperty: (item) => `Cloud cover: ${item.properties['eo:cloud_cover'].toFixed(1)}%`
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
