### PR TITLE
fix: reset map when changing drawing type

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -334,6 +334,14 @@ export class EOxDrawTools extends LitElement {
       this.eoxMap = EoxMap;
       this.#olMap = OlMap;
     }
+    if (
+      changedProperties.get("type") &&
+      changedProperties.get("type") !== this.type
+    ) {
+      this.resetLayer(this);
+      this.firstUpdated();
+      this.currentlyDrawing = false;
+    }
   }
 
   get eoxMap() {


### PR DESCRIPTION
Reset layer and update drawing state on type change.

This PR introduces a reset of the draw layer of the map connected to eox-drawtools when the `type` property is changed. This ensures that the newly selected type is usable with a new draw layer.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
