### PR TITLE
fix(style): limit filter container height and make it scrollable

### DIFF
--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -480,7 +480,14 @@ export class EOxItemFilter extends LitElement {
         ${when(
           this.filterProperties,
           () => html`
-            <div style="display: var(--filter-display);">
+            <div
+              style="display: var(--filter-display); min-height: ${this
+                .inlineMode
+                ? "100%"
+                : this.filterProperties.length > 2
+                  ? "50%"
+                  : this.filterProperties.length * 32 + 105 + "px"}"
+            >
               <eox-itemfilter-container
                 .filters=${this.filters}
                 .filterProperties=${this.filterProperties}
@@ -537,7 +544,7 @@ export class EOxItemFilter extends LitElement {
                       </nav>
                     `,
                   )}
-                  <div class="scroll" style="flex: 1;">
+                  <div class="scroll" style="flex: 1; max-height: 100%">
                     <ul id="filters" class="list no-space">
                       ${map(
                         Object.values(this.filters),

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -56,6 +56,7 @@ eox-itemfilter-container {
   flex-grow: 0;
   flex-shrink: 0;
   overflow: hidden;
+  height: 100%;
 }
 eox-itemfilter-results {
   flex-grow: 1;
@@ -299,20 +300,26 @@ button.icon {
 }
 -container-results::-webkit-scrollbar,
 .inline-container::-webkit-scrollbar,
-.inline-content::-webkit-scrollbar {
+.inline-content::-webkit-scrollbar,
+form#itemfilter > div::-webkit-scrollbar {
   inline-size: 0.4rem;
   block-size: 0.4rem;
 }
 -container-results::-webkit-scrollbar-thumb,
 .inline-container::-webkit-scrollbar-thumb,
-.inline-content::-webkit-scrollbar-thumb {
+.inline-content::-webkit-scrollbar-thumb,
+form#itemfilter > div::-webkit-scrollbar-thumb {
   background: lightgrey;
   border-radius: 1rem;
   cursor: default;
 }
 .inline-container:is(:hover,:focus)::-webkit-scrollbar-thumb,
-.inline-content:is(:hover,:focus)::-webkit-scrollbar-thumb {
+.inline-content:is(:hover,:focus)::-webkit-scrollbar-thumb,
+form#itemfilter > div:is(:hover,:focus)::-webkit-scrollbar-thumb {
   background: var(--outline);
+}
+form#itemfilter > div::-webkit-scrollbar-thumb {
+  background: transparent; 
 }
 .hidden {
   height: 0;


### PR DESCRIPTION
## Implemented changes

This PR adds a maximum height for the filter container, and enables overflow/scrolling by default.
It tries to figure out how many filterProperties there are in order to set the minimum height and tries to find a compromise between filters and results display. Fixes #1897.

## Screenshots/Videos

<img width="334" height="422" alt="image" src="https://github.com/user-attachments/assets/e2d4b57a-f458-44a3-ac00-181bca5fdfe3" />
<img width="334" height="406" alt="image" src="https://github.com/user-attachments/assets/5de95150-3899-45ee-81d1-0e10b255cc10" />
<img width="758" height="324" alt="image" src="https://github.com/user-attachments/assets/a1e6fac4-9b31-437a-8bd3-9cbc8de84bea" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
