### PR TITLE
fix: prevent duplicate drawupdate events

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -385,9 +385,11 @@ export class EOxDrawTools extends LitElement {
   /**
    * initializes the EOxMap and OlMap instances
    * And stores them in the private properties #eoxMap and #olMap, respectively.
-   * It then calls requestUpdate to trigger a re-render.
    */
-  firstUpdated() {
+  updateLayer() {
+    if (this.resetLayer) {
+      this.resetLayer(this);
+    }
     const { EoxMap, OlMap, reset } = initLayerMethod(
       this,
       this.multipleFeatures,
@@ -395,6 +397,15 @@ export class EOxDrawTools extends LitElement {
     this.resetLayer = reset;
     this.eoxMap = EoxMap;
     this.#olMap = OlMap;
+  }
+
+  /**
+   * initializes the EOxMap and OlMap instances
+   * And stores them in the private properties #eoxMap and #olMap, respectively.
+   * It then calls requestUpdate to trigger a re-render.
+   */
+  firstUpdated() {
+    this.updateLayer();
     this.selectionEvents = createSelectHandler(this);
 
     if (this.importFeatures) initMapDragDropImport(this, this.eoxMap);
@@ -408,19 +419,17 @@ export class EOxDrawTools extends LitElement {
   }
 
   updated(changedProperties) {
-    if (changedProperties.has("for")) {
-      const { EoxMap, OlMap } = initLayerMethod(this, this.multipleFeatures);
-      this.eoxMap = EoxMap;
-      this.#olMap = OlMap;
-    }
+    const hasOldValue = (prop) =>
+      changedProperties.has(prop) && changedProperties.get(prop) !== undefined;
+
     if (
-      (changedProperties.get("type") &&
+      hasOldValue("for") ||
+      (changedProperties.has("type") &&
         changedProperties.get("type") !== this.type) ||
       (changedProperties.has("measure") &&
         changedProperties.get("measure") !== this.measure)
     ) {
-      this.resetLayer(this);
-      this.firstUpdated();
+      this.updateLayer();
       this.currentlyDrawing = false;
     }
   }

--- a/elements/drawtools/test/cases/drawupdate-event.js
+++ b/elements/drawtools/test/cases/drawupdate-event.js
@@ -8,24 +8,29 @@ const drawUpdateEventTest = () => {
     const drawtools = $el[0];
     let count = 0;
     drawtools.addEventListener("drawupdate", () => count++);
-    
+
     cy.get("mock-map").then(($mapEl) => {
       const map = $mapEl[0];
-      
+
       map.dispatchEvent(new CustomEvent("addfeatures"));
     });
-    
+
     // Wait for the async setTimeout in emitDrawnFeaturesMethod
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(50).then(() => {
       expect(count).to.eq(1, "should emit only once for one addfeatures event");
-      
+
       cy.get("mock-map").then(($mapEl) => {
         $mapEl[0].dispatchEvent(new CustomEvent("addfeatures"));
       });
     });
-    
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(50).then(() => {
-      expect(count).to.eq(2, "should emit exactly twice for two addfeatures events");
+      expect(count).to.eq(
+        2,
+        "should emit exactly twice for two addfeatures events",
+      );
     });
   });
 };

--- a/elements/drawtools/test/cases/drawupdate-event.js
+++ b/elements/drawtools/test/cases/drawupdate-event.js
@@ -1,0 +1,33 @@
+import { TEST_SELECTORS } from "../../src/enums";
+
+/**
+ * Test to ensure drawupdate event is fired exactly once per 'addfeatures' map event.
+ */
+const drawUpdateEventTest = () => {
+  cy.get(TEST_SELECTORS.drawTools).then(($el) => {
+    const drawtools = $el[0];
+    let count = 0;
+    drawtools.addEventListener("drawupdate", () => count++);
+    
+    cy.get("mock-map").then(($mapEl) => {
+      const map = $mapEl[0];
+      
+      map.dispatchEvent(new CustomEvent("addfeatures"));
+    });
+    
+    // Wait for the async setTimeout in emitDrawnFeaturesMethod
+    cy.wait(50).then(() => {
+      expect(count).to.eq(1, "should emit only once for one addfeatures event");
+      
+      cy.get("mock-map").then(($mapEl) => {
+        $mapEl[0].dispatchEvent(new CustomEvent("addfeatures"));
+      });
+    });
+    
+    cy.wait(50).then(() => {
+      expect(count).to.eq(2, "should emit exactly twice for two addfeatures events");
+    });
+  });
+};
+
+export default drawUpdateEventTest;

--- a/elements/drawtools/test/cases/index.js
+++ b/elements/drawtools/test/cases/index.js
@@ -9,3 +9,4 @@ export { default as setDifferentFormats } from "./set-different-formats"; // Tes
 export { default as featureListTest } from "./feature-list";
 export { default as measureTest } from "./measure";
 export { default as layerIdWithMeasure } from "./layer-id-with-measure";
+export { default as drawUpdateEventTest } from "./drawupdate-event";

--- a/elements/drawtools/test/general.cy.js
+++ b/elements/drawtools/test/general.cy.js
@@ -11,6 +11,7 @@ import {
   featureListTest,
   measureTest,
   layerIdWithMeasure,
+  drawUpdateEventTest,
 } from "./cases";
 
 import { TEST_SELECTORS } from "../src/enums";
@@ -56,4 +57,8 @@ describe("Drawtools", () => {
 
   // Test case to ensure layer-id works with measure
   it("ensures layer-id works with measure enabled", () => layerIdWithMeasure());
+
+  // Test case to ensure drawupdate event is fired exactly once
+  it("ensures drawupdate event is fired exactly once", () =>
+    drawUpdateEventTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR resolves an issue where `drawupdate` was firing twice after drawing or selecting a feature. 

**Root Cause:**
Lit's `updated()` lifecycle hook was inadvertently re-triggering the layer initialization routine when the component populated its default properties (such as `for`). This caused duplicate `addfeatures` listeners to attach to the map instance. 

**Changes:**
- Extracted the interaction bootstrap logic into a reusable `updateLayer()` method.
- Filtered the `updated()` lifecycle triggers so `updateLayer()` only runs when actual value changes occur (e.g. `for`, `type`, `measure`).
- Added a new component test case (`drawupdate-event.js`) to assert that the `drawupdate` payload remains strictly singular going forward emits precisely once per single action as expected. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
