### PR TITLE
feat: introduce `options.removeProperties` to tileURL layerConfig

### DIFF
--- a/elements/layercontrol/src/helpers/get-start-vals.js
+++ b/elements/layercontrol/src/helpers/get-start-vals.js
@@ -55,10 +55,11 @@ export function getStartVals(layer, layerConfig) {
     // Extract query parameters from tile URL
     // @ts-expect-error TODO
     const url = new URL(layer.getSource().getTileUrlFunction()([0, 0, 0]));
-    const removeProperties = layerConfig.schema?.options?.removeProperties ?? [];
+    const removeProperties =
+      layerConfig.schema?.options?.removeProperties ?? [];
     // Remove unwanted properties from query parameters
     removeProperties.forEach((prop) => url.searchParams.delete(prop));
-    
+
     // Retrieve startVals based on schema and query parameters
     nestedValues = {};
     for (const [key, value] of url.searchParams.entries()) {


### PR DESCRIPTION
## Implemented changes
This PR adds the possibility to add an array of params in the schema to be removed from the Tile URL prior to applying the form values, it also includes a fix for retrieving the start values from the URL based on the serialization applied on #1828

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
