### PR TITLE
fix: vector layer projection handling

### DIFF
--- a/elements/map/src/plugins/globe/openglobus.js
+++ b/elements/map/src/plugins/globe/openglobus.js
@@ -130,7 +130,10 @@ export const createGlobusLayer = (olLayer, mapPool) => {
             projection = getProjection("EPSG:" + crs["properties"]["code"]);
           }
         }
-        if (projection && equivalent(projection, getProjection("EPSG:4326"))) {
+        if (
+          (projection && equivalent(projection, getProjection("EPSG:4326"))) ||
+          !crs
+        ) {
           // remmove existing layer with same id if any
           const existingLayer = globus.planet.getLayerByName(id);
           if (existingLayer) {


### PR DESCRIPTION
## Implemented changes

This pull request improves the handling of vector layers with custom projections in the `openglobus.js` plugin and enhances projection management when disabling the globe view. The main updates ensure that only vector layers with compatible projections are added to the globe and that projection utilities are used consistently.

**Vector Layer Projection Handling:**
* Added logic to detect and parse the `crs` property from vector data, retrieving the appropriate projection using `getProjection` and checking for equivalence with `EPSG:4326` before adding the layer to the globe. This prevents incompatible vector layers from being displayed (fallback: CanvasTile layer).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
