### PR TITLE
fix: Update WebGLTile styles on layer update

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -36,6 +36,16 @@ export default defineConfig({
     // specPattern: "**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "cypress/support/e2e.js",
     experimentalRunAllSpecs: true,
+    setupNodeEvents(on, config) {
+      on("before:browser:launch", (browser, launchOptions) => {
+        if (browser.name === "chrome" || browser.name === "edge") {
+          launchOptions.args.push("--enable-unsafe-swiftshader");
+          launchOptions.args.push("--disable-gpu");
+        }
+        return launchOptions;
+      });
+      return config;
+    },
   },
   component: {
     supportFile: "cypress/support/component.js",

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -36,16 +36,6 @@ export default defineConfig({
     // specPattern: "**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "cypress/support/e2e.js",
     experimentalRunAllSpecs: true,
-    setupNodeEvents(on, config) {
-      on("before:browser:launch", (browser, launchOptions) => {
-        if (browser.name === "chrome" || browser.name === "edge") {
-          launchOptions.args.push("--enable-unsafe-swiftshader");
-          launchOptions.args.push("--disable-gpu");
-        }
-        return launchOptions;
-      });
-      return config;
-    },
   },
   component: {
     supportFile: "cypress/support/component.js",

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -283,7 +283,7 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
 
   // Update style if different
   if (
-    ["Vector", "VectorTile","WebGLTile"].includes(newLayerDefinition.type) &&
+    ["Vector", "VectorTile", "WebGLTile"].includes(newLayerDefinition.type) &&
     serialize(
       /** @type {import("../layers.ts").EOxLayerType<"Vector"|"VectorTile"|"WebGLTile",any>} */ (
         newLayerDefinition
@@ -293,7 +293,7 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
     // @ts-expect-error TODO
     existingLayer.setStyle(newLayerDefinition.style);
   }
-  
+
   // Update properties if different
   if (
     serialize(newLayerDefinition.properties) !==

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -283,17 +283,17 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
 
   // Update style if different
   if (
-    ["Vector", "VectorTile"].includes(newLayerDefinition.type) &&
+    ["Vector", "VectorTile","WebGLTile"].includes(newLayerDefinition.type) &&
     serialize(
-      /** @type {import("../layers.ts").EOxLayerType<"Vector"|"VectorTile",any>} */ (
+      /** @type {import("../layers.ts").EOxLayerType<"Vector"|"VectorTile"|"WebGLTile",any>} */ (
         newLayerDefinition
       ).style,
     ) !== serialize(existingJsonDefinition.style)
   ) {
     // @ts-expect-error TODO
-    existingLayer.setStyle(newLayer.getStyle());
+    existingLayer.setStyle(newLayerDefinition.style);
   }
-
+  
   // Update properties if different
   if (
     serialize(newLayerDefinition.properties) !==

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -291,7 +291,12 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
     ) !== serialize(existingJsonDefinition.style)
   ) {
     // @ts-expect-error TODO
-    existingLayer.setStyle(newLayerDefinition.style);
+    existingLayer.setStyle(
+      newLayerDefinition.type === "WebGLTile"
+        ? newLayerDefinition.style
+        : // @ts-expect-error TODO
+          newLayer.getStyle(),
+    );
   }
 
   // Update properties if different


### PR DESCRIPTION
## Implemented changes

Update WebGLTile layer styles in the smart update.
~~`newLayer.getStyle` was replaced with `newLayerDefinition.style` due to the WebGLTile class not having the `getStyle` function, and `getStyle` and `.style` should be interchangeable for [Vector](https://openlayers.org/en/latest/apidoc/module-ol_layer_Vector-VectorLayer.html#getStyle) and [VectorTile](https://openlayers.org/en/latest/apidoc/module-ol_layer_VectorTile-VectorTileLayer.html#getStyle) layers~~

The motivation for implementing this, is to be able to show different GeoZarr source styling without having to refetch the zarr chunks. this is demonstrated in EOPF-Explorer/narratives#8


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
