### PR TITLE
fix: spatial startval loading

### DIFF
--- a/elements/jsonform/src/custom-inputs/spatial/editor.js
+++ b/elements/jsonform/src/custom-inputs/spatial/editor.js
@@ -9,7 +9,7 @@ import {
   isGeoJSON,
   setAttributesAndProperties,
   isLine,
-  bboxesToFeatures,
+  valueToFeatureCollection,
 } from "./utils";
 // import "@eox/drawtools";
 
@@ -114,22 +114,21 @@ export class SpatialEditor extends AbstractEditor {
       const mapId = "map-" + this.formname.replace(/[^\w\s]/gi, "");
       let firstLoad = false;
       eoxmapEl.addEventListener("loadend", () => {
-        const pathParts = this.path.split(".").slice(1);
-        const startVals =
-          this.defaults.startVals[this.key] ||
-          pathParts.reduce((obj, part) => obj?.[part], this.defaults.startVals);
+        const currentVal = this.value;
 
-        if (!firstLoad && startVals && isBox(this.schema)) {
+        if (!firstLoad && currentVal) {
           firstLoad = true;
-          const existingBboxes = bboxesToFeatures(startVals);
-          drawtoolsEl.handleFeatureChange(
-            JSON.stringify({
-              type: "FeatureCollection",
-              features: existingBboxes,
-            }),
-            true,
-            false,
+          const featureCollection = valueToFeatureCollection(
+            currentVal,
+            this.schema,
           );
+          if (featureCollection.features.length > 0) {
+            drawtoolsEl.handleFeatureChange(
+              JSON.stringify(featureCollection),
+              true,
+              false,
+            );
+          }
         }
       });
       eoxmapEl.layers = [{ type: "Tile", source: { type: "OSM" } }];

--- a/elements/jsonform/src/custom-inputs/spatial/utils.js
+++ b/elements/jsonform/src/custom-inputs/spatial/utils.js
@@ -111,3 +111,51 @@ export const bboxesToFeatures = (bboxes) => {
   if (bboxes.length < 1) return [];
   return bboxes.map((bbox) => bboxPolygon(bbox));
 };
+
+/**
+ * Converts a value to a FeatureCollection based on the schema
+ */
+export const valueToFeatureCollection = (value, schema) => {
+  if (!value) return { type: "FeatureCollection", features: [] };
+
+  let features = [];
+
+  if (isBox(schema)) {
+    const bboxes = isMulti(schema) ? value : [value];
+    features = bboxesToFeatures(bboxes);
+  } else if (isPolygon(schema)) {
+    const coords = isMulti(schema) ? value : [value];
+    features = coords.map((c) => ({
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Polygon", coordinates: c },
+    }));
+  } else if (isPoint(schema)) {
+    const coords = isMulti(schema) ? value : [value];
+    features = coords.map((c) => ({
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Point", coordinates: c },
+    }));
+  } else if (isLine(schema)) {
+    const coords = isMulti(schema) ? value : [value];
+    features = coords.map((c) => ({
+      type: "Feature",
+      properties: {},
+      geometry: { type: "LineString", coordinates: c },
+    }));
+  } else if (isGeoJSON(schema)) {
+    if (value.type === "FeatureCollection") {
+      return value;
+    } else if (value.type === "Feature") {
+      features = [value];
+    } else if (value.type === "Geometry" || value.coordinates) {
+      features = [{ type: "Feature", properties: {}, geometry: value }];
+    }
+  }
+
+  return {
+    type: "FeatureCollection",
+    features: features,
+  };
+};

--- a/elements/jsonform/test/_mockedDrawtools.js
+++ b/elements/jsonform/test/_mockedDrawtools.js
@@ -21,6 +21,9 @@ class MockedDrawTools extends HTMLElement {
     this._format = "feature";
     this.updateComplete = new Promise((resolve) => resolve(true));
     this.startDrawing = () => {};
+    this.handleFeatureChange = (features) => {
+      this._features = features;
+    };
   }
 
   // Getters and setters for properties

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -15,3 +15,4 @@ export { default as loadCustomEditorInterfaceTest } from "./load-custom-editor-i
 export { default as loadSubmitButtonTest } from "./submit-button";
 export { default as loadShowOptInPropertiesTest } from "./load-show-opt-in-properties";
 export { default as loadButtonsEditorTest } from "./load-buttons-editor";
+export { default as loadSpatialValuesTest } from "./load-spatial-values";

--- a/elements/jsonform/test/cases/load-spatial-values.js
+++ b/elements/jsonform/test/cases/load-spatial-values.js
@@ -1,0 +1,71 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+const { jsonForm } = TEST_SELECTORS;
+
+const schema = {
+  type: "object",
+  properties: {
+    Bbox: {
+      anyOf: [
+        {
+          type: "array",
+          format: "bounding-box",
+        },
+        {
+          type: "array",
+          minItems: 4,
+          maxItems: 4,
+          items: {
+            type: "number",
+          },
+        },
+      ],
+    },
+  },
+};
+
+const value = {
+  Bbox: [10, 10, 20, 20],
+};
+
+const loadSpatialValuesTest = () => {
+  cy.intercept("**/spatialSchema.json", (req) => {
+    req.reply(schema);
+  });
+  cy.intercept("**/spatialValue.json", (req) => {
+    req.reply(value);
+  });
+
+  cy.mount(
+    html` <eox-jsonform
+      .schema=${"/spatialSchema.json"}
+      .value=${"/spatialValue.json"}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      // Trigger loadend on the map to simulate map loading
+      cy.get("eox-map").then(($el) => {
+        $el[0].dispatchEvent(new CustomEvent("loadend"));
+      });
+
+      cy.get("eox-drawtools").then(($el) => {
+        // Check if handleFeatureChange was called with the correct features
+        // The mock stores it in _features
+        // The value passed to handleFeatureChange is a JSON string
+        const features = JSON.parse($el[0]._features);
+        expect(features.type).to.equal("FeatureCollection");
+        expect(features.features).to.have.length(1);
+        expect(features.features[0].geometry.type).to.equal("Polygon");
+        // [10, 10, 20, 20] -> Polygon coordinates
+        const coords = features.features[0].geometry.coordinates[0];
+        expect(coords[0]).to.deep.equal([10, 10]);
+        expect(coords[2]).to.deep.equal([20, 20]);
+      });
+    });
+};
+
+export default loadSpatialValuesTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -17,6 +17,7 @@ import {
   loadCodeTest,
   loadShowOptInPropertiesTest,
   loadButtonsEditorTest,
+  loadSpatialValuesTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -39,4 +40,5 @@ describe("Jsonform", () => {
   it("loads the jsonform with show opt in properties", () =>
     loadShowOptInPropertiesTest());
   it("loads the buttons editor", () => loadButtonsEditorTest());
+  it("loads spatial values correctly", () => loadSpatialValuesTest());
 });


### PR DESCRIPTION
## Implemented changes

This pull request enhances the handling and testing of spatial values in the`eox-jsonform` component, improving conversion of spatial data to GeoJSON feature collections and adding tests to verify correct behavior. The changes refactor the way spatial values are processed for map display (previously only "bbox" was supported!) and introduce new tests to ensure spatial values are loaded and displayed as expected.

Fixes #1998.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
