### PR TITLE
Fix(tooltip): map/add mouse event coordinates to vector layers 

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -227,7 +227,6 @@ export class EOxSelectInteraction {
               // @ts-expect-error TODO
               Object.assign(feature?.values_, pickedCoordinate(event));
             }
-
           }
         }
         const selectdEvt = new CustomEvent("select", {


### PR DESCRIPTION
## Implemented changes

<!-- description of implemented changes -->
This PR adds the tooltip coordinate feature to vector layers; it was previously supported for COG layers and WMS layers only.
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

![WhatsApp Image 2026-01-09 at 12 14 19](https://github.com/user-attachments/assets/4172b3dd-d3e3-45ec-aa1a-2df6813a3ceb)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
