### PR TITLE
chore: update required node engine version to v20 LTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "vite-plugin-istanbul": "^7.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.19.0"
       }
     },
     "elements/chart": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@storybook/addon-docs": "^9.1.10"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@eox/elements-utils": "^1.1.0",


### PR DESCRIPTION
## Implemented changes

Seeing that more and more packages supporting node 20 require the LTS version, it makes sense to also upgrade the required node for EOxElements to be above `v20.19.x` (current v20 LTS).
Seeing that end of life for ndoe 20 will come in April 2026, we'll need to upgrade anyways in the near future.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
