### PR TITLE
fix(style): center nav-list items

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -427,7 +427,7 @@ export function parseNavWithAddSection(
           ${nav
             .map(({ id, title, state }) =>
               state
-                ? `<li class="nav-${id}"><a href="#${id}"><small class="truncate">${title}</small></a></li>`
+                ? `<li class="nav-${id} center-align"><a href="#${id}"><small class="truncate">${title}</small></a></li>`
                 : "",
             )
             .join("")}


### PR DESCRIPTION
## Implemented changes

This PR centers nav-list items by default, as it looked strange when they are left-aligned. Closes #1898.

## Screenshots/Videos

### Before
<img width="997" height="245" alt="image" src="https://github.com/user-attachments/assets/8ea70568-31e0-42c6-a862-e799c97b11f0" />

### After
<img width="987" height="303" alt="image" src="https://github.com/user-attachments/assets/3ea19adb-8965-4a2c-9923-ba4103ce60ff" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
