### PR TITLE
fix: fetch the XYZ layer's url from _updatedUrl if existed

### DIFF
--- a/elements/map/src/plugins/globe/openglobus.js
+++ b/elements/map/src/plugins/globe/openglobus.js
@@ -146,9 +146,11 @@ export const createGlobusLayer = (olLayer, mapPool) => {
   }
 
   if (source instanceof XYZ_ol) {
+    // @ts-expect-error TODO
+    const url = source._updatedUrl || source.getUrls()[0];
     return new XYZ(id, {
       isBaseLayer: olLayer.get("base"),
-      url: source.getUrls()[0],
+      url: url,
       visibility: olLayer.getVisible(),
       opacity: olLayer.getOpacity(),
     });


### PR DESCRIPTION
## Implemented changes
This PR provides the ability for  XYZ layers  in openglobus layers to adapt the changes in the layers' source url, it allows  the layer to fetch url's if they are updated from the layerConfig (see #2215)

<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
