### PR TITLE
fix(style): link rendering

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -250,14 +250,12 @@ const styleEOX = `
     margin-bottom: 1.6rem;
   }
   .story-telling a {
-    --font-size: 1.1rem;
-    --color: var(--primary-color);
+    --color: var(--primary) !important;
     --background-color: transparent;
     outline: 0;
     background-color: var(--background-color);
     color: var(--color);
     text-underline-offset: 4px;
-    font-size: var(--font-size)
   }
   .story-telling sup a {
     font-size: smaller;


### PR DESCRIPTION
## Implemented changes
This fixes the rendering of links inside the storytelling element, following the core libraries style guidelines.

## Screenshots/Videos

### Before
<img width="149" height="74" alt="image" src="https://github.com/user-attachments/assets/843babb9-2586-426d-b2ba-43f32d8ba78e" />


### After
<img width="126" height="62" alt="image" src="https://github.com/user-attachments/assets/6445eee3-5ec3-43f8-83ce-a6d8e20dab42" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
