### PR TITLE
fix(style): start tour section content 20vh sooner

### DIFF
--- a/elements/storytelling/src/style.eox.js
+++ b/elements/storytelling/src/style.eox.js
@@ -490,6 +490,7 @@ const styleEOX = `
     display: block;
     z-index: 1;
     max-width: 25%;
+    transform: translateY(-20dvh);
   }
   @media screen and (max-width: 1024px) {
     .story-telling .tour section-step {


### PR DESCRIPTION
## Implemented changes

This shifts the tour section steps `20dvh` up, so when scrolling it is clearer to the user that there is a content (card). Previously we heard feedback that the cards appear "too late", so the entire screen was filled with a map and it was not clear that the user has to scroll further.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
