### PR TITLE
feat(drawtools): add programmatic control APIs

### DIFF
--- a/elements/drawtools/README.md
+++ b/elements/drawtools/README.md
@@ -16,7 +16,60 @@ import "@eox/drawtools/dist/eox-drawtools.js"
 <eox-drawtools></eox-drawtools>
 ```
 
-Please refer to the [drawtools docs](https://eox-a.github.io/EOxElements/?path=/docs/elements-eox-drawtools--docs) for more details.
+## API
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `startDrawing()` | Activates the draw interaction on the map |
+| `stopDrawing()` | Deactivates the draw interaction without discarding existing features |
+| `discardDrawing()` | Stops drawing and clears all drawn features |
+| `removeFeatureByIndex(index)` | Removes a feature at the given index. Returns `true` if removed, `false` if out of bounds |
+| `emitDrawnFeatures()` | Manually triggers feature emission and `drawupdate` event |
+
+### Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `type` | `String` | `"Polygon"` | Draw type: `Polygon`, `Box`, `Point`, `Circle`, `LineString` |
+| `multiple-features` | `Boolean` | `false` | Allow drawing more than one feature |
+| `allow-modify` | `Boolean` | `false` | Allow modifying features after drawing |
+| `continuous` | `Boolean` | `false` | Auto-start next drawing after completing one |
+| `show-list` | `Boolean` | `false` | Display a list of drawn features |
+| `show-editor` | `Boolean` | `false` | Show GeoJSON editor |
+| `import-features` | `Boolean` | `false` | Allow drag-drop and file upload import |
+| `format` | `String` | `"feature"` | Output format: `feature`, `geojson`, `wkt` |
+| `projection` | `String` | `"EPSG:4326"` | Projection of emitted features |
+| `suppressEvents` | `Boolean` | `false` | When `true`, suppresses `drawupdate` event emission. Set before programmatic feature changes to avoid feedback loops |
+
+### Events
+
+| Event | Detail | Description |
+|-------|--------|-------------|
+| `drawupdate` | `Feature[] \| GeoJSON \| WKT` | Fires when features are added, modified, or discarded (unless `suppressEvents` is `true`) |
+
+### Programmatic Control Example
+
+```javascript
+const drawtools = document.querySelector("eox-drawtools");
+
+// Start and stop drawing (features preserved)
+drawtools.startDrawing();
+drawtools.stopDrawing();
+
+// Remove a specific feature
+drawtools.removeFeatureByIndex(0);
+
+// Suppress events during bulk operations
+drawtools.suppressEvents = true;
+drawtools.removeFeatureByIndex(0);
+drawtools.removeFeatureByIndex(0);
+drawtools.suppressEvents = false;
+drawtools.emitDrawnFeatures(); // manually emit once
+```
+
+Please refer to the [drawtools docs](https://eox-a.github.io/EOxElements/?path=/docs/elements-eox-drawtools--docs) for more details and interactive examples.
 
 ## Development
 

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -64,6 +64,7 @@ export class EOxDrawTools extends LitElement {
       format: { type: String },
       type: { type: String },
       unstyled: { type: Boolean },
+      suppressEvents: { attribute: false, state: true, type: Boolean },
     };
   }
 
@@ -111,6 +112,12 @@ export class EOxDrawTools extends LitElement {
      * Whether the user is currently in the process of drawing or not
      */
     this.currentlyDrawing = false;
+
+    /**
+     * When true, suppresses `drawupdate` event emission.
+     * Set this before programmatic feature changes to avoid feedback loops.
+     */
+    this.suppressEvents = false;
 
     /**
      * The current native OpenLayers `draw` interaction

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -4,6 +4,7 @@ import "./components/controller";
 import { styleEOX } from "./style.eox";
 import {
   startDrawingMethod,
+  stopDrawingMethod,
   initLayerMethod,
   discardDrawingMethod,
   emitDrawnFeaturesMethod,
@@ -257,6 +258,14 @@ export class EOxDrawTools extends LitElement {
    */
   startDrawing() {
     startDrawingMethod(this);
+  }
+
+  /**
+   * Stops the active drawing interaction without discarding existing features.
+   * The draw interaction is deactivated but all features remain on the layer.
+   */
+  stopDrawing() {
+    stopDrawingMethod(this);
   }
 
   /**

--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -276,6 +276,25 @@ export class EOxDrawTools extends LitElement {
   }
 
   /**
+   * Remove a feature at the given index from the draw layer source
+   * and update drawnFeatures. Emits drawupdate unless suppressEvents is set.
+   *
+   * @param {number} index - Zero-based index of the feature to remove.
+   * @returns {boolean} True if a feature was removed, false if index was out of bounds.
+   */
+  removeFeatureByIndex(index) {
+    const source = this.drawLayer?.getSource();
+    if (!source) return false;
+
+    const features = source.getFeatures();
+    if (index < 0 || index >= features.length) return false;
+
+    source.removeFeature(features[index]);
+    this.emitDrawnFeatures();
+    return true;
+  }
+
+  /**
    * @onClick Event handler triggered to discard/stop drawing
    * on the map and delete the drawn shapes.
    */

--- a/elements/drawtools/src/methods/draw/emit-drawn-features.js
+++ b/elements/drawtools/src/methods/draw/emit-drawn-features.js
@@ -52,7 +52,9 @@ const emitDrawnFeaturesMethod = (EoxDrawTool, drawUpdateEvent) => {
     EoxDrawTool.requestUpdate();
 
     // Triggering `drawupdate` event after drawFeature is updated
-    drawUpdateEvent(value);
+    if (!EoxDrawTool.suppressEvents) {
+      drawUpdateEvent(value);
+    }
   };
 
   // Emit features after a timeout (ensures update)

--- a/elements/drawtools/src/methods/draw/index.js
+++ b/elements/drawtools/src/methods/draw/index.js
@@ -9,3 +9,4 @@ export { default as createSelectHandler } from "./create-select-handler"; // Fac
 export { default as initSelection } from "./init-selection"; // Initializes selection interactions
 export { default as handleLayerId } from "./handle-layer-id"; // handle switching between selection and drawing
 export { default as initMeasuring, updateMeasure } from "./init-measuring"; // Initializes measuring logic
+export { default as stopDrawingMethod } from "./stop-drawing"; // Stops drawing without discarding features

--- a/elements/drawtools/src/methods/draw/init-layer.js
+++ b/elements/drawtools/src/methods/draw/init-layer.js
@@ -107,7 +107,7 @@ const initLayerMethod = (EoxDrawTool, multipleFeatures) => {
   );
 
   EoxDrawTool.modify = /** @type {import("ol/interaction").Modify} */ (
-    /** @type {unknown} */ (EoxMap.interactions["drawInteractionmodify"])
+    /** @type {unknown} */ (EoxMap.interactions["drawInteraction_modify"])
   );
 
   // Initialize selection interactions

--- a/elements/drawtools/src/methods/draw/start-drawing.js
+++ b/elements/drawtools/src/methods/draw/start-drawing.js
@@ -1,3 +1,8 @@
+import stopDrawingMethod from "./stop-drawing.js";
+
+/** @type {((e: KeyboardEvent) => void) | null} */
+let escapeHandler = null;
+
 /**
  * Initiates the drawing process by initializing the draw layer,
  * activating drawing, and updating the drawing status.
@@ -19,19 +24,25 @@ const startDrawingMethod = (EoxDrawTool) => {
     EoxDrawTool.requestUpdate();
   };
 
+  // Remove any previous Escape listener to avoid accumulation
+  if (escapeHandler) {
+    document.removeEventListener("keydown", escapeHandler);
+    escapeHandler = null;
+  }
+
   // Initialize the drawing process
   initializeDrawing();
   // Update the drawing status
   updateDrawingStatus();
 
-  // Abort drawing on Esc key
-  document.addEventListener("keydown", ({ key }) => {
+  // Abort drawing on Esc key — delegates to stopDrawingMethod for
+  // consistent state cleanup (isDrawingEnabled, selectionEvents, etc.)
+  escapeHandler = ({ key }) => {
     if (key === "Escape" && EoxDrawTool.currentlyDrawing) {
-      EoxDrawTool.draw?.setActive(false);
-      EoxDrawTool.currentlyDrawing = false;
-      EoxDrawTool.requestUpdate();
+      stopDrawingMethod(EoxDrawTool);
     }
-  });
+  };
+  document.addEventListener("keydown", escapeHandler);
 };
 
 export default startDrawingMethod;

--- a/elements/drawtools/src/methods/draw/stop-drawing.js
+++ b/elements/drawtools/src/methods/draw/stop-drawing.js
@@ -1,0 +1,25 @@
+/**
+ * Stops the active drawing interaction without discarding existing features.
+ * This deactivates the draw tool and selection, but preserves all drawn features
+ * on the layer. Use discardDrawing() to also clear features.
+ *
+ * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
+ */
+const stopDrawingMethod = (EoxDrawTool) => {
+  if (!EoxDrawTool.currentlyDrawing) return;
+
+  // Deactivate draw interaction but leave features intact
+  EoxDrawTool.draw?.setActive(false);
+
+  // Mark layer as not drawing — prevents re-activation on layer updates
+  EoxDrawTool.drawLayer?.set("isDrawingEnabled", false);
+
+  // Remove selection event listener
+  EoxDrawTool.selectionEvents?.removeSelectionEvent();
+
+  // Update state
+  EoxDrawTool.currentlyDrawing = false;
+  EoxDrawTool.requestUpdate();
+};
+
+export default stopDrawingMethod;

--- a/elements/drawtools/test/_mockMap.js
+++ b/elements/drawtools/test/_mockMap.js
@@ -38,7 +38,10 @@ export class MockMap extends HTMLElement {
                 if (this.onAddFeature) this.onAddFeature({ feature });
               },
               getFeatures: () => this.features,
-              removeFeature: () => this.features.splice(0, 1),
+              removeFeature: (feature) => {
+                const idx = this.features.indexOf(feature);
+                if (idx >= 0) this.features.splice(idx, 1);
+              },
               on: (event, cb) => {
                 if (event === "addfeature") this.onAddFeature = cb;
               },

--- a/elements/drawtools/test/cases/index.js
+++ b/elements/drawtools/test/cases/index.js
@@ -8,3 +8,6 @@ export { default as setLayerId } from "./set-layer-id"; // Test to set the layer
 export { default as setDifferentFormats } from "./set-different-formats"; // Test if the drawn features are emitted in different formats
 export { default as featureListTest } from "./feature-list";
 export { default as measureTest } from "./measure";
+export { default as stopDrawingTest } from "./stop-drawing";
+export { default as suppressEventsTest } from "./suppress-events";
+export { default as removeFeatureByIndexTest } from "./remove-feature-by-index";

--- a/elements/drawtools/test/cases/remove-feature-by-index.js
+++ b/elements/drawtools/test/cases/remove-feature-by-index.js
@@ -1,0 +1,47 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+const { drawTools } = TEST_SELECTORS;
+
+/**
+ * Tests that removeFeatureByIndex removes the correct feature from the draw
+ * layer source and emits a drawupdate event.
+ */
+const removeFeatureByIndexTest = () => {
+  // Set up event listener stub
+  cy.get(drawTools).then(($el) => {
+    $el[0].addEventListener("drawupdate", cy.stub().as("drawUpdateStub"));
+  });
+
+  // The mock map starts with 2 features in the source.
+  // Remove index 0 — the second feature should remain.
+  cy.get(drawTools).then(($el) => {
+    const source = $el[0].drawLayer.getSource();
+    const featuresBefore = source.getFeatures();
+    expect(featuresBefore).to.have.length(2);
+
+    // Keep a reference to the second feature to verify it survives
+    const secondFeature = featuresBefore[1];
+
+    const result = $el[0].removeFeatureByIndex(0);
+    expect(result).to.be.true;
+
+    // Verify the correct feature was removed
+    const featuresAfter = source.getFeatures();
+    expect(featuresAfter).to.have.length(1);
+    expect(featuresAfter[0]).to.equal(secondFeature);
+  });
+
+  // Wait for the setTimeout(0) in emitDrawnFeatures
+  cy.wait(50);
+
+  // Verify drawupdate was fired
+  cy.get("@drawUpdateStub").should("be.called");
+
+  // Test out-of-bounds returns false
+  cy.get(drawTools).then(($el) => {
+    expect($el[0].removeFeatureByIndex(-1)).to.be.false;
+    expect($el[0].removeFeatureByIndex(999)).to.be.false;
+  });
+};
+
+export default removeFeatureByIndexTest;

--- a/elements/drawtools/test/cases/stop-drawing.js
+++ b/elements/drawtools/test/cases/stop-drawing.js
@@ -1,0 +1,40 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+const { drawTools, controller, drawBtn } = TEST_SELECTORS;
+
+/**
+ * Tests that stopDrawing() deactivates the draw interaction
+ * without discarding existing features.
+ */
+const stopDrawingTest = () => {
+  cy.get(drawTools)
+    .shadow()
+    .within(() => {
+      cy.get(controller).within(() => {
+        // Start drawing
+        cy.get(drawBtn).click();
+        cy.get(drawBtn).should("have.attr", "disabled", "disabled");
+      });
+    });
+
+  // Verify currently drawing, then call stopDrawing
+  cy.get(drawTools).should(($el) => {
+    expect($el[0].currentlyDrawing).to.be.true;
+  });
+
+  // Record feature count before stopping
+  let featureCountBefore;
+  cy.get(drawTools).then(($el) => {
+    featureCountBefore = $el[0].drawLayer.getSource().getFeatures().length;
+    $el[0].stopDrawing();
+  });
+
+  // Verify drawing stopped AND features preserved
+  cy.get(drawTools).should(($el) => {
+    expect($el[0].currentlyDrawing).to.be.false;
+    const featuresAfter = $el[0].drawLayer.getSource().getFeatures();
+    expect(featuresAfter.length).to.equal(featureCountBefore);
+  });
+};
+
+export default stopDrawingTest;

--- a/elements/drawtools/test/cases/suppress-events.js
+++ b/elements/drawtools/test/cases/suppress-events.js
@@ -1,0 +1,40 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+const { drawTools } = TEST_SELECTORS;
+
+/**
+ * Tests that suppressEvents prevents drawupdate event emission
+ * during programmatic feature changes.
+ */
+const suppressEventsTest = () => {
+  // Set up event listener stub
+  cy.get(drawTools).then(($el) => {
+    $el[0].addEventListener("drawupdate", cy.stub().as("drawUpdateStub"));
+  });
+
+  // Enable suppressEvents, then trigger emitDrawnFeatures
+  cy.get(drawTools).then(($el) => {
+    $el[0].suppressEvents = true;
+    $el[0].emitDrawnFeatures();
+  });
+
+  // Wait for the setTimeout(0) in emitDrawnFeatures to complete
+  cy.wait(50);
+
+  // Verify drawupdate was NOT fired
+  cy.get("@drawUpdateStub").should("not.be.called");
+
+  // Disable suppressEvents and trigger again
+  cy.get(drawTools).then(($el) => {
+    $el[0].suppressEvents = false;
+    $el[0].emitDrawnFeatures();
+  });
+
+  // Wait for the setTimeout(0) again
+  cy.wait(50);
+
+  // Verify drawupdate was fired this time
+  cy.get("@drawUpdateStub").should("be.calledOnce");
+};
+
+export default suppressEventsTest;

--- a/elements/drawtools/test/general.cy.js
+++ b/elements/drawtools/test/general.cy.js
@@ -10,6 +10,9 @@ import {
   setLayerId,
   featureListTest,
   measureTest,
+  stopDrawingTest,
+  suppressEventsTest,
+  removeFeatureByIndexTest,
 } from "./cases";
 
 import { TEST_SELECTORS } from "../src/enums";
@@ -52,4 +55,14 @@ describe("Drawtools", () => {
 
   // Test case to check area and line measurement
   it("checks area and line measurement", () => measureTest());
+
+  // Test case for stopDrawing preserving features
+  it("stops drawing without discarding features", () => stopDrawingTest());
+
+  // Test case for suppressEvents flag
+  it("suppresses drawupdate events when suppressEvents is set", () =>
+    suppressEventsTest());
+
+  // Test case for removeFeatureByIndex
+  it("removes a feature by index", () => removeFeatureByIndexTest());
 });


### PR DESCRIPTION
## Summary

Adds public APIs for programmatic control of drawtools, enabling applications to manage draw state and features without reaching into internal properties.

- **`stopDrawing()`** — deactivates draw interaction without discarding features (complements existing `startDrawing()` / `discardDrawing()`)
- **`suppressEvents`** property — when `true`, prevents `drawupdate` event emission during programmatic feature changes (avoids feedback loops)
- **`removeFeatureByIndex(index)`** — removes a specific feature from the draw layer by index; returns `boolean`
- **Escape key fix** — prevents listener accumulation on repeated start/stop cycles; delegates to `stopDrawing()` for consistent state cleanup

Also includes the modify interaction key fix from #2227 (can be rebased once that merges).

## Motivation

Applications using drawtools for multi-feature editing (e.g., multiple AOIs) need to:
1. Stop drawing without losing existing features — previously required `draw.setActive(false)` + `currentlyDrawing = false` + `drawLayer.set('isDrawingEnabled', false)` (internal properties)
2. Programmatically remove individual features — previously required accessing `drawLayer.getSource().removeFeature()` (internal OL source)
3. Suppress events during bulk operations — previously required external guard flags since `drawupdate` fires on any source change

These APIs make these operations first-class without touching internals.

## Changes

| File | Change |
|------|--------|
| `src/methods/draw/stop-drawing.js` | New: `stopDrawingMethod` |
| `src/methods/draw/start-drawing.js` | Fix: remove old Escape handler before adding new; delegate to `stopDrawingMethod` |
| `src/methods/draw/emit-drawn-features.js` | Gate `drawUpdateEvent()` with `suppressEvents` check |
| `src/methods/draw/index.js` | Export `stopDrawingMethod` |
| `src/methods/draw/init-layer.js` | Fix: modify interaction key (`drawInteraction_modify`) |
| `src/main.js` | Add `suppressEvents` property, `stopDrawing()`, `removeFeatureByIndex()` methods |
| `test/_mockMap.js` | Fix: `removeFeature` respects feature argument |
| `test/cases/stop-drawing.js` | New test |
| `test/cases/suppress-events.js` | New test |
| `test/cases/remove-feature-by-index.js` | New test |
| `test/cases/index.js` | Export new tests |
| `test/general.cy.js` | Register new tests |
| `README.md` | API documentation with methods/properties/events tables |

## Test plan

- [ ] All existing Cypress tests pass
- [ ] New test: `stopDrawing()` deactivates draw, preserves features
- [ ] New test: `suppressEvents = true` prevents `drawupdate`, `false` allows it
- [ ] New test: `removeFeatureByIndex(0)` removes correct feature, out-of-bounds returns `false`
- [ ] Manual: draw features, call `stopDrawing()`, verify features remain on map