### PR TITLE
fix: preserve user-provided dimensions in WMTSCapabilities source

### DIFF
--- a/elements/map/src/custom/sources/WMTSCapabilities.js
+++ b/elements/map/src/custom/sources/WMTSCapabilities.js
@@ -70,7 +70,11 @@ class WMTSCapabilities extends TileImage {
     this.matrixSet_ = capabilitiesOptions.matrixSet;
     this.style_ = capabilitiesOptions.style;
     this.format_ = capabilitiesOptions.format;
-    this.dimensions_ = capabilitiesOptions.dimensions;
+    // User-provided dimensions (e.g. time) take precedence
+    this.dimensions_ = {
+      ...capabilitiesOptions.dimensions,
+      ...options.dimensions,
+    };
 
     // Set URLs for the tile source
     this.setUrls(capabilitiesOptions.urls);


### PR DESCRIPTION
After fetching and parsing the capabilities XML, the dimensions from optionsFromCapabilities() were unconditionally assigned, overwriting any user-supplied dimensions (e.g. time).

Merge both objects so user-provided values take precedence over capabilities defaults.

## Implemented changes

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
