### PR TITLE
fix: layer datetime emission

### DIFF
--- a/elements/layercontrol/src/components/layer-datetime.js
+++ b/elements/layercontrol/src/components/layer-datetime.js
@@ -72,9 +72,24 @@ export class EOxLayerControlLayerDatetime extends LitElement {
    * @param {CustomEvent<{date:string[]}>} evt
    **/
   #handleStepChange(evt) {
-    const formatDate = (d) =>
-      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-    const currentStep = formatDate(new Date(evt.detail.date[0]));
+    const dateObj = new Date(evt.detail.date[0]);
+
+    // Check if configuration implies datetime (ISO strings)
+    const isDatetimeConfig = this.layerDatetime.controlValues?.some(
+      (v) => typeof v === "string" && v.includes("T"),
+    );
+
+    let currentStep;
+    if (isDatetimeConfig) {
+      currentStep = dateObj.toISOString();
+    } else {
+      const formatDate = (d) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      currentStep = formatDate(dateObj);
+    }
+    if (currentStep === this.layerDatetime.currentStep) {
+      return;
+    }
 
     this.dispatchEvent(
       new CustomEvent("datetime:updated", {

--- a/elements/layercontrol/test/emit-datetime.cy.js
+++ b/elements/layercontrol/test/emit-datetime.cy.js
@@ -1,0 +1,170 @@
+import "../src/main";
+import "@eox/timecontrol";
+import "./_mockMap";
+
+describe("LayerControl Datetime Emit", () => {
+  beforeEach(() => {
+    cy.mount("<mock-map></mock-map>").as("mock-map");
+    cy.mount(`<eox-layercontrol for="mock-map"></eox-layercontrol>`).as(
+      "eox-layercontrol",
+    );
+  });
+
+  it("does not trigger datetime:updated on initialization if values match", () => {
+    const onDatetimeUpdated = cy.spy().as("onDatetimeUpdated");
+    cy.get("eox-layercontrol").then(($el) => {
+      $el[0].addEventListener("datetime:updated", onDatetimeUpdated);
+    });
+
+    const mockLayer = {
+      properties: {
+        id: "datetime-init-test",
+        title: "Datetime Init Test",
+        layerDatetime: {
+          slider: true,
+          controlValues: ["2024-01-01", "2024-01-02"],
+          currentStep: "2024-01-01",
+        },
+      },
+    };
+
+    cy.get("mock-map").then(($el) => {
+      const mockMap = $el[0];
+      mockMap.setLayers([mockLayer]);
+    });
+
+    // Wait for initialization
+    cy.get("eox-layercontrol")
+      .shadow()
+      .find("eox-layercontrol-layer-tools")
+      .shadow()
+      .find("eox-timecontrol-slider")
+      .should("exist");
+
+    cy.get("@onDatetimeUpdated").should("not.have.been.called");
+  });
+
+  it("triggers datetime:updated when values change", () => {
+    const onDatetimeUpdated = cy.spy().as("onDatetimeUpdated");
+    cy.get("eox-layercontrol").then(($el) => {
+      $el[0].addEventListener("datetime:updated", onDatetimeUpdated);
+    });
+
+    const controlValues = ["2024-01-01", "2024-01-02"];
+    const mockLayer = {
+      properties: {
+        id: "datetime-init-test",
+        title: "Datetime Init Test",
+        layerDatetime: {
+          slider: true,
+          controlValues: controlValues,
+          currentStep: "2024-01-01",
+        },
+      },
+    };
+
+    cy.get("mock-map").then(($el) => {
+      const mockMap = $el[0];
+      mockMap.setLayers([mockLayer]);
+    });
+
+    // Wait for initialization
+    cy.get("eox-layercontrol")
+      .shadow()
+      .find("eox-layercontrol-layer-tools")
+      .shadow()
+      .find("eox-timecontrol-slider")
+      .should("exist");
+
+    cy.get("eox-layercontrol")
+      .shadow()
+      .find("eox-layercontrol-layer-tools")
+      .shadow()
+      .find("eox-timecontrol-slider")
+      .shadow()
+      .find("tc-range-slider")
+      .as("slider");
+
+    // Change the slider value
+    cy.get("@slider").then(($el) => {
+      // Simulate slider change
+      $el[0].value1 = controlValues[1];
+      $el[0].dispatchEvent(
+        new CustomEvent("change", {
+          detail: {
+            value1: controlValues[1],
+            value2: undefined,
+          },
+        }),
+      );
+    });
+
+    cy.get("@onDatetimeUpdated").should("have.been.called");
+  });
+
+  it("emits a valid datetime string", () => {
+    const onDatetimeUpdated = cy.spy().as("onDatetimeUpdated");
+    cy.get("eox-layercontrol").then(($el) => {
+      $el[0].addEventListener("datetime:updated", onDatetimeUpdated);
+    });
+
+    const controlValues = ["2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z"];
+    const mockLayer = {
+      properties: {
+        id: "datetime-emit-test",
+        title: "Datetime Emit Test",
+        layerDatetime: {
+          slider: true,
+          controlValues: controlValues,
+          currentStep: "2024-01-01T10:00:00Z",
+        },
+      },
+    };
+
+    cy.get("mock-map").then(($el) => {
+      const mockMap = $el[0];
+      mockMap.setLayers([mockLayer]);
+    });
+
+    // Wait for initialization
+    cy.get("eox-layercontrol")
+      .shadow()
+      .find("eox-layercontrol-layer-tools")
+      .shadow()
+      .find("eox-timecontrol-slider")
+      .should("exist");
+
+    cy.get("eox-layercontrol")
+      .shadow()
+      .find("eox-layercontrol-layer-tools")
+      .shadow()
+      .find("eox-timecontrol-slider")
+      .shadow()
+      .find("tc-range-slider")
+      .as("slider");
+
+    // Change the slider value
+    cy.get("@slider").then(($el) => {
+      // Simulate slider change
+      $el[0].value1 = controlValues[1];
+      $el[0].dispatchEvent(
+        new CustomEvent("change", {
+          detail: {
+            value1: controlValues[1],
+            value2: undefined,
+          },
+        }),
+      );
+    });
+
+    cy.get("@onDatetimeUpdated").should((spy) => {
+      expect(spy).to.be.called;
+      const call = spy.getCall(0);
+      const { datetime } = call.args[0].detail;
+      // Check if it contains time information.
+      expect(datetime).to.include("T");
+      // Check if it matches ISO format roughly
+      expect(datetime).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+  });
+});


### PR DESCRIPTION
## Implemented changes

This PR fixes eox-layercontrol datetime event and its emission format.

- [x] Prevent Infinite Loop: Added a check in [layer-datetime](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to stop the [datetime:updated](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) event from triggering on initialization if the value hasn't changed. This resolves the reported issue where applications engaging with the event could enter an infinite update loop.
- [x] Correct DateTime Emission: Updated handleStepChange to emit a full ISO datetime string (e.g., 2024-01-01T12:00:00Z) instead of just a date string (YYYY-MM-DD) when the configuration uses datetime values.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
