### PR TITLE
chore(docs): storybook glob inclusion instead of exclusion

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,6 +17,7 @@ const config = {
       "./About.mdx",
       "./Usage.mdx",
       "./Coding Agents.mdx",
+      "../*.stories.@(js|jsx|mjs|ts|tsx)", // root level stoires (kitchen sink)
       // Only include stories from elements folders
       "../elements/**/stories/*.stories.@(js|jsx|mjs|ts|tsx)",
     ];


### PR DESCRIPTION
## Implemented changes

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)


This PR changes the storybook config so it works on Mac again. Apparently the glob negation is unreliable on Mac, so this method tries to go from a "catch-all and exclude the unneeded stuff" to an "include only the needed stuff" approach. 
