### PR TITLE
feat: auto-expand tools

### DIFF
--- a/elements/layercontrol/src/components/layer-group.js
+++ b/elements/layercontrol/src/components/layer-group.js
@@ -24,6 +24,10 @@ export class EOxLayerControlLayerGroup extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     globallyExclusiveLayers: { type: Boolean },
+    toolsAutoExpand: {
+      attribute: "tools-auto-expand",
+      type: Boolean,
+    },
     customEditorInterfaces: { attribute: false, type: Array },
   };
 
@@ -93,6 +97,13 @@ export class EOxLayerControlLayerGroup extends LitElement {
      * @type {Boolean}
      */
     this.toolsAsList = false;
+
+    /**
+     * If enabled, toggling the layer visibility will also open/close the layer tools.
+     *
+     * @type {Boolean}
+     */
+    this.toolsAutoExpand = false;
 
     /**
      * If enabled, exclusive layers (marked with the property `layerControlExclusive`) will be globally exclusive (default: exclusive within their layer group).
@@ -179,6 +190,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
                 .unstyled=${this.unstyled}
                 .toolsAsList=${this.toolsAsList}
                 .globallyExclusiveLayers=${this.globallyExclusiveLayers}
+                .toolsAutoExpand=${this.toolsAutoExpand}
                 .customEditorInterfaces=${this.customEditorInterfaces}
                 @changed=${() => this.requestUpdate()}
               ></eox-layercontrol-layer>
@@ -186,7 +198,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
 
             <!-- Render the list of layers within the details -->
             <eox-layercontrol-layer-list
-              .noShadow=${true}
+              .noShadow=${this.noShadow}
               .idProperty=${this.idProperty}
               .layers=${this.group.getLayers()}
               .map=${this.map}
@@ -196,6 +208,7 @@ export class EOxLayerControlLayerGroup extends LitElement {
               .unstyled=${this.unstyled}
               .toolsAsList=${this.toolsAsList}
               .globallyExclusiveLayers=${this.globallyExclusiveLayers}
+              .toolsAutoExpand=${this.toolsAutoExpand}
               .customEditorInterfaces=${this.customEditorInterfaces}
               @changed=${() => this.requestUpdate()}
             ></eox-layercontrol-layer-list>

--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -24,6 +24,10 @@ export class EOxLayerControlLayerList extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     globallyExclusiveLayers: { type: Boolean },
+    toolsAutoExpand: {
+      attribute: "tools-auto-expand",
+      type: Boolean,
+    },
     customEditorInterfaces: { attribute: false, type: Array },
   };
 
@@ -96,6 +100,13 @@ export class EOxLayerControlLayerList extends LitElement {
     this.toolsAsList = false;
 
     /**
+     * If enabled, toggling the layer visibility will also open/close the layer tools.
+     *
+     * @type {Boolean}
+     */
+    this.toolsAutoExpand = false;
+
+    /**
      * If enabled, exclusive layers (marked with the property `layerControlExclusive`) will be globally exclusive (default: exclusive within their layer group).
      *
      * @type {Boolean}
@@ -159,7 +170,7 @@ export class EOxLayerControlLayerList extends LitElement {
                     /** @type {import("ol/layer").Group} */ (layer).getLayers
                       ? html`
                           <eox-layercontrol-layer-group
-                            .noShadow=${true}
+                            .noShadow=${this.noShadow}
                             .group=${layer}
                             .idProperty=${this.idProperty}
                             .map=${this.map}
@@ -170,28 +181,28 @@ export class EOxLayerControlLayerList extends LitElement {
                             .toolsAsList=${this.toolsAsList}
                             .globallyExclusiveLayers=${this
                               .globallyExclusiveLayers}
+                            .toolsAutoExpand=${this.toolsAutoExpand}
                             .customEditorInterfaces=${this
                               .customEditorInterfaces}
-                            @changed=${() => this.requestUpdate()}
                           >
                           </eox-layercontrol-layer-group>
                         `
                       : html`
                           <eox-layercontrol-layer
-                            .noShadow=${true}
+                            .noShadow=${this.noShadow}
                             .layer=${layer}
+                            .layerType=${getLayerType(layer, this.map)}
                             .map=${this.map}
                             .titleProperty=${this.titleProperty}
                             .showLayerZoomState=${this.showLayerZoomState}
-                            .layerType=${getLayerType(layer, this.map)}
                             .tools=${this.tools}
                             .unstyled=${this.unstyled}
                             .toolsAsList=${this.toolsAsList}
                             .globallyExclusiveLayers=${this
                               .globallyExclusiveLayers}
+                            .toolsAutoExpand=${this.toolsAutoExpand}
                             .customEditorInterfaces=${this
                               .customEditorInterfaces}
-                            @changed=${() => this.requestUpdate()}
                           ></eox-layercontrol-layer>
                         `
                   }

