### PR TITLE
feat: new `layerschanged` event

### DIFF
--- a/elements/map/src/main.js
+++ b/elements/map/src/main.js
@@ -109,6 +109,7 @@ addCommonStylesheet();
  * - `loadend`: Fired when the map has finished loading.
  * - `mapmounted`: Fired when the map is successfully mounted.
  * - `select`: Fired when a feature is selected.
+ * - `layerschanged`: Fired when the layers have been changed.
  *
  * ## Helper Methods
  *
@@ -122,6 +123,7 @@ addCommonStylesheet();
  * @fires {CustomEvent} loadend - The map has finished loading
  * @fires {CustomEvent} mapmounted - The map has been successfully mounted
  * @fires {CustomEvent} select - A feature is selected
+ * @fires {CustomEvent} layerschanged - The layers have been changed
  */
 export class EOxMap extends LitElement {
   // Define static properties for the component


### PR DESCRIPTION
## Implemented changes
Added a new event to the `eox-map` which emits `layerchanged` event when a layer is `set`.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
