### PR TITLE
fix: feedback screenResolution, styling, tsconfig

### DIFF
--- a/elements/feedback/src/feedback-button.js
+++ b/elements/feedback/src/feedback-button.js
@@ -90,7 +90,7 @@ export class EOxFeedbackButton extends HTMLElement {
         ${this.getAttribute("unstyled") === null && styleEOX}
         :host {
           position: fixed !important;
-          margin: 0px 20px !important;
+          margin: 0px 20px;
           ${this.position.includes("top") ? "top: 0px;" : ""}
           ${this.position.includes("right") ? "right: 0px;" : ""}
           ${this.position.includes("bottom") ? "bottom: 0px;" : ""}

--- a/elements/feedback/src/main.js
+++ b/elements/feedback/src/main.js
@@ -321,6 +321,8 @@ export class EOxFeedback extends HTMLElement {
 
     requestBody.append("location", window.location.href);
 
+    requestBody.append("screenResolution", `width: ${window.innerWidth}px | height: ${window.innerHeight}px`);
+
     if (!this.endpoint) {
       throw new Error("No endpoint attribute defined!");
     }

--- a/elements/feedback/src/main.js
+++ b/elements/feedback/src/main.js
@@ -12,7 +12,7 @@ import "./feedback-button.js";
  *
  * On submit, the element sends a `POST` request with `FormData` to the configured
  * `endpoint`. The payload includes the feedback message (or custom form fields when
- * using a `schema`), the current page URL, the browser's user agent, and optionally
+ * using a `schema`), the current page URL, the browser's user agent, screen resolution and optionally
  * a screenshot file. This makes it straightforward to connect to any backend — for
  * example a service that creates issues in a Git platform (GitLab, GitHub, …), sends
  * notifications, or stores feedback in a database.

--- a/elements/feedback/src/main.js
+++ b/elements/feedback/src/main.js
@@ -321,7 +321,10 @@ export class EOxFeedback extends HTMLElement {
 
     requestBody.append("location", window.location.href);
 
-    requestBody.append("screenResolution", `width: ${window.innerWidth}px | height: ${window.innerHeight}px`);
+    requestBody.append(
+      "screenResolution",
+      `width: ${window.innerWidth}px | height: ${window.innerHeight}px`,
+    );
 
     if (!this.endpoint) {
       throw new Error("No endpoint attribute defined!");

--- a/elements/feedback/tsconfig.build.json
+++ b/elements/feedback/tsconfig.build.json
@@ -6,6 +6,7 @@
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,
+    "paths": {},
     "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.d.ts"]

--- a/elements/feedback/tsconfig.build.json
+++ b/elements/feedback/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./types",
+    "rootDir": "src",
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Implemented changes

- Adds screenResolution to the created API request, but I don't consider it a feature big enough to warrant a minor version increase.
- Removes !important from `margin` style definition to let it be stylable by apps integrating the feedback button.
- Fixes tsconfig config so that types are generated where package.json announces it

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
