### PR TITLE
chore(test): add better mocking for drawtools map

### DIFF
--- a/elements/drawtools/test/_mockMap.js
+++ b/elements/drawtools/test/_mockMap.js
@@ -62,6 +62,7 @@ export class MockMap extends HTMLElement {
       drawInteraction_modify: {
         // Simulating on method for drawInteraction_modify
         on() {},
+        un() {},
       },
     };
     // Simulating removeInteraction method

--- a/elements/drawtools/test/cases/feature-list.js
+++ b/elements/drawtools/test/cases/feature-list.js
@@ -3,14 +3,25 @@ import { TEST_SELECTORS } from "../../src/enums";
 // Destructure TEST_SELECTORS object
 const { drawTools, list, deleteFeatureBtn } = TEST_SELECTORS;
 
+const featureMock = {
+  get: () => null,
+  clone: function () {
+    return this;
+  },
+  getGeometry: () => ({
+    transform: () => {},
+  }),
+  setGeometry: () => {},
+};
+
 const testFeatures = [
   {
     getId: () => "0",
-    get: () => null,
+    ...featureMock,
   },
   {
     getId: () => "1",
-    get: () => null,
+    ...featureMock,
   },
 ];
 


### PR DESCRIPTION
## Implemented changes

This pull request introduces improvements to the test mocks used in the draw tools feature list tests. The changes enhance the realism and reusability of the feature mocks, and add missing mock methods to the map element.

* Refactored the test feature mocks in `feature-list.js` to use a reusable `featureMock` object, which now includes stub implementations for commonly used methods such as `clone`, `getGeometry`, and `setGeometry` to better simulate real feature objects.
* Added an `un` method to the `drawInteraction_modify` mock in `_mockMap.js` to simulate the removal of event listeners, aligning the mock's interface more closely with the real interaction object.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
