### PR TITLE
feat: support layerconfig custom editor interfaces

### DIFF
--- a/elements/layercontrol/src/components/layer-config.js
+++ b/elements/layercontrol/src/components/layer-config.js
@@ -27,6 +27,7 @@ export class EOxLayerControlLayerConfig extends LitElement {
     unstyled: { type: Boolean },
     noShadow: { type: Boolean },
     layerConfig: { attribute: false },
+    customEditorInterfaces: { attribute: false, type: Array },
   };
 
   /**
@@ -92,6 +93,15 @@ export class EOxLayerControlLayerConfig extends LitElement {
      * Throttle #handleDataChange() by 1000 milliseconds
      */
     this.throttleDataChange = _throttle(this.#handleDataChange, 1000);
+
+    /**
+     * List of custom editor interfaces for layer config eox-jsonform
+     * Read more about the implementation of custom editor interfaces here:
+     * https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
+     *
+     * @type {Array}
+     */
+    this.customEditorInterfaces = [];
   }
 
   /** Decide what type of throttling to do based on layerConfig type
@@ -201,6 +211,7 @@ export class EOxLayerControlLayerConfig extends LitElement {
             .value=${this.#startVals}
             .options=${options}
             .noShadow=${true}
+            .customEditorInterfaces=${this.customEditorInterfaces}
             @change=${this.throttleDataChange}
           ></eox-jsonform>
         `,

--- a/elements/layercontrol/src/components/layer-group.js
+++ b/elements/layercontrol/src/components/layer-group.js
@@ -24,6 +24,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     globallyExclusiveLayers: { type: Boolean },
+    customEditorInterfaces: { attribute: false, type: Array },
   };
 
   constructor() {
@@ -99,6 +100,15 @@ export class EOxLayerControlLayerGroup extends LitElement {
      * @type {Boolean}
      */
     this.globallyExclusiveLayers = false;
+
+    /**
+     * List of custom editor interfaces for layer config eox-jsonform
+     * Read more about the implementation of custom editor interfaces here:
+     * https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
+     *
+     * @type {Array}
+     */
+    this.customEditorInterfaces = [];
   }
 
   /**
@@ -169,6 +179,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
                 .unstyled=${this.unstyled}
                 .toolsAsList=${this.toolsAsList}
                 .globallyExclusiveLayers=${this.globallyExclusiveLayers}
+                .customEditorInterfaces=${this.customEditorInterfaces}
                 @changed=${() => this.requestUpdate()}
               ></eox-layercontrol-layer>
             </summary>

--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -24,6 +24,7 @@ export class EOxLayerControlLayerList extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     globallyExclusiveLayers: { type: Boolean },
+    customEditorInterfaces: { attribute: false, type: Array },
   };
 
   constructor() {
@@ -100,6 +101,15 @@ export class EOxLayerControlLayerList extends LitElement {
      * @type {Boolean}
      */
     this.globallyExclusiveLayers = false;
+
+    /**
+     * List of custom editor interfaces for layer config eox-jsonform
+     * Read more about the implementation of custom editor interfaces here:
+     * https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
+     *
+     * @type {Array}
+     */
+    this.customEditorInterfaces = [];
   }
 
   /**
@@ -160,6 +170,8 @@ export class EOxLayerControlLayerList extends LitElement {
                             .toolsAsList=${this.toolsAsList}
                             .globallyExclusiveLayers=${this
                               .globallyExclusiveLayers}
+                            .customEditorInterfaces=${this
+                              .customEditorInterfaces}
                             @changed=${() => this.requestUpdate()}
                           >
                           </eox-layercontrol-layer-group>
@@ -177,6 +189,8 @@ export class EOxLayerControlLayerList extends LitElement {
                             .toolsAsList=${this.toolsAsList}
                             .globallyExclusiveLayers=${this
                               .globallyExclusiveLayers}
+                            .customEditorInterfaces=${this
+                              .customEditorInterfaces}
                             @changed=${() => this.requestUpdate()}
                           ></eox-layercontrol-layer>
                         `

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -34,6 +34,7 @@ export class EOxLayerControlLayerTools extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     embedded: { state: true },
+    customEditorInterfaces: { attribute: false, type: Array },
   };
 
   constructor() {
@@ -83,6 +84,15 @@ export class EOxLayerControlLayerTools extends LitElement {
     setTimeout(() => {
       this.embedded = this.parentElement?.tagName === "EOX-LAYERCONTROL-LAYER";
     });
+
+    /**
+     * List of custom editor interfaces for layer config eox-jsonform
+     * Read more about the implementation of custom editor interfaces here:
+     * https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
+     *
+     * @type {Array}
+     */
+    this.customEditorInterfaces = [];
   }
 
   /**
@@ -141,6 +151,7 @@ export class EOxLayerControlLayerTools extends LitElement {
               .noShadow=${true}
               .layerConfig=${this.layer.get("layerConfig")}
               .unstyled=${this.unstyled}
+              .customEditorInterfaces=${this.customEditorInterfaces}
               @changed=${() => this.requestUpdate()}
             ></eox-layercontrol-layerconfig>
           `,

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -31,6 +31,7 @@ export class EOxLayerControlLayer extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     globallyExclusiveLayers: { type: Boolean },
+    customEditorInterfaces: { attribute: false, type: Array },
   };
 
   /**
@@ -114,6 +115,15 @@ export class EOxLayerControlLayer extends LitElement {
      * @type {Boolean}
      */
     this.globallyExclusiveLayers = false;
+
+    /**
+     * List of custom editor interfaces for layer config eox-jsonform
+     * Read more about the implementation of custom editor interfaces here:
+     * https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
+     *
+     * @type {Array}
+     */
+    this.customEditorInterfaces = [];
   }
 
   /**
@@ -358,6 +368,7 @@ export class EOxLayerControlLayer extends LitElement {
             .tools=${this.tools}
             .unstyled=${this.unstyled}
             .toolsAsList=${this.toolsAsList}
+            .customEditorInterfaces=${this.customEditorInterfaces}
           ></eox-layercontrol-layer-tools>
         `,
       )}

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -68,6 +68,7 @@ export class EOxLayerControl extends LitElement {
       attribute: "globally-exclusive-layers",
       type: Boolean,
     },
+    customEditorInterfaces: { attribute: false, type: Array },
   };
 
   /**
@@ -159,6 +160,15 @@ export class EOxLayerControl extends LitElement {
      * @type {Boolean}
      */
     this.globallyExclusiveLayers = false;
+
+    /**
+     * List of custom editor interfaces for layer config eox-jsonforms
+     * Read more about the implementation of custom editor interfaces here:
+     * https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
+     *
+     * @type {Array}
+     */
+    this.customEditorInterfaces = [];
   }
 
   /**
@@ -255,6 +265,7 @@ export class EOxLayerControl extends LitElement {
             .unstyled=${this.unstyled}
             .toolsAsList=${this.toolsAsList}
             .globallyExclusiveLayers=${this.globallyExclusiveLayers}
+            .customEditorInterfaces=${this.customEditorInterfaces}
             @changed=${this.#handleLayerControlLayerListChange}
             @datetime:updated=${(evt) => handleDatetimeUpdate(evt, this)}
             @layerConfig:change=${this.#handleLayerConfigChange}


### PR DESCRIPTION
## Implemented changes

This PR adds support for `customEditorInterfaces` analog to `eox-jsonform`.

## Screenshots/Videos

<img width="289" height="356" alt="image" src="https://github.com/user-attachments/assets/9ea29ada-c33d-45c9-9441-e2d0218aac5e" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
