### PR TITLE
feat: result sorting

### DIFF
--- a/elements/itemfilter/src/enums/config.js
+++ b/elements/itemfilter/src/enums/config.js
@@ -71,6 +71,14 @@ export const ELEMENT_CONFIG = Object.freeze({
   imageProperty: undefined,
 
   /**
+   * Sorting behavior for the results.
+   * Can be undefined (alphabetical auto-detect), false (no sorting),
+   * string (property to sort by), function (custom comparator),
+   * or object { key: string, order: 'asc'|'desc' }
+   */
+  resultSorting: undefined,
+
+  /**
    * Allow opening multiple filter accordions in parallel
    * @default true
    */
@@ -103,6 +111,7 @@ export const ELEMENT_PROPERTIES = [
   "subTitleProperty",
   "imageProperty",
   "idProperty",
+  "resultSorting",
   "expandMultipleFilters",
   "expandResults",
   "expandMultipleResults",

--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -41,6 +41,7 @@ import {
  * - Auto-spreading of single-item aggregations to root level
  * - Card display mode for results (`result-type="cards"`)
  * - Secondary result action button with custom icon and event handler (`click:result-action`)
+ * - Custom result sorting via `resultSorting` property
  * - Customizable layout and styling via CSS variables
  *
  * Usage examples and visual demos are available in Storybook stories, including scenarios for inline mode, external filtering, nested properties, card display, CSS variable customization, and result actions.
@@ -73,6 +74,7 @@ export class EOxItemFilter extends LitElement {
       titleProperty: { attribute: "title-property", type: String },
       subTitleProperty: { attribute: "sub-title-property", type: String },
       imageProperty: { attribute: "image-property", type: String },
+      resultSorting: { attribute: false, type: Object },
       expandMultipleFilters: {
         attribute: "enable-multiple-filter",
         type: Boolean,
@@ -233,6 +235,18 @@ export class EOxItemFilter extends LitElement {
     this.imageProperty = undefined;
 
     /**
+     * Sorting behavior for the results. Can be:
+     * - undefined (default): smart alphabetical sorting (skips if externalFilter or fuseConfig.shouldSort is truthy)
+     * - false: no sorting
+     * - string: property key to sort by (ascending)
+     * - function: custom comparator function (a, b) => number
+     * - object: { key: string, order?: 'asc' | 'desc' }
+     *
+     * @type false|string|Function|{key:string, order?:'asc'|'desc'}
+     */
+    this.resultSorting = undefined;
+
+    /**
      * Unique id property of items
      *
      * @type String
@@ -297,6 +311,10 @@ export class EOxItemFilter extends LitElement {
    * Applies the filters to the items and updates the result aggregation.
    */
   apply() {
+    this.#config = ELEMENT_PROPERTIES.reduce((acc, property) => {
+      acc[property] = this[property];
+      return acc;
+    }, {});
     this.#resultAggregation = filterApplyMethod(
       this.#config,
       this.#items,
@@ -335,10 +353,12 @@ export class EOxItemFilter extends LitElement {
    * Sorts the given items based on the current configuration.
    *
    * @param {Array<object>} items - The items to be sorted.
+   * @param {Object} [options] - Optional sorting parameters.
+   * @param {boolean} [options.isExternalResult] - Flag for results from external filter.
    * @returns {Array<object>} - The sorted items.
    */
-  sortResults(items) {
-    return sortResultsMethod(items, this.#config);
+  sortResults(items, options) {
+    return sortResultsMethod(items, this.#config, options);
   }
 
   /**

--- a/elements/itemfilter/src/methods/itemfilter/search.js
+++ b/elements/itemfilter/src/methods/itemfilter/search.js
@@ -17,7 +17,9 @@ async function searchMethod(config, items, EOxItemFilter) {
     results = await filterClient(items, EOxItemFilter.filters, config);
   }
 
-  EOxItemFilter.results = EOxItemFilter.sortResults(results);
+  EOxItemFilter.results = EOxItemFilter.sortResults(results, {
+    isExternalResult: !!EOxItemFilter.externalFilter,
+  });
 }
 
 export default searchMethod;

--- a/elements/itemfilter/src/methods/itemfilter/sort-results.js
+++ b/elements/itemfilter/src/methods/itemfilter/sort-results.js
@@ -1,19 +1,65 @@
 import { getValue } from "../../helpers";
 
 /**
- * Sorts the provided items based on the title property specified in the configuration.
+ * Sorts the provided items based on the resultSorting configuration.
+ * Supports:
+ * - undefined (default): smart alphabetical sorting (skips if externalFilter or fuseConfig.shouldSort is truthy)
+ * - false: no sorting
+ * - string: property key to sort by (ascending)
+ * - function: custom comparator function (a, b) => number
+ * - object: { key: string, order?: 'asc' | 'desc' }
  *
  * @param {Array<Object>} items - The items to be sorted.
  * @param {Object} config - The configuration object containing sorting options.
+ * @param {Object} [options] - Optional sorting parameters.
+ * @param {boolean} [options.isExternalResult] - Flag for results from external filter.
  * @returns {Array<Object>} The sorted array of items.
  */
-function sortResultsMethod(items, config) {
-  return [...items].sort((a, b) =>
-    getValue(config.titleProperty, a)
-      .toString()
-      .localeCompare(getValue(config.titleProperty, b))
-      .toString(),
-  );
+function sortResultsMethod(items, config, options = {}) {
+  const { resultSorting } = config;
+
+  // 1. Explicitly disabled sorting
+  if (resultSorting === false) {
+    return items;
+  }
+
+  // 2. Default/Smart sorting (undefined)
+  if (resultSorting === undefined) {
+    // Skip sorting if results come from an external source (assumed sorted)
+    // or if Fuse.js is configured to handle its own sorting by score.
+    if (options.isExternalResult || config.fuseConfig?.shouldSort) {
+      return items;
+    }
+    // Backward compatible default: alphabetical by titleProperty
+    return [...items].sort((a, b) => {
+      const valA = getValue(config.titleProperty, a) || "";
+      const valB = getValue(config.titleProperty, b) || "";
+      return valA.toString().localeCompare(valB.toString());
+    });
+  }
+
+  // 3. Custom comparator function
+  if (typeof resultSorting === "function") {
+    return [...items].sort(resultSorting);
+  }
+
+  // 4. Sort by property (string or object)
+  const sortKey =
+    typeof resultSorting === "string" ? resultSorting : resultSorting.key;
+  const sortOrder =
+    typeof resultSorting === "object" && resultSorting.order === "desc"
+      ? -1
+      : 1;
+
+  if (sortKey) {
+    return [...items].sort((a, b) => {
+      const valA = getValue(sortKey, a) || "";
+      const valB = getValue(sortKey, b) || "";
+      return valA.toString().localeCompare(valB.toString()) * sortOrder;
+    });
+  }
+
+  return items;
 }
 
 export default sortResultsMethod;

--- a/elements/itemfilter/stories/index.js
+++ b/elements/itemfilter/stories/index.js
@@ -10,3 +10,4 @@ export { default as ExternalStory, ExternalFetchFnStory } from "./external"; // 
 export { default as CardDisplayStory } from "./card-display";
 export { default as CSSVariablesStory } from "./css-variables";
 export { default as ResultActionStory } from "./result-action";
+export { ResultSortingStory } from "./result-sorting";

--- a/elements/itemfilter/stories/itemfilter.stories.js
+++ b/elements/itemfilter/stories/itemfilter.stories.js
@@ -11,6 +11,7 @@ import {
   PreSetFilterStory,
   PrimaryStory,
   ResultActionStory,
+  ResultSortingStory,
 } from "./index.js";
 
 export default {
@@ -72,3 +73,13 @@ export const CSSVariables = CSSVariablesStory();
  * The icon can be configered with the `resultActionIcon` property. Useful for additional actions on results, such as opening details or triggering workflows.
  */
 export const ResultAction = ResultActionStory();
+
+/**
+ * The `resultSorting` property allows you to customize the sorting behavior of results. You can provide:
+ * - `undefined` (default): smart alphabetical sorting (skips if `externalFilter` or `fuseConfig.shouldSort` is set)
+ * - `false`: disable sorting completely (results follow filter engine order)
+ * - `string`: sort ascending by that property key (supports dot notation)
+ * - `function`: a custom comparator function `(a, b) => number`
+ * - `object`: `{ key: string, order?: 'asc' | 'desc' }` for property sorting with direction (this example)
+ */
+export const ResultSorting = ResultSortingStory();

--- a/elements/itemfilter/stories/result-sorting.js
+++ b/elements/itemfilter/stories/result-sorting.js
@@ -1,0 +1,22 @@
+import { html } from "lit";
+import testItems from "../test/testItems.json";
+
+/**
+ * Demonstrates the `resultSorting` property for custom sorting of results.
+ * It's possible to sort results by any property of the items, including custom functions and sort directions.
+ *
+ * ```html
+ * <eox-itemfilter .resultSorting="${{ key: 'title', order: 'desc' }}"></eox-itemfilter>
+ * ```
+ */
+export const ResultSortingStory = () => ({
+  render: (args) =>
+    html`<eox-itemfilter
+      .items=${args.items}
+      .resultSorting=${args.resultSorting}
+    ></eox-itemfilter>`,
+  args: {
+    items: testItems,
+    resultSorting: { key: "themes", order: "desc" },
+  },
+});

--- a/elements/itemfilter/test/cases/general/index.js
+++ b/elements/itemfilter/test/cases/general/index.js
@@ -15,4 +15,5 @@ export { default as imageTest } from "./image";
 export { default as validationTest } from "./validation";
 export { default as slotRenderTest } from "./slots";
 export { default as resultsActionTest } from "./results-action";
+export { resultSortingTest } from "./result-sorting";
 export { default as resultAggregationTest } from "./results-aggregation";

--- a/elements/itemfilter/test/cases/general/result-sorting.js
+++ b/elements/itemfilter/test/cases/general/result-sorting.js
@@ -1,0 +1,97 @@
+/**
+ * Tests for result sorting logic in the eox-itemfilter component.
+ */
+export const resultSortingTest = () => {
+  // 1. Default alphabetical (ascending by title)
+  cy.get("eox-itemfilter")
+    .as("itemfilter")
+    .then(($el) => {
+      const eoxItemFilter = $el[0];
+      eoxItemFilter.resultSorting = undefined;
+      eoxItemFilter.apply();
+    });
+  cy.get("eox-itemfilter").then(($el) => {
+    const results = $el[0].results;
+    const titles = results.map((r) => r.title);
+    const sorted = [...titles].sort((a, b) => a.localeCompare(b));
+    expect(
+      titles,
+      "Titles in eoxItemFilter.results should be sorted",
+    ).to.deep.equal(sorted);
+  });
+
+  // 2. Disabled sorting (resultSorting = false)
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.resultSorting = false;
+    eoxItemFilter.apply();
+  });
+  cy.get("eox-itemfilter").then(($el) => {
+    const results = $el[0].results;
+    const titles = results.map((r) => r.title);
+    const sorted = [...titles].sort((a, b) => a.localeCompare(b));
+    expect(titles).to.not.deep.equal(sorted);
+  });
+
+  // 3. Sort by custom property (e.g. 'themes')
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.resultSorting = "themes";
+    eoxItemFilter.apply();
+  });
+  cy.get("eox-itemfilter")
+    .shadow()
+    .find("ul#results li")
+    .then(() => {
+      // In our test items, we need to find what the 'themes' values are
+      // For simplicity, we just check they are in increasing order.
+      // We can't easily see hidden 'themes' in the UI without custom template,
+      // but we can check the component state.
+      cy.get("eox-itemfilter").then(($el) => {
+        const results = $el[0].results;
+        const themes = results.map((r) => r.themes?.[0] || "");
+        const sortedThemes = [...themes].sort((a, b) => a.localeCompare(b));
+        expect(themes).to.deep.equal(sortedThemes);
+      });
+    });
+
+  // 4. Sort by object { key, order: 'desc' }
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.resultSorting = { key: "title", order: "desc" };
+    eoxItemFilter.apply();
+  });
+  cy.get("eox-itemfilter").then(($el) => {
+    const results = $el[0].results;
+    const titles = results.map((r) => r.title);
+    const sortedDesc = [...titles].sort((a, b) => b.localeCompare(a));
+    expect(titles).to.deep.equal(sortedDesc);
+  });
+
+  // 5. Custom comparator function
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.resultSorting = (a, b) => b.title.localeCompare(a.title);
+    eoxItemFilter.apply();
+  });
+  cy.get("eox-itemfilter").then(($el) => {
+    const results = $el[0].results;
+    const titles = results.map((r) => r.title);
+    const sortedDesc = [...titles].sort((a, b) => b.localeCompare(a));
+    expect(titles).to.deep.equal(sortedDesc);
+  });
+
+  // 6. Auto-detect skip alphabetical when fuseConfig.shouldSort is true
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.resultSorting = undefined;
+    eoxItemFilter.fuseConfig = { shouldSort: true };
+    eoxItemFilter.apply();
+  });
+  cy.get("eox-itemfilter").then(($el) => {
+    const results = $el[0].results;
+    const titles = results.map((r) => r.title);
+    const sorted = [...titles].sort((a, b) => a.localeCompare(b));
+    expect(titles).to.not.deep.equal(sorted);
+  });
+};

--- a/elements/itemfilter/test/general.cy.js
+++ b/elements/itemfilter/test/general.cy.js
@@ -17,6 +17,7 @@ import {
   validationTest,
   slotRenderTest,
   resultsActionTest,
+  resultSortingTest,
   resultAggregationTest,
 } from "./cases/general/";
 
@@ -149,4 +150,9 @@ describe("Item Filter Config", () => {
    */
   it("should aggregate results correctly, handling edge cases", () =>
     resultAggregationTest());
+
+  /**
+   * Test case to verify result sorting.
+   */
+  it("should sort results based on configuration", () => resultSortingTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR adds **result sorting** to the configurable options of `eox-itemfilter`.

### API Design
**Property**: `resultSorting` (attribute: false, complex type)

| Value	| Behavior |
|-----------|---------------|
| `undefined` (default)	| Smart: alphabetical by `titleProperty`, UNLESS externally filtered or `fuseConfig.shouldSort` is set |
| `false`	| No sorting — preserve order from filter engine |
| `string` (e.g. `"datetime"`)	| Sort ascending by that property key |
| `function(a, b)`	| Custom comparator function |
| `{ key: string, order?: 'asc' \| 'desc' }`	| Sort by property with configurable direction |

**Auto-detection** (only when `resultSorting` is `undefined`):

- `externalFilter` in use → skip sorting (external API returns pre-sorted) — only for search results, not "show all" initial render
- `fuseConfig.shouldSort` truthy → skip sorting (Fuse.js sorts by score)
- Otherwise → alphabetical by `titleProperty` (backward-compatible)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
