### PR TITLE
feat: support custom editor `defaults`

### DIFF
--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -35,6 +35,7 @@ export class EOxJSONForm extends LitElement {
   static properties = {
     schema: { attribute: false, type: Object },
     value: { attribute: false, type: Object },
+    defaults: { attribute: false, type: Object },
     options: { attribute: false, type: Object },
     customEditorInterfaces: { attribute: false, type: Array },
     noShadow: { attribute: "no-shadow", type: Boolean },
@@ -64,6 +65,13 @@ export class EOxJSONForm extends LitElement {
      * @type {JsonSchema}
      */
     this.value = null;
+
+    /**
+     * Default values for the JSONEditor instance
+     *
+     * @type {object}
+     */
+    this.defaults = {};
 
     /**
      * Options for the form editor
@@ -227,8 +235,11 @@ export class EOxJSONForm extends LitElement {
         this.#editor = await createEditor(this);
         this.#dispatchEvent();
       }
-    } else if (changedProperties.has("customEditorInterfaces")) {
-      if (this.customEditorInterfaces) {
+    } else if (
+      changedProperties.has("customEditorInterfaces") ||
+      changedProperties.has("defaults")
+    ) {
+      if (this.customEditorInterfaces || this.defaults) {
         this.#editor = await createEditor(this);
         this.#dispatchEvent();
       }

--- a/elements/jsonform/stories/defaults.js
+++ b/elements/jsonform/stories/defaults.js
@@ -1,0 +1,111 @@
+import { html } from "lit";
+
+/**
+ * Demonstration of using the `defaults` property to configure JSONEditor defaults,
+ * specifically implementing a custom upload handler.
+ */
+export default {
+  args: {
+    schema: {
+      type: "object",
+      title: "Upload Example",
+      properties: {
+        upload_default: {
+          type: "string",
+          format: "url",
+          options: {
+            upload: {
+              upload_handler: "testUploadHandler",
+            },
+          },
+          links: [
+            {
+              href: "{{self}}",
+            },
+          ],
+        },
+        upload_custom_link: {
+          type: "string",
+          format: "url",
+          options: {
+            upload: {
+              upload_handler: "testUploadHandler",
+            },
+          },
+          links: [
+            {
+              href: "{{self}}",
+              rel: "view",
+            },
+          ],
+        },
+        upload_readonly: {
+          readonly: true,
+          type: "string",
+          format: "url",
+          options: {
+            upload: {
+              upload_handler: "testUploadHandler",
+            },
+          },
+          links: [
+            {
+              href: "{{self}}",
+            },
+          ],
+        },
+        upload_fail: {
+          type: "string",
+          format: "url",
+          options: {
+            upload: {
+              upload_handler: "testUploadHandler",
+            },
+          },
+          links: [
+            {
+              href: "{{self}}",
+            },
+          ],
+        },
+      },
+    },
+    submit: (e) => console.log(e.detail),
+    defaults: {
+      callbacks: {
+        upload: {
+          testUploadHandler: function (jseditor, type, file, cbs) {
+            if (type === "root.upload_fail") cbs.failure("Upload failed");
+            else {
+              var tick = 0;
+
+              var tickFunction = function () {
+                tick += 1;
+                console.log("progress: " + tick);
+
+                if (tick < 100) {
+                  cbs.updateProgress(tick);
+                  window.setTimeout(tickFunction, 50);
+                } else if (tick == 100) {
+                  cbs.updateProgress();
+                  window.setTimeout(tickFunction, 500);
+                } else {
+                  cbs.success("http://www.example.com/images/" + file.name);
+                }
+              };
+
+              window.setTimeout(tickFunction);
+            }
+          },
+        },
+      },
+    },
+  },
+  render: (args) => html`
+    <eox-jsonform
+      .schema=${args.schema}
+      .defaults=${args.defaults}
+      @submit=${args.submit}
+    ></eox-jsonform>
+  `,
+};

--- a/elements/jsonform/stories/index.js
+++ b/elements/jsonform/stories/index.js
@@ -18,4 +18,6 @@ export { default as ValidationStory } from "./validation"; // Validate input
 export { default as CodeStory } from "./code"; // Show code editor as input
 export { default as OptionalPropertiesStory } from "./optional-properties"; // Hide optional properties
 export { default as ShowOptInPropertiesStory } from "./show-opt-in-properties"; // Show opt-in properties
+export { default as DefaultsStory } from "./defaults"; // Configure defaults
+
 export { default as FlexLayoutStory } from "./flex-layout"; // Flex layout story

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -22,6 +22,7 @@ import {
   CodeStory,
   OptionalPropertiesStory,
   FlexLayoutStory,
+  DefaultsStory,
 } from "./index.js";
 
 export default {
@@ -170,6 +171,12 @@ export const FlexLayout = FlexLayoutStory;
  * Demonstrates extensibility via custom editor interfaces based on the JSONEditor.AbstractEditor.
  */
 export const CustomEditorInterfaces = CustomEditorInterfacesStory;
+
+/**
+ * Defaults example. Demonstrates how to configure JSONEditor defaults.
+ * Shows how to implement a custom upload handler using the `defaults` property.
+ */
+export const Defaults = DefaultsStory;
 
 /**
  * Unstyled example. Renders the form without default styles.

--- a/elements/jsonform/test/cases/defaults.js
+++ b/elements/jsonform/test/cases/defaults.js
@@ -1,0 +1,64 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+const { jsonForm } = TEST_SELECTORS;
+
+const defaultsTest = () => {
+  const uploadHandlerSpy = cy.spy().as("uploadHandler");
+
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          upload: {
+            type: "string",
+            format: "url",
+            options: {
+              upload: {
+                upload_handler: "testUploadHandler",
+              },
+            },
+          },
+        },
+      }}
+      .defaults=${{
+        callbacks: {
+          upload: {
+            testUploadHandler: (jseditor, path, file, cbs) => {
+              uploadHandlerSpy(path, file);
+              cbs.success("http://example.com/" + file.name);
+            },
+          },
+        },
+      }}
+    ></eox-jsonform>`,
+  );
+
+  // Check if upload input exists
+  cy.get(jsonForm).shadow().find("input[type='file']").should("exist");
+
+  // Upload a file
+  cy.get(jsonForm)
+    .shadow()
+    .find("input[type='file']")
+    .selectFile(
+      {
+        contents: Cypress.Buffer.from("file content"),
+        fileName: "test.txt",
+        mimeType: "text/plain",
+      },
+      { force: true },
+    );
+
+  // Click the upload button
+  cy.get(jsonForm)
+    .shadow()
+    .find(".json-editor-btn-upload")
+    .click({ force: true });
+
+  // Check if upload handler was called
+  cy.get("@uploadHandler").should("have.been.called");
+};
+
+export default defaultsTest;

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -17,3 +17,4 @@ export { default as loadShowOptInPropertiesTest } from "./load-show-opt-in-prope
 export { default as loadButtonsEditorTest } from "./load-buttons-editor";
 export { default as loadSpatialValuesTest } from "./load-spatial-values";
 export { default as validationBehaviorTest } from "./validation-behavior";
+export { default as defaultsTest } from "./defaults";

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -19,6 +19,7 @@ import {
   loadButtonsEditorTest,
   loadSpatialValuesTest,
   validationBehaviorTest,
+  defaultsTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -43,4 +44,5 @@ describe("Jsonform", () => {
   it("loads the buttons editor", () => loadButtonsEditorTest());
   it("loads spatial values correctly", () => loadSpatialValuesTest());
   it("handles validation behavior correctly", () => validationBehaviorTest());
+  it("handles defaults correctly", () => defaultsTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR adds support for custom editor `defaults`. Previously they were hardcoded, and `json-editor` doesn't allow to change them after initialization.
By passing `defaults`, it is now possible to e.g. create custom callbacks and more. One example story has been added copying the [`upload` example from the `json-editor` repository](https://github.com/json-editor/json-editor/blob/master/docs/upload.html).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
