### PR TITLE
fix(deps): don't overwrite plugin bundle

### DIFF
--- a/elements/map/vite.config.globe.js
+++ b/elements/map/vite.config.globe.js
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
+    emptyOutDir: false,
     lib: {
       entry: "./src/plugins/globe/index.js",
       name: "eox-map-globe",


### PR DESCRIPTION
## Implemented changes

In `v2.0.0`, the globe plugin dist by mistake overwrote the advanced layers and sources; this caused issues in vanilla JS apps without bundler as the plugin bundle was not found.
This PR prevents the globe bundle from emptying the dist folder, so both plugins are present.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
