### PR TITLE
feat: area and length measurements

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -54,6 +54,7 @@ export class EOxDrawTools extends LitElement {
       featureStyles: { attribute: false },
       modify: { attribute: false, state: true },
       multipleFeatures: { attribute: "multiple-features", type: Boolean },
+      measure: { type: Boolean },
       importFeatures: { attribute: "import-features", type: Boolean },
       showEditor: { attribute: "show-editor", type: Boolean },
       showList: { attribute: "show-list", type: Boolean },
@@ -164,6 +165,14 @@ export class EOxDrawTools extends LitElement {
      * Allow adding more than one feature at a time
      */
     this.multipleFeatures = false;
+
+    /**
+     * Display area/line measurement for the drawn features.
+     * When enabled, a "measure" property is added to each drawn feature's properties,
+     * containing the calculated area (for Polygons and Circles) or length (for LineStrings).
+     * This measurement is also displayed as a text label on the map using OpenLayers flat styles.
+     */
+    this.measure = false;
 
     /**
      * Allow import features using drag-drop and upload button
@@ -351,8 +360,10 @@ export class EOxDrawTools extends LitElement {
       this.#olMap = OlMap;
     }
     if (
-      changedProperties.get("type") &&
-      changedProperties.get("type") !== this.type
+      (changedProperties.get("type") &&
+        changedProperties.get("type") !== this.type) ||
+      (changedProperties.has("measure") &&
+        changedProperties.get("measure") !== this.measure)
     ) {
       this.resetLayer(this);
       this.firstUpdated();

--- a/elements/drawtools/src/methods/draw/index.js
+++ b/elements/drawtools/src/methods/draw/index.js
@@ -8,3 +8,4 @@ export { default as emitDrawnFeaturesMethod } from "./emit-drawn-features"; // E
 export { default as createSelectHandler } from "./create-select-handler"; // Factory function to create select event handler
 export { default as initSelection } from "./init-selection"; // Initializes selection interactions
 export { default as handleLayerId } from "./handle-layer-id"; // handle switching between selection and drawing
+export { default as initMeasuring, updateMeasure } from "./init-measuring"; // Initializes measuring logic

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -1,4 +1,6 @@
-import { onDrawEndMethod, initSelection } from "./";
+import onDrawEndMethod from "./on-draw-end";
+import initSelection from "./init-selection";
+import initMeasuring, { updateMeasure } from "./init-measuring";
 
 import { getElement } from "@eox/elements-utils";
 
@@ -35,6 +37,14 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
       "stroke-width": 2,
       "circle-radius": 5,
       "circle-fill-color": `rgba(${primaryColor}, 1)`,
+      ...(EoxDrawTool.measure && {
+        "text-value": ["coalesce", ["get", "measure"], ""],
+        "text-fill-color": `rgba(${primaryColor}, 1)`,
+        "text-stroke-color": "white",
+        "text-stroke-width": 3,
+        "text-font": "bold 14px sans-serif",
+        "text-overflow": true,
+      }),
     },
     interactions: [
       {
@@ -52,6 +62,14 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
             "stroke-line-dash": [7, 3],
             "circle-radius": 5,
             "circle-fill-color": `rgba(${primaryColor}, 1)`,
+            ...(EoxDrawTool.measure && {
+              "text-value": ["coalesce", ["get", "measure"], ""],
+              "text-fill-color": `rgba(${primaryColor}, 1)`,
+              "text-stroke-color": "white",
+              "text-stroke-width": 3,
+              "text-font": "bold 14px sans-serif",
+              "text-overflow": true,
+            }),
           },
         },
       },
@@ -94,10 +112,23 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
 
   // Initialize selection interactions
   initSelection(EoxDrawTool, EoxMap, EoxDrawTool.layerId);
+
+  if (EoxDrawTool.measure) {
+    initMeasuring(EoxDrawTool);
+  }
+
   const onModifyEnd = () => EoxDrawTool.onModifyEnd();
   const onAddFeatures = () => onDrawEndMethod(EoxDrawTool);
 
   EoxDrawTool.modify?.on("modifyend", onModifyEnd);
+
+  if (EoxDrawTool.measure) {
+    EoxDrawTool.draw?.on("drawstart", (evt) => {
+      const feature = evt.feature;
+      updateMeasure(feature);
+      feature.getGeometry().on("change", () => updateMeasure(feature));
+    });
+  }
 
   EoxMap.addEventListener("addfeatures", onAddFeatures);
 

--- a/elements/drawtools/src/methods/draw/init-measuring.js
+++ b/elements/drawtools/src/methods/draw/init-measuring.js
@@ -1,0 +1,69 @@
+import { getArea, getLength } from "ol/sphere";
+
+/**
+ * @param {import("ol").Feature} feature
+ */
+export const updateMeasure = (feature) => {
+  const geom = feature.getGeometry();
+  if (!geom) return;
+  let measure = "";
+  if (geom.getType() === "Polygon" || geom.getType() === "MultiPolygon") {
+    const area = getArea(geom);
+    if (area > 1000000) {
+      measure = (area / 1000000).toFixed(2) + " km²";
+    } else {
+      measure = area.toFixed(2) + " m²";
+    }
+  } else if (
+    geom.getType() === "LineString" ||
+    geom.getType() === "MultiLineString"
+  ) {
+    const length = getLength(geom);
+    if (length > 1000) {
+      measure = (length / 1000).toFixed(2) + " km";
+    } else {
+      measure = length.toFixed(2) + " m";
+    }
+  } else if (geom.getType() === "Circle") {
+    // @ts-expect-error getRadius
+    const radius = geom.getRadius();
+    const area = Math.PI * Math.pow(radius, 2);
+    if (area > 1000000) {
+      measure = (area / 1000000).toFixed(2) + " km²";
+    } else {
+      measure = area.toFixed(2) + " m²";
+    }
+  }
+  if (measure && feature.get("measure") !== measure) {
+    feature.set("measure", measure);
+  }
+};
+
+/**
+ * Initializes measuring on the draw layer.
+ * Updates the feature property "measure" on geometry change.
+ *
+ * @param {import("../../main").EOxDrawTools} EoxDrawTool
+ */
+const initMeasuring = (EoxDrawTool) => {
+  const source = EoxDrawTool.drawLayer.getSource();
+
+  /**
+   * @param {import("ol/source/Vector").VectorSourceEvent} evt
+   */
+  const handleFeature = (evt) => {
+    const feature = evt.feature;
+    if (feature) {
+      updateMeasure(feature);
+      feature.getGeometry().on("change", () => updateMeasure(feature));
+    }
+  };
+
+  source.on("addfeature", handleFeature);
+  source.getFeatures().forEach((feature) => {
+    updateMeasure(feature);
+    feature.getGeometry().on("change", () => updateMeasure(feature));
+  });
+};
+
+export default initMeasuring;

--- a/elements/drawtools/stories/drawtools.stories.js
+++ b/elements/drawtools/stories/drawtools.stories.js
@@ -16,6 +16,7 @@ import {
   FeaturesProjectionStory,
   FormatStory,
   ContinuousDrawingStory,
+  MeasureStory,
 } from "./index";
 
 export default {
@@ -118,6 +119,16 @@ export const Formats = FormatStory;
  * draw button (which uses `--primary`) and the delete/discard button (which uses `--error`).
  */
 export const CSSVariableOverride = CSSVariableOverrideStory;
+
+/**
+ * By setting the `measure` attribute or property to `true`, the element displays
+ * area/line measurement for the drawn features.
+ * The measurement logic automatically calculates the area for polygons and circles,
+ * and the length for line segments. These values are updated in real-time as the
+ * geometry is modified and are displayed as text labels on the map features.
+ * The `measure` property is also added to the properties of the emitted feature.
+ */
+export const Measure = MeasureStory;
 
 /**
  * By setting the `unstyled` attribute or property, the element has no styling applied.

--- a/elements/drawtools/stories/index.js
+++ b/elements/drawtools/stories/index.js
@@ -14,3 +14,4 @@ export { default as FormatStory } from "./formats"; // Story showcasing emitting
 export { default as ContinuousDrawingStory } from "./continuous-drawing"; // Story demonstrating continuous drawing
 export { default as CSSVariableOverrideStory } from "./css-variable-override"; // Story demonstrating css override
 export { default as UnstyledStory } from "./unstyled"; // Story demonstrating unstyled variant of element.
+export { default as MeasureStory } from "./measure"; // Story demonstrating measurement functionality.

--- a/elements/drawtools/stories/measure.js
+++ b/elements/drawtools/stories/measure.js
@@ -1,0 +1,35 @@
+import { html } from "lit";
+import { STORIES_LAYERS_ARRAY, STORIES_MAP_STYLE } from "../src/enums";
+
+export const Measure = {
+  args: {
+    for: "eox-map#measure",
+    allowModify: true,
+    multipleFeatures: true,
+    measure: true,
+    type: "Polygon",
+    storyAdditionalComponents: {
+      "eox-map": {
+        id: "measure",
+        style: STORIES_MAP_STYLE,
+        layers: STORIES_LAYERS_ARRAY,
+      },
+    },
+  },
+  render: (args) => html`
+    <eox-drawtools
+      for=${args.for}
+      .allowModify=${args.allowModify}
+      .multipleFeatures=${args.multipleFeatures}
+      .measure=${args.measure}
+      .type=${args.type}
+    ></eox-drawtools>
+    <eox-map
+      id=${args.storyAdditionalComponents["eox-map"].id}
+      style=${args.storyAdditionalComponents["eox-map"].style}
+      .layers=${args.storyAdditionalComponents["eox-map"].layers}
+    ></eox-map>
+  `,
+};
+
+export default Measure;

--- a/elements/drawtools/test/_mockMap.js
+++ b/elements/drawtools/test/_mockMap.js
@@ -30,9 +30,18 @@ export class MockMap extends HTMLElement {
                 this.features = [];
               },
               // Simulating getFeatures method
-              addFeatures: (features) => this.features.concat(features),
+              addFeatures: (features) => {
+                this.features = this.features.concat(features);
+              },
+              addFeature: (feature) => {
+                this.features.push(feature);
+                if (this.onAddFeature) this.onAddFeature({ feature });
+              },
               getFeatures: () => this.features,
               removeFeature: () => this.features.splice(0, 1),
+              on: (event, cb) => {
+                if (event === "addfeature") this.onAddFeature = cb;
+              },
             }),
           },
         ],

--- a/elements/drawtools/test/cases/index.js
+++ b/elements/drawtools/test/cases/index.js
@@ -7,3 +7,4 @@ export { default as copyGeoJsonEditorTest } from "./copy-geo-json-editor"; // Te
 export { default as setLayerId } from "./set-layer-id"; // Test to set the layer id and check if the draw button icon changes
 export { default as setDifferentFormats } from "./set-different-formats"; // Test if the drawn features are emitted in different formats
 export { default as featureListTest } from "./feature-list";
+export { default as measureTest } from "./measure";

--- a/elements/drawtools/test/cases/measure.js
+++ b/elements/drawtools/test/cases/measure.js
@@ -1,0 +1,16 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+const { drawTools } = TEST_SELECTORS;
+
+const measureTest = () => {
+  cy.get(drawTools).then(($el) => {
+    const eoxDrawTools = $el[0];
+    eoxDrawTools.measure = true;
+    const features = eoxDrawTools.drawLayer.getSource().getFeatures();
+    if (features && features.length > 0) {
+      expect(features[0].get("measure")).to.not.be.undefined;
+    }
+  });
+};
+
+export default measureTest;

--- a/elements/drawtools/test/general.cy.js
+++ b/elements/drawtools/test/general.cy.js
@@ -9,6 +9,7 @@ import {
   setDifferentFormats,
   setLayerId,
   featureListTest,
+  measureTest,
 } from "./cases";
 
 import { TEST_SELECTORS } from "../src/enums";
@@ -48,4 +49,7 @@ describe("Drawtools", () => {
 
   // Test case to render a list of features
   it("renders a list of features", () => featureListTest());
+
+  // Test case to check area and line measurement
+  it("checks area and line measurement", () => measureTest());
 });


### PR DESCRIPTION
## Implemented changes

Adds real-time measurement support to eox-drawtools via a new `measure` attribute/property. Geometries calculate and display area (Polygons/Circles) or length (LineStrings) as labels on the map.

- Added `measure` attribute to enable the feature.
- Implemented real-time measurement updates during drawing and modification.
- Injects a `measure` string property into emitted map features.
- Configured automatic measurement labels using OpenLayers flat styles.
- Included new Storybook example and Cypress component tests.

## Screenshots/Videos

https://github.com/user-attachments/assets/287b456e-114c-4278-be09-6132ae4b1f45


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
