### PR TITLE
fix(style): upload editor layout and styling

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -299,7 +299,8 @@ export const createEditor = (element) => {
         } else {
           if (
             !button.classList.contains("json-editor-btn-edit") &&
-            !button.classList.contains("json-editor-btn-edit_properties")
+            !button.classList.contains("json-editor-btn-edit_properties") &&
+            !button.classList.contains("json-editor-btn-upload")
           ) {
             [
               "circle",
@@ -416,6 +417,17 @@ export const createEditor = (element) => {
           <i class="small">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>cancel</title><path d="M12 2C17.5 2 22 6.5 22 12S17.5 22 12 22 2 17.5 2 12 6.5 2 12 2M12 4C10.1 4 8.4 4.6 7.1 5.7L18.3 16.9C19.3 15.5 20 13.8 20 12C20 7.6 16.4 4 12 4M16.9 18.3L5.7 7.1C4.6 8.4 4 10.1 4 12C4 16.4 7.6 20 12 20C13.9 20 15.6 19.4 16.9 18.3Z" /></svg>
           </i>`;
+          }
+          if (button.classList.contains("json-editor-btn-upload")) {
+            button.classList.add("small");
+            button.classList.add("no-margin");
+            button.innerHTML = `
+          <i class="small">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>upload-circle-outline</title><path d="M8 17V15H16V17H8M16 10L12 6L8 10H10.5V14H13.5V10H16M12 2C17.5 2 22 6.5 22 12C22 17.5 17.5 22 12 22C6.5 22 2 17.5 2 12C2 6.5 6.5 2 12 2M12 4C7.58 4 4 7.58 4 12C4 16.42 7.58 20 12 20C16.42 20 20 16.42 20 12C20 7.58 16.42 4 12 4Z" /></svg>
+          </i>
+          <span>
+            Upload
+          </span>`;
           }
         }
       });

--- a/elements/jsonform/src/style.eox.js
+++ b/elements/jsonform/src/style.eox.js
@@ -179,6 +179,21 @@ export const styleEOX = `
   input[type="checkbox"]:not(.je-modal input) {
     visibility: hidden;
   }
+  .form-control input[type="file"]+div > div {
+    display: flex;
+    gap: 0;
+  }
+  .form-control input[type="file"]+div > div > input  {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+  .form-control input[type="file"]+div > div > button {
+    margin-left: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+  }
   .form-control input[disabled],
   .form-control textarea[disabled], {
     opacity: .5;


### PR DESCRIPTION
## Implemented changes

This PR fixes the layout and styling of the default upload editor, including the visibility of the "upload" button. It is not yet pretty, but at least usable...

## Screenshots/Videos
### Before
<img width="412" height="516" alt="image" src="https://github.com/user-attachments/assets/1a319dd5-5cf8-4a16-b9e7-7c94496553cb" />

### After
<img width="404" height="409" alt="image" src="https://github.com/user-attachments/assets/b59c765e-a5c0-4bd4-96f9-c0700c4c75eb" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
