### PR TITLE
fix: layerConfig showing the legend when it matches `boundTo`

### DIFF
--- a/elements/layercontrol/src/components/layer-legend.js
+++ b/elements/layercontrol/src/components/layer-legend.js
@@ -75,7 +75,9 @@ export class EOxLayerControlLayerLegend extends LitElement {
    * @see {@link https://clhenrick.github.io/color-legend-element/}
    **/
   set layerLegend(value) {
-    if (Array.isArray(value)) {
+    if (!value) {
+      this.#layerLegend = null;
+    } else if (Array.isArray(value)) {
       this.#layerLegend = value.map((config, idx) => ({
         id: (this.layer?.get("id") ?? "") + idx,
         ...config,

--- a/elements/layercontrol/src/helpers/get-legend-config.js
+++ b/elements/layercontrol/src/helpers/get-legend-config.js
@@ -36,17 +36,17 @@ const getLegendConfig = (legendConfig, data) => {
     const propName = legend.boundTo.key;
     const expectedToMatch = legend.boundTo.value;
 
-    // if the property is not in the data, the legend will be shown
-    return !(propName in flatData) || flatData[propName] == expectedToMatch;
+    // only show the legend if the property exists and matches the expected value
+    return propName in flatData && flatData[propName] == expectedToMatch;
   });
 
-  // if no active legends are found, use all legends
+  // If no legends are active, return null
   if (!activeLegends.length) {
-    activeLegends = availableLegends;
+    activeLegends = null;
   }
 
-  return /** @type {import("../components/layer-legend").LegendConfig[]} */ (
-    activeLegends.map((activeLegend) => {
+  return /** @type {import("../components/layer-legend").LegendConfig[] | null} */ (
+    activeLegends?.map((activeLegend) => {
       delete activeLegend.boundTo;
       if (!("domainProperties" in activeLegend) || "domain" in activeLegend) {
         return activeLegend;


### PR DESCRIPTION
## Implemented changes
This ensures that the legend is only shown in case the value of `boundTo.key` matches `boundTo.value`
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
