### PR TITLE
feat: emit mouseenter and mouseleave events on results

### DIFF
--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -409,6 +409,42 @@ export class EOxItemFilter extends LitElement {
   }
 
   /**
+   * Dispatches an event when result component triggers the "mouseenter:result" event.
+   *
+   * @param {{detail: Object}} evt - "mouseenter:result" event triggered by result component
+   */
+  mouseEnterResult(evt) {
+    /**
+     * Fires when a result is hovered; event detail is `result`
+     */
+    this.dispatchEvent(
+      new CustomEvent("mouseenter:result", {
+        detail: evt.detail,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
+   * Dispatches an event when result component triggers the "mouseleave:result" event.
+   *
+   * @param {{detail: Object}} evt - "mouseleave:result" event triggered by result component
+   */
+  mouseLeaveResult(evt) {
+    /**
+     * Fires when a result is hovered; event detail is `result`
+     */
+    this.dispatchEvent(
+      new CustomEvent("mouseleave:result", {
+        detail: evt.detail,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
    * Emits "click:result-action" event.
    *
    * @param {{detail: Object}} evt - "click:result-action" event triggered by result component
@@ -545,6 +581,8 @@ export class EOxItemFilter extends LitElement {
               .enableResultAction=${this.enableResultAction}
               .resultActionIcon=${this.resultActionIcon}
               @result=${this.updateResult}
+              @mouseenter:result=${this.mouseEnterResult}
+              @mouseleave:result=${this.mouseLeaveResult}
               @click:result-action=${this.emitResultAction}
             >
               <nav class="title-nav">

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -95,6 +95,20 @@ export function createItemListMethod(
                 }),
               );
             }}
+            @mouseenter=${() => {
+              EOxItemFilterResults.dispatchEvent(
+                new CustomEvent("mouseenter:result", {
+                  detail: item,
+                }),
+              );
+            }}
+            @mouseleave=${() => {
+              EOxItemFilterResults.dispatchEvent(
+                new CustomEvent("mouseleave:result", {
+                  detail: item,
+                }),
+              );
+            }}
           >
             <nav id="${item.id}" class="responsive tiny-space">
               ${when(


### PR DESCRIPTION
## Implemented changes

This PR adds support for `mouseenter:result` and `mouseleave:result` events. These are triggered when result items are hovered.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
