### PR TITLE
fix: remove tileUrl params on date change

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -165,6 +165,9 @@ export const createEditor = (element) => {
       ),
     );
     const hideTabsIfPropertiesHidden = (properties) => {
+      if (!properties) {
+        return;
+      }
       // Find tabs for hidden properties and set data-hidden
       // in order to hide them with CSS
       Object.entries(properties)

--- a/elements/layercontrol/src/helpers/get-start-vals.js
+++ b/elements/layercontrol/src/helpers/get-start-vals.js
@@ -55,10 +55,6 @@ export function getStartVals(layer, layerConfig) {
     // Extract query parameters from tile URL
     // @ts-expect-error TODO
     const url = new URL(layer.getSource().getTileUrlFunction()([0, 0, 0]));
-    const removeProperties =
-      layerConfig.schema?.options?.removeProperties ?? [];
-    // Remove unwanted properties from query parameters
-    removeProperties.forEach((prop) => url.searchParams.delete(prop));
 
     // Retrieve startVals based on schema and query parameters
     nestedValues = {};

--- a/elements/layercontrol/src/methods/layer-config/data-change.js
+++ b/elements/layercontrol/src/methods/layer-config/data-change.js
@@ -28,9 +28,15 @@ const dataChangeMethod = (data, tileUrlFunc, EOxLayerControlLayerConfig) => {
     EOxLayerControlLayerConfig.layer
       .getSource()
       // @ts-expect-error TODO
-      .setTileUrlFunction((...args) =>
-        updateUrl(newTileUrlFunc(...args), data),
-      );
+      .setTileUrlFunction((...args) => {
+        const url = new URL(newTileUrlFunc(...args));
+        const removeProperties =
+          EOxLayerControlLayerConfig.layerConfig.schema?.options
+            ?.removeProperties ?? [];
+        // Remove unwanted properties from query parameters
+        removeProperties.forEach((prop) => url.searchParams.delete(prop));
+        return updateUrl(url.href, data);
+      });
 
     // TODO: It's not advisable to access protected methods directly.
     // Setting a new key for the layer source to trigger a refresh.


### PR DESCRIPTION
## Implemented changes
Moved the implementation of `removeProperties` to `dataChangeMethod` from it's previous location in `getStartVals`.
The reason for this is that `getStartVals` can return `null` in [some cases](https://github.com/EOX-A/EOxElements/blob/aa2eaae12ee940f2519a2fcb0049f939ba32c6a8/elements/layercontrol/src/helpers/get-start-vals.js#L72-L73) and then the removed properties would get overridden by the default tileUrl params.

This PR also includes a related a small check in the jsonform `hideTabsIfPropertiesHidden` in case of schemas that do not include top level `properties` in case of using for example `anyOf` or `allOf`
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
