### PR TITLE
chore: remove dist from dev releases

### DIFF
--- a/.github/workflows/preview_release.yml
+++ b/.github/workflows/preview_release.yml
@@ -43,9 +43,5 @@ jobs:
 
       - name: Install dependencies 👨🏻‍💻
         run: npm ci --prefer-offline --no-audit
-
-      - name: Build packages 🔧
-        run: npm run build:all
-
       - name: Release preview 🚀
         run: npx pkg-pr-new publish './elements/*' './utils/' --comment=off


### PR DESCRIPTION
## Implemented changes

Removed the build step from the preview CD to not include the dist to solve the `max payload` of 20mb error in pkg.pr.new. 

This breaks releases that uses `dist` imports with a dev release

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
