### PR TITLE
fix(style): render bullet points correctly

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -329,7 +329,7 @@ const styleEOX = `
       }
   }
 
-  .story-telling .section-wrap.section-item * {
+  .story-telling .section-wrap.section-item *:not(li) {
     overflow-x: hidden;
   }
 


### PR DESCRIPTION
## Implemented changes

This pull request makes a small adjustment to the CSS selector for the `.story-telling .section-wrap.section-item` elements. The change ensures that the `overflow-x: hidden;` style is applied to all child elements except for `li` elements, which need it in order to render their bullet points.

## Screenshots/Videos

### Before
<img width="745" height="288" alt="image" src="https://github.com/user-attachments/assets/b9b56966-5b85-4e9c-9af8-390c41446b32" />

### After
<img width="782" height="294" alt="image" src="https://github.com/user-attachments/assets/46050131-9ee3-4b28-94c7-a09f455a06a6" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
