### PR TITLE
fix: render markdown links with target blank, add link class

### DIFF
--- a/elements/stacinfo/src/helpers/properties.js
+++ b/elements/stacinfo/src/helpers/properties.js
@@ -49,6 +49,23 @@ export function transformProperties(properties, element, type = "property") {
       },
     );
 
+    // Ensure all rendered <a> tags have target="_blank" and class="link"
+    property.formatted = property.formatted.replace(
+      /<a(?![^>]*class=["']?link["']?)([^>]*)>/gi,
+      (_, attrs) => {
+        // Add class="link" if not present
+        let newAttrs = attrs;
+        if (!/class=["']?link["']?/i.test(attrs)) {
+          newAttrs += ' class="link"';
+        }
+        // Add target="_blank" if not present
+        if (!/target=["']?_blank["']?/i.test(attrs)) {
+          newAttrs += ' target="_blank"';
+        }
+        return `<a${newAttrs}>`;
+      },
+    );
+
     /**
      * Filters links based on their roles and relationships.
      *


### PR DESCRIPTION
## Implemented changes

This PR addas another check for `target="_blank"` link rendering to also support markdown syntax links (`[]()`). Previously only raw links (staring with `http` etc.) were supported.
Also, the `link` class is added to make links more distinguishable from the rest of the text.

## Screenshots/Videos

### Before
<img width="820" height="408" alt="image" src="https://github.com/user-attachments/assets/5ed725bc-eb64-4037-a7c3-535ca016819b" />


### After
<img width="826" height="413" alt="image" src="https://github.com/user-attachments/assets/cf96b2b7-4c36-4eef-b583-2fdb5ba37f0b" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
