### PR TITLE
feat(style): flex layout

### DIFF
--- a/elements/jsonform/src/custom-inputs/spatial/editor.js
+++ b/elements/jsonform/src/custom-inputs/spatial/editor.js
@@ -31,6 +31,11 @@ export class SpatialEditor extends AbstractEditor {
     const drawToolsOptions = this.schema?.options?.drawtools ?? {};
     const mapOptions = this.schema?.options?.map ?? {};
 
+    if (this.schema?.options?.layout === "flex") {
+      this.container.style.display = "flex";
+      this.container.style.gap = "10px";
+    }
+
     // Create label and description elements if not in compact mode
     if (!options.compact)
       this.header = this.label = theme.getFormInputLabel(

--- a/elements/jsonform/stories/flex-layout.js
+++ b/elements/jsonform/stories/flex-layout.js
@@ -1,0 +1,15 @@
+/**
+ * Story demonstrating the flex layout configuration for eox-jsonform.
+ * Displays the map and form controls side-by-side.
+ */
+import { html } from "lit";
+import flexLayoutSchema from "./public/flexLayoutSchema.json";
+
+export default {
+  args: {
+    schema: flexLayoutSchema,
+  },
+  render: (args) => html`
+    <eox-jsonform .schema=${args.schema}></eox-jsonform>
+  `,
+};

--- a/elements/jsonform/stories/index.js
+++ b/elements/jsonform/stories/index.js
@@ -18,3 +18,4 @@ export { default as ValidationStory } from "./validation"; // Validate input
 export { default as CodeStory } from "./code"; // Show code editor as input
 export { default as OptionalPropertiesStory } from "./optional-properties"; // Hide optional properties
 export { default as ShowOptInPropertiesStory } from "./show-opt-in-properties"; // Show opt-in properties
+export { default as FlexLayoutStory } from "./flex-layout"; // Flex layout story

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -21,6 +21,7 @@ import {
   ValidationStory,
   CodeStory,
   OptionalPropertiesStory,
+  FlexLayoutStory,
 } from "./index.js";
 
 export default {
@@ -157,6 +158,12 @@ export const WKT = WKTStory;
  * Demonstrates output format customization for spatial inputs.
  */
 export const Geojson = GeoJSONStory;
+
+/**
+ * Flex Layout example. Demonstrates how to use flex layout for arranging form elements side-by-side.
+ * Shows how to configure the layout of the form using schema options.
+ */
+export const FlexLayout = FlexLayoutStory;
 
 /**
  * Custom Editor Interfaces example. Shows how to create custom form inputs for json-editor.

--- a/elements/jsonform/stories/public/flexLayoutSchema.json
+++ b/elements/jsonform/stories/public/flexLayoutSchema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "polygons": {
+      "title": "Multi polygon",
+      "type": "array",
+      "format": "polygons",
+      "options": {
+        "layout": "flex",
+        "map": {
+          "style": "width: 400px; height: 300px;"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Implemented changes

This pull request introduces a new "flex layout" feature for the spatial editor in the JSONForm package, allowing map and form controls to be displayed side-by-side. It adds both the implementation and a storybook example to demonstrate this layout option.

This allows for a more compact layout inside the form rendering.

## Screenshots/Videos

<img width="605" height="329" alt="image" src="https://github.com/user-attachments/assets/ebbc7b43-4955-45f2-bc32-e05ead0c1b21" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
