### PR TITLE
chore: TS - remove introduced pretypes, specify type gen order, remove type and style gen from type check step

### DIFF
--- a/.github/workflows/check_typing.yml
+++ b/.github/workflows/check_typing.yml
@@ -41,10 +41,8 @@ jobs:
       - name: Install dependencies 👨🏻‍💻
         run: npm ci --prefer-offline --no-audit
 
-      - name: Generate styles & types 🔧
-        run: |
-          npm run styles && \
-          npm run types:generate:all
+      - name: Generate styles 🔧
+        run: npm run styles
 
       - name: Run typing check 👀
         run: npm run typecheck

--- a/.github/workflows/check_typing.yml
+++ b/.github/workflows/check_typing.yml
@@ -41,8 +41,5 @@ jobs:
       - name: Install dependencies 👨🏻‍💻
         run: npm ci --prefer-offline --no-audit
 
-      - name: Generate styles 🔧
-        run: npm run styles
-
       - name: Run typing check 👀
         run: npm run typecheck

--- a/elements/drawtools/package.json
+++ b/elements/drawtools/package.json
@@ -32,8 +32,7 @@
     }
   },
   "scripts": {
-    "pretypes:generate": "cd ../map && npm run types:generate",
-    "types:generate": "npm run pretypes:generate && tsc --project tsconfig.build.json || true",
+    "types:generate": "tsc --project tsconfig.build.json || true",
     "prepack": "npm run types:generate",
     "build": "vite build",
     "watch": "vite build --watch"

--- a/elements/feedback/package.json
+++ b/elements/feedback/package.json
@@ -32,8 +32,7 @@
     }
   },
   "scripts": {
-    "pretypes:generate": "cd ../jsonform && npm run types:generate",
-    "types:generate": "npm run pretypes:generate && tsc --project tsconfig.build.json || true",
+    "types:generate": "tsc --project tsconfig.build.json || true",
     "prepack": "npm run types:generate",
     "build": "vite build",
     "watch": "vite build --watch"

--- a/elements/itemfilter/package.json
+++ b/elements/itemfilter/package.json
@@ -33,8 +33,7 @@
     }
   },
   "scripts": {
-    "pretypes:generate": "cd ../layout && npm run types:generate && cd ../map && npm run types:generate",
-    "types:generate": "npm run pretypes:generate && tsc --project tsconfig.build.json || true",
+    "types:generate": "tsc --project tsconfig.build.json || true",
     "prepack": "npm run types:generate",
     "build": "vite build",
     "watch": "vite build --watch"

--- a/elements/jsonform/package.json
+++ b/elements/jsonform/package.json
@@ -32,8 +32,7 @@
     }
   },
   "scripts": {
-    "pretypes:generate": "cd ../drawtools && npm run types:generate && cd ../map && npm run types:generate",
-    "types:generate": "npm run pretypes:generate && tsc --project tsconfig.build.json || true",
+    "types:generate": "tsc --project tsconfig.build.json || true",
     "prepack": "npm run types:generate",
     "build": "vite build",
     "watch": "vite build --watch"

--- a/elements/layercontrol/package.json
+++ b/elements/layercontrol/package.json
@@ -35,8 +35,7 @@
     }
   },
   "scripts": {
-    "pretypes:generate": "cd ../map && npm run types:generate && cd ../jsonform && npm run types:generate && cd ../timecontrol && npm run types:generate",
-    "types:generate": "npm run pretypes:generate && tsc --project tsconfig.build.json || true",
+    "types:generate": "tsc --project tsconfig.build.json || true",
     "prepack": "npm run types:generate",
     "build": "vite build",
     "watch": "vite build --watch"

--- a/elements/storytelling/package.json
+++ b/elements/storytelling/package.json
@@ -32,8 +32,7 @@
     }
   },
   "scripts": {
-    "pretypes:generate": "cd ../jsonform && npm run types:generate",
-    "types:generate": "npm run pretypes:generate && tsc --project tsconfig.build.json || true",
+    "types:generate": "tsc --project tsconfig.build.json || true",
     "prepack": "npm run types:generate",
     "build": "vite build",
     "watch": "vite build --watch"

--- a/elements/timecontrol/package.json
+++ b/elements/timecontrol/package.json
@@ -34,8 +34,7 @@
     }
   },
   "scripts": {
-    "pretypes:generate": "cd ../itemfilter && npm run types:generate && cd ../map && npm run types:generate",
-    "types:generate": "npm run pretypes:generate && tsc --project tsconfig.build.json || true",
+    "types:generate": "tsc --project tsconfig.build.json || true",
     "prepack": "npm run types:generate",
     "build": "vite build",
     "watch": "vite build --watch"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint elements",
     "lint:fix": "eslint elements --fix",
     "typecheck": "tsc",
-    "types:generate:all": "npm run types:generate --ws",
+    "types:generate:all": "npm run types:generate -w utils && npm run types:generate -w elements/map -w elements/layout -w elements/chart -w elements/geosearch -w elements/stacinfo -w elements/tour && npm run types:generate -w elements/drawtools && npm run types:generate -w elements/itemfilter && npm run types:generate -w elements/jsonform && npm run types:generate -w elements/storytelling -w elements/feedback && npm run types:generate -w elements/timecontrol && npm run types:generate -w elements/layercontrol",
     "storybook": "storybook dev -p 6006",
     "build:docs": "npm run styles && npm run build:element-story-bundle --ws --if-present && npm run generate-manifest && npm run generate-typedoc && npm run generate-snippets && npm run generate-llms && npm run build:storybook && cp custom-elements.json docs/custom-elements.json && cp story-snippets.json docs/story-snippets.json && cp llms.txt docs/llms.txt && cp llms-full.txt docs/llms-full.txt",
     "build:storybook": "storybook build -o docs",


### PR DESCRIPTION
## Implemented changes
Fix slow pipelines by removing recursive type generation. Standardize build order and slim down CI checks

 - Remove pretypes:generate: Elements no longer trigger dependency builds. Resolve redundant loops and pipeline slowness (~5m 24s-> 42s.) -> Users have to generate types individually with dependencies if run locally just for single element.
- Ordered Root Build: Update types:generate:all in root package.json. Run types:generate in strict dependency order. Each element build once.
- Remove npm run types:generate:all from check_typing.yml -> Root typecheck use paths to verify source directly. Pre-generation redundant.
- Remove npm run styles from check_typing.yml. CSS artifacts not needed for type analysis.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
