### PR TITLE
fix: ensure uniqueness of labels and checkboxes

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -218,6 +218,15 @@ export const createEditor = (element) => {
         ) {
           input.parentElement.classList.add("checkbox");
           input.parentElement.classList.add("small");
+          // Generate unique random id and for attributes
+          // since there might be multiple checkboxes with the same name
+          // hidden (when using if-then-else) causing issues with clicking labels
+          input.setAttribute(
+            "name",
+            input.getAttribute("name") + Math.round(Math.random() * 1000),
+          );
+          input.id = input.getAttribute("name");
+          parent.setAttribute("for", input.getAttribute("name"));
           const span = document.createElement("span");
           if (
             input.nextSibling &&


### PR DESCRIPTION
## Implemented changes

This fixes an issue which arose when trying to render checkboxes in a schema that uses if-then-else. Apparently, json-editor renders the form multiple times, but hides all but one. This was causing issues, since the `label` for the checkboxes were actually connected to the first (hidden) checkbox instead of the correct one. Since our theme requires labels to be clicked instead of the actual checkbox, a solution was required to uniquely connect a `label` with an `input`, not depending on the json-editor naming convention.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
