### PR TITLE
fix: check if tooltip element is already defined

### DIFF
--- a/elements/map/src/components/tooltip.js
+++ b/elements/map/src/components/tooltip.js
@@ -66,4 +66,8 @@ export class EOxMapTooltip extends LitElement {
 }
 
 // Define the custom element
-customElements.define("eox-map-tooltip", EOxMapTooltip);
+// We first check if it has already been defined in order to prevent errors
+// as the tooltip is imported in helpers.js and thus multiple times
+if (!customElements.get("eox-map-tooltip")) {
+  customElements.define("eox-map-tooltip", EOxMapTooltip);
+}


### PR DESCRIPTION
## Implemented changes

For eox-map-tooltip`a cehck is necessary as it is imported in helpers.js and thus used multiple times.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
