### PR TITLE
feat: introduce `fetchFn` for external filter

### DIFF
--- a/elements/itemfilter/src/helpers/filter-external.js
+++ b/elements/itemfilter/src/helpers/filter-external.js
@@ -16,9 +16,11 @@ async function filterExternal(items, filters, config) {
     typeof functionResult === "string" || functionResult instanceof String
       ? functionResult
       : functionResult.url;
-  // Generate the URL for the external API based on the provided items and filters
-  const response = await fetch(url);
-  const jsonData = await response.json();
+
+  const jsonData =
+    typeof functionResult === "object" && "fetchFn" in functionResult
+      ? await functionResult.fetchFn(url)
+      : await fetch(url).then(async (response) => await response.json());
 
   // Return the array from the parsed JSON data
   return functionResult.key ? getValue(functionResult.key, jsonData) : jsonData;


### PR DESCRIPTION
## Implemented changes
This allows to pass a function to fetch the external filter URL, to allow more complex logic that could live next to fetching for example:

```javascript
const createExternalFilter = (
  propsFilters,
  bboxFilter,
  currentItems,
) => {
  let controller = new AbortController();
  /**
   * @param {Array<any>} _items
   * @param {Record<string,any>} filters
   */
  return (_items, filters) => ({
    url: buildSearchUrl(filters, propsFilters, bboxFilter),
    /** @param {string} url */
    fetchFn: async (url) => {
      controller.abort();
      controller = new AbortController();
      const signal = controller.signal;
      return await axios
        .get(url, { signal })
        .then((res) => res.data.features)
        .catch((e) => {
          // return previous items if aborted
          if (e.name === "AbortError" || e.name === "CanceledError") {
            return currentItems.value;
          }
          console.error(e);
          return [];
        });
    },
  });
};
```

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
