### PR TITLE
fix(style): vertical padding for list items and tools

### DIFF
--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -232,8 +232,8 @@ export class EOxLayerControlLayerList extends LitElement {
     .list li ul.list li ul.list > li eox-layercontrol-layer {
       padding-left: calc(var(--list-padding) * 2 - .5rem);
     }
-    .list li ul.list > li:has(details[open]) eox-layercontrol-tools-items {
-      display: block;
+    .list.no-space {
+      margin-block: var(--padding-inline) !important;
     }
     .list.no-space li.square {
       padding: 0;

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -324,6 +324,13 @@ export class EOxLayerControlLayerTools extends LitElement {
       padding: .5rem !important;
       display: block;
     }*/
+    :host {
+      display: block;
+      margin-block: var(--padding-vertical) !important;
+    }
+    details[open] eox-layercontrol-tools-items {
+      display: block;
+    }
   `;
 }
 


### PR DESCRIPTION
## Implemented changes

This PR adjusts the vertical margins/paddings to better fit to the rest of the UI, now also using the `--padding-vertical` CSS variable.

## Screenshots/Videos

### Before
<img width="258" height="345" alt="image" src="https://github.com/user-attachments/assets/f4a181a7-a303-400f-85a4-5ec20920f27d" />

### After
<img width="243" height="314" alt="image" src="https://github.com/user-attachments/assets/a5e3c410-34e1-4535-84a1-6d864da9e464" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
