### PR TITLE
fix(style): disabled select

### DIFF
--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -166,6 +166,9 @@ export const styleEOX = `
   .form-control textarea {
     min-block-size: 6rem;
   }
+  .form-control select:disabled {
+    opacity: 0.6;
+  }
   .form-control input:not([data-schematype="boolean"] input):not([type="range"]):focus,
   .form-control input:not([data-schematype="boolean"] input):not([type="range"]):focus-visible,
     .form-control textarea:focus,


### PR DESCRIPTION
## Implemented changes

This PR fixes the styling of disabled `select` inputs by making them less opaque.

## Screenshots/Videos
<img width="341" height="184" alt="image" src="https://github.com/user-attachments/assets/1b98f858-bbf8-4b52-9251-077bfe9c5660" />

<img width="214" height="159" alt="image" src="https://github.com/user-attachments/assets/a20d1654-da28-48c8-beaa-b35c7be0a020" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
