### PR TITLE
fix: bubble up `layerConfig:change` event

### DIFF
--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -102,6 +102,22 @@ export class EOxLayerControlLayerTools extends LitElement {
     return this.noShadow ? this : super.createRenderRoot();
   }
 
+  /**
+   * Bubbles up the layerConfig:change event with the updated jsonform value and layer reference.
+   * @param {CustomEvent} evt
+   */
+  #handleLayerConfigChange(evt) {
+    this.dispatchEvent(
+      new CustomEvent("layerConfig:change", {
+        bubbles: true,
+        detail: {
+          jsonformValue: evt.detail.jsonformValue,
+          layer: evt.detail.layer,
+        },
+      }),
+    );
+  }
+
   // Initializes '_removeButton' invoking 'removeButton' function with 'this' context.
   _removeButton = (icon) => removeButton(this, icon);
 
@@ -153,6 +169,7 @@ export class EOxLayerControlLayerTools extends LitElement {
               .unstyled=${this.unstyled}
               .customEditorInterfaces=${this.customEditorInterfaces}
               @changed=${() => this.requestUpdate()}
+              @layerConfig:change=${this.#handleLayerConfigChange}
             ></eox-layercontrol-layerconfig>
           `,
         )}


### PR DESCRIPTION
## Implemented changes
Dispatches the `layerConfig:change` event from the `layer-tools`. The event stopped bubbling previously up due to adding a shadowRoot to the `layer-tools` element. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
