### PR TITLE
fix: filter out group layers in globe initialization

### DIFF
--- a/elements/map/src/plugins/globe/methods.js
+++ b/elements/map/src/plugins/globe/methods.js
@@ -7,6 +7,7 @@ export const createMapPool = (maxMaps, EOxMap, target) => {
   // Get the serializable definitions of all layers on the main map.
   const allMainLayers = getFlatLayersArray(EOxMap.map.getLayers().getArray());
   const layerDefs = allMainLayers
+    .filter((l) => l.get("type") !== "Group")
     .map((l) => l.get("_jsonDefinition"))
     .filter(Boolean);
 

--- a/elements/map/src/plugins/globe/openglobus.js
+++ b/elements/map/src/plugins/globe/openglobus.js
@@ -25,6 +25,7 @@ export const createGlobe = ({ EOxMap, target, mapPool }) => {
   globus = new OgGlobe({
     target,
     layers: EOxMap.getFlatLayersArray(EOxMap.map.getLayers().getArray())
+      .filter((l) => l.get("type") !== "Group")
       .map((l) => createGlobusLayer(l, mapPool))
       .filter((l) => l !== undefined),
     sun: { active: false },
@@ -77,9 +78,7 @@ export const refreshGlobe = () => {
 export const createGlobusLayer = (olLayer, mapPool) => {
   const source = olLayer.getSource && olLayer.getSource();
   const id = olLayer.get("id");
-  if (olLayer.get("type") === "Group") {
-    return undefined;
-  }
+
   if (source instanceof OSM) {
     return new OpenStreetMap(id, {
       isBaseLayer: olLayer.get("base"),


### PR DESCRIPTION
## Implemented changes

### Fix Globe Layer Rendering for Grouped Layers

This PR fixes an issue where layers nested inside groups were not rendering correctly on the globe.

**Changes:**
- Filter out `Group` layers when creating the hidden map pool (`createMapPool`) to ensure only leaf layers are rendered for tiles.
- Filter out `Group` layers in `createGlobe` before processing, removing the redundant check inside `createGlobusLayer`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
