### PR TITLE
fix: loading images lazily with low fetch priority

### DIFF
--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -120,6 +120,8 @@ export function createItemListMethod(
                       getValue(config.imageProperty, item)
                         ? html`
                             <img
+                              loading="lazy"
+                              fetchpriority="low"
                               class="image"
                               src="${getValue(config.imageProperty, item)}"
                             />
@@ -143,6 +145,8 @@ export function createItemListMethod(
                         ${getValue(config.imageProperty, item)
                           ? html`
                               <img
+                                loading="lazy"
+                                fetchpriority="low"
                                 class="image"
                                 src="${getValue(config.imageProperty, item)}"
                               />


### PR DESCRIPTION
## Implemented changes
The browser fires requests to load all the images. In case of long list items, if the browser made any requests to the same domain, the request will be blocked until all the images are loaded. This fixes the issue by loading them lazily and assigns a  low fetch priority

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
