### PR TITLE
chore: show validation error if the editor exists

### DIFF
--- a/elements/jsonform/src/custom-inputs/spatial/editor.js
+++ b/elements/jsonform/src/custom-inputs/spatial/editor.js
@@ -269,7 +269,7 @@ export class SpatialEditor extends AbstractEditor {
           }
 
           this.onChange(true);
-          this.jsoneditor.showValidationErrors();
+          this.jsoneditor?.showValidationErrors();
         }
       ),
     );


### PR DESCRIPTION
## Implemented changes
Check if the jsoneditor exists before triggering a validation.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