--- a/elements/layercontrol/src/components/layer-list.js
+++ b/elements/layercontrol/src/components/layer-list.js
@@ -184,6 +184,7 @@ export class EOxLayerControlLayerList extends LitElement {
                             .toolsAutoExpand=${this.toolsAutoExpand}
                             .customEditorInterfaces=${this
                               .customEditorInterfaces}
+                            @changed=${() => this.requestUpdate()}
                           >
                           </eox-layercontrol-layer-group>
                         `
@@ -203,6 +204,7 @@ export class EOxLayerControlLayerList extends LitElement {
                             .toolsAutoExpand=${this.toolsAutoExpand}
                             .customEditorInterfaces=${this
                               .customEditorInterfaces}
+                            @changed=${() => this.requestUpdate()}
                           ></eox-layercontrol-layer>
                         `
                   }

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -34,6 +34,10 @@ export class EOxLayerControlLayerTools extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     open: { type: Boolean, reflect: true },
+    toolsAutoExpand: {
+      attribute: "tools-auto-expand",
+      type: Boolean,
+    },
     embedded: { state: true },
     customEditorInterfaces: { attribute: false, type: Array },
   };
@@ -85,23 +89,11 @@ export class EOxLayerControlLayerTools extends LitElement {
     this.open = false;
 
     /**
-     * Determine if tools are embedded in layercontrol or stand-alone
+     * If enabled, toggling the layer visibility will also open/close the layer tools.
      *
      * @type {Boolean}
      */
-    setTimeout(() => {
-      this.embedded = this.parentElement?.tagName === "EOX-LAYERCONTROL-LAYER";
-      if (
-        typeof this.open === "undefined" ||
-        this.open === false ||
-        this.open === null
-      ) {
-        this.open =
-          this.embedded === false
-            ? true
-            : this.layer?.get("layerControlToolsExpand");
-      }
-    });
+    this.toolsAutoExpand = false;
 
     /**
      * List of custom editor interfaces for layer config eox-jsonform
@@ -118,6 +110,35 @@ export class EOxLayerControlLayerTools extends LitElement {
    */
   createRenderRoot() {
     return this.noShadow ? this : super.createRenderRoot();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.embedded = this.parentElement?.tagName === "EOX-LAYERCONTROL-LAYER";
+  }
+
+  firstUpdated() {
+    if (
+      typeof this.open === "undefined" ||
+      this.open === false ||
+      this.open === null
+    ) {
+      this.open = this.toolsAutoExpand
+        ? !!this.layer?.getVisible()
+        : this.embedded === false
+          ? true
+          : !!this.layer?.get("layerControlToolsExpand");
+    }
+  }
+
+  updated(changedProperties) {
+    if (
+      this.toolsAutoExpand &&
+      (changedProperties.has("toolsAutoExpand") ||
+        changedProperties.has("layer"))
+    ) {
+      this.open = !!this.layer?.getVisible();
+    }
   }
 
   /**

--- a/elements/layercontrol/src/components/layer-tools.js
+++ b/elements/layercontrol/src/components/layer-tools.js
@@ -96,6 +96,29 @@ export class EOxLayerControlLayerTools extends LitElement {
     this.toolsAutoExpand = false;
 
     /**
+     * Determine if tools are embedded in layercontrol or stand-alone
+     *
+     * @type {Boolean}
+     */
+    setTimeout(() => {
+      const parent =
+        this.parentElement ||
+        /** @type {ShadowRoot} */ (this.getRootNode())?.host;
+      this.embedded = parent?.tagName === "EOX-LAYERCONTROL-LAYER";
+      if (
+        typeof this.open === "undefined" ||
+        this.open === false ||
+        this.open === null
+      ) {
+        this.open = this.toolsAutoExpand
+          ? !!this.layer?.getVisible()
+          : this.embedded === false
+            ? true
+            : !!this.layer?.get("layerControlToolsExpand");
+      }
+    });
+
+    /**
      * List of custom editor interfaces for layer config eox-jsonform
      * Read more about the implementation of custom editor interfaces here:
      * https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
@@ -110,25 +133,6 @@ export class EOxLayerControlLayerTools extends LitElement {
    */
   createRenderRoot() {
     return this.noShadow ? this : super.createRenderRoot();
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    this.embedded = this.parentElement?.tagName === "EOX-LAYERCONTROL-LAYER";
-  }
-
-  firstUpdated() {
-    if (
-      typeof this.open === "undefined" ||
-      this.open === false ||
-      this.open === null
-    ) {
-      this.open = this.toolsAutoExpand
-        ? !!this.layer?.getVisible()
-        : this.embedded === false
-          ? true
-          : !!this.layer?.get("layerControlToolsExpand");
-    }
   }
 
   updated(changedProperties) {

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -31,6 +31,10 @@ export class EOxLayerControlLayer extends LitElement {
     noShadow: { type: Boolean },
     toolsAsList: { type: Boolean },
     globallyExclusiveLayers: { type: Boolean },
+    toolsAutoExpand: {
+      attribute: "tools-auto-expand",
+      type: Boolean,
+    },
     customEditorInterfaces: { attribute: false, type: Array },
   };
 
@@ -108,6 +112,13 @@ export class EOxLayerControlLayer extends LitElement {
      * @type {Boolean}
      */
     this.toolsAsList = false;
+
+    /**
+     * If enabled, toggling the layer visibility will also open/close the layer tools.
+     *
+     * @type {Boolean}
+     */
+    this.toolsAutoExpand = false;
 
     /**
      * If enabled, exclusive layers (marked with the property `layerControlExclusive`) will be globally exclusive (default: exclusive within their layer group).
@@ -288,7 +299,7 @@ export class EOxLayerControlLayer extends LitElement {
             </div>
 
             ${when(
-              isToolsAvail,
+              isToolsAvail && !this.toolsAutoExpand,
               () => html`
                 <button
                   class="transparent square primary-text small action tools ${this
@@ -364,6 +375,7 @@ export class EOxLayerControlLayer extends LitElement {
             .tools=${this.tools}
             .unstyled=${this.unstyled}
             .toolsAsList=${this.toolsAsList}
+            .toolsAutoExpand=${this.toolsAutoExpand}
             .customEditorInterfaces=${this.customEditorInterfaces}
           ></eox-layercontrol-layer-tools>
         `,

--- a/elements/layercontrol/src/main.js
+++ b/elements/layercontrol/src/main.js
@@ -55,6 +55,10 @@ export class EOxLayerControl extends LitElement {
       attribute: "globally-exclusive-layers",
       type: Boolean,
     },
+    toolsAutoExpand: {
+      attribute: "tools-auto-expand",
+      type: Boolean,
+    },
     customEditorInterfaces: { attribute: false, type: Array },
   };
 
@@ -147,6 +151,13 @@ export class EOxLayerControl extends LitElement {
      * @type {Boolean}
      */
     this.globallyExclusiveLayers = false;
+
+    /**
+     * If enabled, toggling the layer visibility will also open/close the layer tools.
+     *
+     * @type {Boolean}
+     */
+    this.toolsAutoExpand = false;
 
     /**
      * List of custom editor interfaces for layer config eox-jsonforms
@@ -252,6 +263,7 @@ export class EOxLayerControl extends LitElement {
             .unstyled=${this.unstyled}
             .toolsAsList=${this.toolsAsList}
             .globallyExclusiveLayers=${this.globallyExclusiveLayers}
+            .toolsAutoExpand=${this.toolsAutoExpand}
             .customEditorInterfaces=${this.customEditorInterfaces}
             @changed=${this.#handleLayerControlLayerListChange}
             @datetime:updated=${(evt) => handleDatetimeUpdate(evt, this)}

--- a/elements/layercontrol/src/methods/layer/input-click.js
+++ b/elements/layercontrol/src/methods/layer/input-click.js
@@ -10,10 +10,22 @@ const inputClickMethod = (evt, EOxLayerControlLayer) => {
   // Set the visibility of the layer based on the input's checked state.
   layer.setVisible(evt.target.checked);
 
+  if (EOxLayerControlLayer.toolsAutoExpand) {
+    /**
+     * @type {import("../../components/layer-tools").EOxLayerControlLayerTools}
+     */
+    const layerTools = EOxLayerControlLayer.renderRoot.querySelector(
+      "eox-layercontrol-layer-tools",
+    );
+    if (layerTools) {
+      layerTools.open = evt.target.checked;
+    }
+  }
+
   // Check if the layer is checked and marked as 'layerControlExclusive'.
   if (evt.target.checked && layer.get("layerControlExclusive")) {
     /**
-     * @type NodeListOf<Element & {layer: any, requestUpdate: function}>
+     * @type NodeListOf<import("../../components/layer").EOxLayerControlLayer>
      */
     const siblings = EOxLayerControlLayer.closest(
       `${EOxLayerControlLayer.globallyExclusiveLayers ? ".layers" : "eox-layercontrol-layer-list"} > ul`,
@@ -26,6 +38,17 @@ const inputClickMethod = (evt, EOxLayerControlLayer) => {
         sibling.layer?.get("layerControlExclusive")
       ) {
         sibling.layer.setVisible(false);
+        if (sibling.toolsAutoExpand) {
+          /**
+           * @type {import("../../components/layer-tools").EOxLayerControlLayerTools}
+           */
+          const siblingLayerTools = sibling.renderRoot.querySelector(
+            "eox-layercontrol-layer-tools",
+          );
+          if (siblingLayerTools) {
+            siblingLayerTools.open = false;
+          }
+        }
         sibling.requestUpdate();
       }
     });

--- a/elements/layercontrol/stories/index.js
+++ b/elements/layercontrol/stories/index.js
@@ -15,4 +15,5 @@ export { default as addExternalLayerStory } from "./add-external-layer";
 export { default as layerZoomStateStory } from "./layer-zoom-state";
 export { default as unstyledStory } from "./unstyled";
 export { default as toolsAsListStory } from "./tools-as-list";
+export { default as toolsAutoExpandStory } from "./tools-auto-expand";
 export { default as layerColorStory } from "./layer-color";

--- a/elements/layercontrol/stories/layercontrol.stories.js
+++ b/elements/layercontrol/stories/layercontrol.stories.js
@@ -8,6 +8,7 @@ import {
   OptionalLayersStory,
   PrimaryStory,
   ToolsStory,
+  toolsAutoExpandStory,
   addExternalLayerStory,
   layerDatetimeStory,
   layerZoomStateStory,
@@ -98,6 +99,11 @@ export const LayerZoomState = layerZoomStateStory;
  * Shows tools rendered as a list instead of tabs. By enabling the `toolsAsList` property, the tools section is displayed as a vertical list, which can be useful for compact or mobile layouts.
  */
 export const ToolsAsList = toolsAsListStory;
+
+/**
+ * Demonstrates the `toolsAutoExpand` property. When enabled, toggling a layer's visibility automatically expands or collapses its tools section. Additionally, the manual tools toggle button is hidden, as the visibility checkbox takes over its role.
+ */
+export const ToolsAutoExpand = toolsAutoExpandStory;
 
 /**
  * Demonstrates color swatches for layers. Shows how to define and display custom colors for layers, useful for thematic mapping and visual differentiation of datasets.

--- a/elements/layercontrol/stories/tools-auto-expand.js
+++ b/elements/layercontrol/stories/tools-auto-expand.js
@@ -1,0 +1,43 @@
+import { html } from "lit";
+import {
+  STORIES_LAYER_DEFORESTED_BIOMASS,
+  STORIES_LAYER_REGION,
+  STORIES_LAYERCONTROL_STYLE,
+  STORIES_MAP_STYLE,
+  STORIES_LAYER_TERRAIN_LIGHT,
+} from "../src/enums";
+
+export const toolsAutoExpandStory = {
+  args: {
+    for: "eox-map#tools-auto-expand",
+    tools: ["info", "opacity"],
+    toolsAutoExpand: true,
+    storyAdditionalComponents: {
+      "eox-map": {
+        style: STORIES_MAP_STYLE,
+        layers: [
+          STORIES_LAYER_TERRAIN_LIGHT,
+          STORIES_LAYER_DEFORESTED_BIOMASS,
+          STORIES_LAYER_REGION,
+        ],
+        id: "tools-auto-expand",
+      },
+    },
+    style: STORIES_LAYERCONTROL_STYLE,
+  },
+  render: (args) => html`
+    <eox-layercontrol
+      .for=${args.for}
+      .tools=${args.tools}
+      .toolsAutoExpand=${args.toolsAutoExpand}
+      .style=${args.style}
+    ></eox-layercontrol>
+    <eox-map
+      id=${args.storyAdditionalComponents["eox-map"].id}
+      .style=${args.storyAdditionalComponents["eox-map"].style}
+      .layers=${args.storyAdditionalComponents["eox-map"].layers}
+    ></eox-map>
+  `,
+};
+
+export default toolsAutoExpandStory;

--- a/elements/layercontrol/test/cases/general/index.js
+++ b/elements/layercontrol/test/cases/general/index.js
@@ -10,3 +10,4 @@ export { default as renderOptionalLayer } from "./render-optional-layer";
 export { default as showCorrectLayerTitle } from "./show-layer-title";
 export { default as colorSwatch } from "./color-swatch";
 export { default as checkLayerDatetime } from "./check-layer-datetime";
+export { default as toolsAutoExpand } from "./tools-auto-expand";

--- a/elements/layercontrol/test/cases/general/tools-auto-expand.js
+++ b/elements/layercontrol/test/cases/general/tools-auto-expand.js
@@ -1,0 +1,77 @@
+const toolsAutoExpand = () => {
+  cy.get("mock-map").then(($el) => {
+    const mockMap = $el[0];
+    mockMap.setLayers([
+      {
+        properties: { id: "a", description: "foo" },
+        visible: true,
+      },
+      {
+        properties: { id: "b", description: "bar" },
+        visible: true,
+      },
+    ]);
+  });
+  cy.wait(200);
+
+  cy.get("eox-layercontrol")
+    .and(($el) => {
+      const layerControl = $el[0];
+      layerControl.toolsAutoExpand = true;
+      layerControl.tools = ["info"];
+    })
+    .shadow()
+    .within(() => {
+      // Layer A (visible): tools should be open
+      cy.get("li")
+        .first()
+        .within(() => {
+          cy.get("input[type=checkbox]").should("be.checked");
+          cy.get("button.tools").should("not.exist");
+          cy.get("eox-layercontrol-layer-tools").should(
+            "have.prop",
+            "open",
+            true,
+          );
+        });
+
+      // Layer B (visible): tools should be open
+      cy.get("li")
+        .last()
+        .within(() => {
+          cy.get("input[type=checkbox]").should("be.checked");
+          cy.get("button.tools").should("not.exist");
+          cy.get("eox-layercontrol-layer-tools").should(
+            "have.prop",
+            "open",
+            true,
+          );
+        });
+
+      // Toggle Layer A to invisible
+      cy.get("li").first().find("input[type=checkbox]").click({ force: true });
+      cy.get("li")
+        .first()
+        .within(() => {
+          cy.get("eox-layercontrol-layer-tools").should(
+            "have.prop",
+            "open",
+            false,
+          );
+        });
+
+      // Toggle Layer A back to visible
+      cy.get("li").first().find("input[type=checkbox]").click({ force: true });
+      cy.get("li")
+        .first()
+        .within(() => {
+          cy.get("eox-layercontrol-layer-tools").should(
+            "have.prop",
+            "open",
+            true,
+          );
+        });
+    });
+};
+
+export default toolsAutoExpand;

--- a/elements/layercontrol/test/cases/general/tools-auto-expand.js
+++ b/elements/layercontrol/test/cases/general/tools-auto-expand.js
@@ -12,7 +12,6 @@ const toolsAutoExpand = () => {
       },
     ]);
   });
-  cy.wait(200);
 
   cy.get("eox-layercontrol")
     .and(($el) => {

--- a/elements/layercontrol/test/cases/layer-update/check-layer-removed-from-root.js
+++ b/elements/layercontrol/test/cases/layer-update/check-layer-removed-from-root.js
@@ -17,11 +17,7 @@ const checkLayerRemovedFromRoot = () => {
       cy.get(`[data-layer=${layerToDelete}] eox-layercontrol-layer-tools`)
         .shadow()
         .within(() => {
-          cy.get(".tools > summary").click({
-            force: true,
-          });
-          // Click on the 'remove' icon to delete the layer
-          cy.get("button.remove-icon:visible").first().click();
+          cy.get("button.remove-icon").first().click({ force: true });
         });
 
       // Check if the layer UI element is removed from the layer control

--- a/elements/layercontrol/test/general.cy.js
+++ b/elements/layercontrol/test/general.cy.js
@@ -13,6 +13,7 @@ import {
   showCorrectLayerTitle,
   checkLayerLegend,
   colorSwatch,
+  toolsAutoExpand,
   // checkLayerDatetime,
 } from "./cases/general";
 
@@ -65,6 +66,9 @@ describe("LayerControl", () => {
   it("replaces icon with color swatch if color property is present on the layer", () => {
     colorSwatch();
   });
+
+  // Test to verify the toolsAutoExpand property
+  it("supports toolsAutoExpand", () => toolsAutoExpand());
   // TODO: Fix this test
   // it("emit 'datetime:updated' correctly when moving the slider", () => {
   //   checkLayerDatetime();


### PR DESCRIPTION
## Implemented changes

This PR introduces a new `toolsAutoExpand` property / `tools-auto-expand` attribute which, when enabled, automatically opens/closes the layer tools together with layer visibility. If enabled, the tools icon/dropdown are not shown.

## Screenshots/Videos

https://github.com/user-attachments/assets/09890ed6-d092-4d0c-8dee-f812286e30a3


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
