### PR TITLE
fix: allow tooltip to appear outside the map container

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -69,6 +69,9 @@ export class EOxSelectInteraction {
             id: "eox-map-tooltip",
             ...options.overlay,
           });
+          /** @type {HTMLElement} */ (
+            /** @type {HTMLElement} */ (overlay.getElement()).parentNode
+          ).style.position = "fixed";
           this.eoxMap.map.addOverlay(overlay);
         }
       }


### PR DESCRIPTION
## Implemented changes
This PR allows the tooltip to appear outside the map container, it sets the tooltip ( ol/Overlay) element style position to "fixed")
<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos
<img width="1270" height="1126" alt="image (6)" src="https://github.com/user-attachments/assets/957b9ce3-029c-4ab9-97a2-362c85daad41" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
