### PR TITLE
feat: map tour step layer fading

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -236,9 +236,9 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
       // Explicit Preloader: Forces loading of tiles for future steps (different zoom/center)
       // This complements the "Hidden Layer" strategy which only handles the current view.
       setTimeout(() => {
-        const eoxMap = /** @type {any} */ (parent.querySelector(
-          elementSelector,
-        ));
+        const eoxMap = /** @type {any} */ (
+          parent.querySelector(elementSelector)
+        );
         if (eoxMap && eoxMap.preloadTiles) {
           section.steps.forEach((step, stepIndex) => {
             // Stagger requests to prevent freezing the main thread & network congestion


### PR DESCRIPTION
## Implemented changes

This pull request introduces significant improvements to the way map layers are managed and preloaded in the `eox-storytelling` element. The changes focus on deduplicating layers with the same ID but different sources, optimizing the loading and preloading of map layers for better performance, and adding smooth fade transitions between layer changes.

Key improvements include:

**Layer Deduplication and Management:**

* Layers with the same ID but different sources are now assigned unique IDs to prevent conflicts and ensure each layer is handled separately, allowing for simultaneous preloading and correct rendering.

**Layer Preloading and Loading Optimization:**

* Layers for the first step are prioritized for initial loading to improve perceived performance, while remaining layers are loaded after a short delay to avoid network contention.
* An explicit preloading mechanism is introduced, which preloads tiles for all steps in the background, staggering requests to prevent main thread blocking and network congestion.

**Layer Attribute Assignment and Animation:**

* The `assignNewAttrValue` function is updated to merge all relevant layers, ensuring that inactive layers are set to fully transparent for preloading, and to animate opacity changes for a smooth fade effect when transitioning between steps.
* A new `fadeLayer` function is added to handle the opacity transitions with easing, ensuring visually appealing cross-fades between layer states.

These changes collectively enhance the user experience by making map transitions smoother and improving the efficiency of resource loading.

## Screenshots/Videos

https://github.com/user-attachments/assets/9d7962f5-e83c-42e0-9d4a-6262deb1e441

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
