### PR TITLE
fix: hide feedback panel when taking screenshot

### DIFF
--- a/elements/feedback/src/main.js
+++ b/elements/feedback/src/main.js
@@ -417,6 +417,7 @@ export class EOxFeedback extends HTMLElement {
           }
           z-index: 10000;
         }
+        :host(.hidden),
         .hidden {
           display: none !important;
         }

--- a/elements/feedback/src/main.js
+++ b/elements/feedback/src/main.js
@@ -224,10 +224,12 @@ export class EOxFeedback extends HTMLElement {
     const submitButton = this.shadowRoot.querySelector("button#submit");
     submitButton.classList.add("disabled");
 
+    this.classList.add("hidden");
     this.regionScreenshot = new RegionScreenshot();
 
     ["closed", "errorCreated", "screenshotDownload"].forEach((event) => {
       this.regionScreenshot.on(event, () => {
+        this.classList.remove("hidden");
         const checkbox = this.shadowRoot.querySelector("input[type=checkbox]");
         if (!(checkbox instanceof HTMLInputElement)) return;
         checkbox.checked = false;
@@ -248,6 +250,7 @@ export class EOxFeedback extends HTMLElement {
     });
 
     this.regionScreenshot.on("screenshotGenerated", (dataUrl) => {
+      this.classList.remove("hidden");
       const screenshot = document.createElement("img");
       screenshot.src = dataUrl;
       screenshot.classList.add("border");


### PR DESCRIPTION
## Implemented changes

Adds a hidden class to the whole element when taking screenshot and removes the class when done or is cancelled.

fixes https://github.com/EOX-A/EOxElements/issues/2241

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix - tried but failed
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
