### PR TITLE
Fix: `geosearch` select event's `details` not correctly passed

### DIFF
--- a/elements/geosearch/src/main.js
+++ b/elements/geosearch/src/main.js
@@ -305,7 +305,11 @@ class EOxGeoSearch extends LitElement {
     /**
      * The select event, including the details of the selected item
      */
-    this.dispatchEvent(new CustomEvent("geosearchSelect", event));
+    this.dispatchEvent(
+      new CustomEvent("geosearchSelect", {
+        detail: event,
+      }),
+    );
   }
 
   updateMap() {


### PR DESCRIPTION
## Implemented Changes
- The `details` object of the geosearch `select` event was not being passed correctly, which prevented access to the selected place details from the event.

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
