### PR TITLE
fix(style): styling of inline code and code blocks

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -72,13 +72,16 @@ const styleEOX = `
     font-size: var(--code-font-size, var(--font-size));
     color: var(--code-color, #004170);
   }
-  :not(pre) > code {
+  code:not(pre > code) {
     display: inline;
     border-radius: 4px;
     background: var(--code-bg-color, #8e96aa24);
     padding: var(--code-padding, 3px 6px);
   }
-
+  pre > code {
+    padding-left: 1rem;
+    background: transparent;
+  }
   :host {
     overflow: unset !important;
     --eox-storytelling-hero-height: 76dvh;
@@ -240,7 +243,7 @@ const styleEOX = `
   }
   .story-telling p,
   .story-telling code {
-    --font-size: 1.1rem;
+    --font-size: inherit;
   }
   .story-telling p {
     display: block;


### PR DESCRIPTION
## Implemented changes

This PR improves the styling of inline code and code blocks, adjusting font size, padding, and background color.

## Screenshots/Videos

<img width="482" height="102" alt="image" src="https://github.com/user-attachments/assets/7a710142-27c2-4823-ac62-eacc3262714f" />
<img width="432" height="251" alt="image" src="https://github.com/user-attachments/assets/6f079416-0526-4589-8c3a-c213b81e9e48" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
