### PR TITLE
fix: storytelling hero text fit by decreasing padding

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -392,7 +392,7 @@ const styleEOX = `
     position: relative;      
     width: 100%;
     height: var(--eox-storytelling-hero-height);
-    padding: 10rem 2rem;
+    padding: 1rem 2rem;
     overflow: hidden;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Implemented changes

as said in PR title

fix https://github.com/EOX-A/EOxElements/issues/2035

## Screenshots/Videos

Before:

<img width="924" height="944" alt="Screenshot From 2025-12-18 14-30-59" src="https://github.com/user-attachments/assets/a1e8f278-0ef7-4853-b0ba-5213f2285d41" />

After: 
<img width="924" height="944" alt="image" src="https://github.com/user-attachments/assets/5d4eb6ad-e4fa-4e7e-8cb0-f8f65a3b6eba" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
