### PR TITLE
feat: show utc in layercontrol datetime

### DIFF
--- a/elements/layercontrol/src/components/layer-datetime.js
+++ b/elements/layercontrol/src/components/layer-datetime.js
@@ -40,6 +40,7 @@ export class EOxLayerControlLayerDatetime extends LitElement {
      *
      * @type {{
      *   play?: boolean;
+     *   showUTC?: boolean;
      *   slider?: boolean;
      *   navigation?: boolean;
      *   currentStep: string|number;
@@ -137,7 +138,7 @@ export class EOxLayerControlLayerDatetime extends LitElement {
               },
             ]}
             @select=${this.#handleStepChange}
-            .showUTC=${true}
+            .showUTC=${this.layerDatetime.showUTC || false}
           >
             <eox-timecontrol-date
               .navigation=${this.layerDatetime.navigation ?? false}

--- a/elements/layercontrol/src/components/layer-datetime.js
+++ b/elements/layercontrol/src/components/layer-datetime.js
@@ -137,6 +137,7 @@ export class EOxLayerControlLayerDatetime extends LitElement {
               },
             ]}
             @select=${this.#handleStepChange}
+            .showUTC=${true}
           >
             <eox-timecontrol-date
               .navigation=${this.layerDatetime.navigation ?? false}

--- a/elements/layercontrol/src/enums/stories/index.js
+++ b/elements/layercontrol/src/enums/stories/index.js
@@ -610,6 +610,7 @@ export const STORIES_LAYER_VESSEL_DENSITY_CARGO = {
       slider: true,
       currentStep: "2021-03-01",
       displayFormat: "DD.MM.YYYY",
+      showUTC: true,
       controlValues: [
         "2022-12-01",
         "2022-11-01",


### PR DESCRIPTION
## Implemented changes
- Updated `layercontrol` datetime with the latest update of `timecontrol` to display UTC using `showUTC` attribute. Based of this PR - https://github.com/EOX-A/EOxElements/pull/2176

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
