### PR TITLE
fix: add getter for EOxMap zoomExtent

### DIFF
--- a/elements/map/src/main.js
+++ b/elements/map/src/main.js
@@ -24,6 +24,7 @@ import {
   getLonLatCenterMethod,
   getLonLatExtentMethod,
   setZoomExtentMethod,
+  getZoomExtentMethod,
   setControlsMethod,
   setLayersMethod,
   setPreventScrollMethod,
@@ -326,13 +327,13 @@ export class EOxMap extends LitElement {
   }
 
   /**
-   * Gets the zoom extent of the map.
+   * Gets the current extent of the map.
    *
-   * @type {import("ol/extent").Extent} extent - The set zoom extent.
-   * @returns {import("ol/extent").Extent} extent - The set zoom extent.
+   * @type {Array<number>}
+   * @returns {Array<number>} The extent in current map projection.
    */
   get zoomExtent() {
-    return this.#zoomExtent;
+    return getZoomExtentMethod(this);
   }
 
   /**

--- a/elements/map/src/methods/map/getters.js
+++ b/elements/map/src/methods/map/getters.js
@@ -33,3 +33,15 @@ export function getLonLatExtentMethod(EOxMap) {
   // Otherwise, transform the extent to longitude/latitude
   return transformExtent(currentExtent, EOxMap.projection);
 }
+
+/**
+ * Get the current map view extent.
+ *
+ * @param {import("../../main").EOxMap} EOxMap - The map object containing the map instance, projection information, and size.
+ * @returns {import("ol/extent").Extent} - The extent of the map in map projection.
+ */
+export function getZoomExtentMethod(EOxMap) {
+  // Calculate the current extent of the map based on its view and size
+  const extent = EOxMap.map.getView().calculateExtent(EOxMap.map.getSize());
+  return extent;
+}

--- a/elements/map/src/methods/map/index.js
+++ b/elements/map/src/methods/map/index.js
@@ -9,7 +9,11 @@ export {
   setProjectionMethod,
   setSyncMethod,
 } from "./setters";
-export { getLonLatCenterMethod, getLonLatExtentMethod } from "./getters";
+export {
+  getLonLatCenterMethod,
+  getLonLatExtentMethod,
+  getZoomExtentMethod,
+} from "./getters";
 export { default as addOrUpdateLayerMethod } from "./add-update-layer";
 export {
   removeInteractionMethod,


### PR DESCRIPTION
## Implemented changes

Fixes following warning from console:

`Field "zoomExtent" on EOxMap was declared as a reactive property but it does not have a getter. This will be an error in a future version of Lit. See https://lit.dev/msg/reactive-property-without-getter for more information.`

Although the getter does not make too much sense because the zoomExtent and does not correspond to current view extent and behaves internally as a method, this pleases lit, which would error out on next major version.

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
