### PR TITLE
fix(style): rotate layercontrol tools button

### DIFF
--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing } from "lit";
+import { LitElement, html } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { map } from "lit/directives/map.js";
 import { when } from "lit/directives/when.js";
@@ -33,6 +33,7 @@ export class EOxLayerControlLayerTools extends LitElement {
     unstyled: { type: Boolean },
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
+    open: { type: Boolean, reflect: true },
     embedded: { state: true },
     customEditorInterfaces: { attribute: false, type: Array },
   };
@@ -77,12 +78,29 @@ export class EOxLayerControlLayerTools extends LitElement {
     this.toolsAsList = false;
 
     /**
+     * If enabled, the tools section will be opened.
+     *
+     * @type {Boolean}
+     */
+    this.open = false;
+
+    /**
      * Determine if tools are embedded in layercontrol or stand-alone
      *
      * @type {Boolean}
      */
     setTimeout(() => {
       this.embedded = this.parentElement?.tagName === "EOX-LAYERCONTROL-LAYER";
+      if (
+        typeof this.open === "undefined" ||
+        this.open === false ||
+        this.open === null
+      ) {
+        this.open =
+          this.embedded === false
+            ? true
+            : this.layer?.get("layerControlToolsExpand");
+      }
     });
 
     /**
@@ -242,9 +260,12 @@ export class EOxLayerControlLayerTools extends LitElement {
             () => html`
               <details
                 class="tools"
-                open=${this.embedded === false
-                  ? true
-                  : this.layer.get("layerControlToolsExpand") || nothing}
+                .open=${live(this.open)}
+                @toggle=${(
+                  /** @type {{ target: { open: boolean; }; }} */ evt,
+                ) => {
+                  this.open = evt.target.open;
+                }}
               >
                 <summary></summary>
                 <eox-layercontrol-tools-items

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -296,15 +296,11 @@ export class EOxLayerControlLayer extends LitElement {
                     ? this.tools[0]
                     : "dots"}"
                   @click=${() => {
-                    const toolsDetails =
-                      this.renderRoot
-                        .querySelector("eox-layercontrol-layer-tools")
-                        ?.shadowRoot?.querySelector("details") ||
-                      this.renderRoot
-                        .querySelector("eox-layercontrol-layer-tools")
-                        ?.querySelector("details");
-                    // Toggle tools details open/close
-                    toolsDetails.open = !toolsDetails.open;
+                    /** @type {import("./layer-tools").EOxLayerControlLayerTools} */
+                    const layerTools = this.renderRoot.querySelector(
+                      "eox-layercontrol-layer-tools",
+                    );
+                    layerTools.open = !layerTools.open;
                   }}
                 >
                   <i class="small">
@@ -391,7 +387,7 @@ export class EOxLayerControlLayer extends LitElement {
     eox-layercontrol-layer .action.tools.dots {
       transition: rotate 0s;
     }
-    eox-layercontrol-layer:has(eox-layercontrol-layer-tools > details[open]) .action.tools.dots {
+    eox-layercontrol-layer:has(eox-layercontrol-layer-tools[open]) .action.tools.dots {
       transform: rotate(180deg);
     }
     eox-layercontrol-layer > nav > .action.visibility {


### PR DESCRIPTION
## Implemented changes

This PR fixes the layer tools dropdown/opening toggle button, which stopped rotating after previous refactoring (introduction of shadow DOM).

## Screenshots/Videos

### Before
<img width="255" height="159" alt="image" src="https://github.com/user-attachments/assets/850acfa8-70e0-4e4d-84cb-0578440fb113" />

### After
<img width="243" height="144" alt="image" src="https://github.com/user-attachments/assets/86c69f71-7210-457f-a3f5-7ecd7303fbed" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
