### PR TITLE
chore: do not run gitleaks for fork PRs

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,6 +6,9 @@ jobs:
   scan:
     name: gitleaks
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' || 
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Implemented changes

GitHub secrets are not available to PRs from forks, so running the gitleaks CI step there makes no sense as it will fail.

Updating the action to only run on PRs which are not coming from forks,

## Screenshots/Videos

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
