### PR TITLE
fix(style): date picker colors for transparent/dark mode

### DIFF
--- a/elements/timecontrol/src/components/timecontrol-picker.js
+++ b/elements/timecontrol/src/components/timecontrol-picker.js
@@ -310,9 +310,9 @@ export class EOxTimeControlPicker extends LitElement {
           dateMin: options.min,
           dateMax: options.max,
           displayDateMin: options.min,
-          disableToday: true,
+          disableToday: false,
           displayDateMax: options.max,
-          displayDatesOutside: false,
+          displayDatesOutside: true,
           type: "default",
           selectionDatesMode: this.range ? "multiple-ranged" : "single",
           ...(selectedDates

--- a/elements/timecontrol/src/helpers/inject-calendar-styles.js
+++ b/elements/timecontrol/src/helpers/inject-calendar-styles.js
@@ -24,10 +24,10 @@ export const calendarStyle = `
   :host {
     background-color: var(--surface-container-lowest);
   }
-  .vc:is(eox-timecontrol-picker .vc) {
+  .vc:not(body > .vc) {
     background-color: transparent !important;
   }
-  .vc:not(eox-timecontrol-picker .vc) {
+  .vc:is(body > .vc) {
     background-color: var(--surface-container-lowest);
     z-index: 9999;
   }

--- a/elements/timecontrol/src/helpers/inject-calendar-styles.js
+++ b/elements/timecontrol/src/helpers/inject-calendar-styles.js
@@ -93,14 +93,18 @@ export const calendarStyle = `
     color: var(--on-surface) !important;
   }
   button:hover {
-    background-color: var(--surface-container-low) !important;
-  }
-  .vc-date.vc-data-available .vc-date__btn {
-    background-color: var(--surface-container-low) !important;
+    background-color: color-mix(in srgb, var(--primary) 10%, transparent)!important
   }
   .vc-date[data-vc-date-selected] .vc-date__btn {
     background-color: var(--primary) !important;
     color: var(--on-primary) !important;
+  }
+  .vc-date[data-vc-date-month="prev"] button,
+  .vc-date[data-vc-date-month="next"] button {
+    opacity: 0.5 !important;
+  }
+  .vc-date[data-vc-date-today] button {
+    border: 1px solid var(--primary) !important;
   }
   .vc-arrow {
     padding: 0;
@@ -116,18 +120,13 @@ export const calendarStyle = `
   }
   .vc-arrow:hover:before {
     background: var(--primary) !important;
+    opacity: 1 !important;
   }
   .vc-dates__row {
     grid-gap: 2px;
   }
   .vc-date.vc-data-available:hover .vc-date__popup {
     opacity: 1 !important;
-  }
-  .vc-item-popup {
-    padding: 8px;
-    // max-width: 300px;
-    background-color: var(--surface-container-lowest);
-    border-radius: 0.75rem;
   }
   .v-date_popup {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);

--- a/elements/timecontrol/src/helpers/inject-calendar-styles.js
+++ b/elements/timecontrol/src/helpers/inject-calendar-styles.js
@@ -1,6 +1,12 @@
+import eoxColorsLight from "@eox/ui/style/colors/light.css?inline";
+import eoxColorsDark from "@eox/ui/style/colors/dark.css?inline";
+import eoxVariables from "@eox/ui/beercss/variables.css?inline";
 import vanillaCalendarCSS from "vanilla-calendar-pro/styles/index.css?inline";
 
 export const calendarStyle = `
+  ${eoxColorsLight}
+  ${eoxColorsDark}
+  ${eoxVariables}
   ${vanillaCalendarCSS}
   :root, :host, body {
     --dot-color-1: var(--primary);
@@ -15,7 +21,14 @@ export const calendarStyle = `
     --dot-color-10: #FF6B00;
     --dot-color-11: #E100FF;
   }
-  .vc {
+  :host {
+    background-color: var(--surface-container-lowest);
+  }
+  .vc:is(eox-timecontrol-picker .vc) {
+    background-color: transparent !important;
+  }
+  .vc:not(eox-timecontrol-picker .vc) {
+    background-color: var(--surface-container-lowest);
     z-index: 9999;
   }
   .vc * {
@@ -72,27 +85,40 @@ export const calendarStyle = `
   .vc-date[data-vc-date-selected] .vc-day__plus::before {
     background: var(--on-primary) !important;
   }
-  [data-vc-theme=light] .vc-date.vc-data-available .vc-date__btn {
-    --tw-bg-opacity: 1;
-    background-color: rgb(241 245 249 / var(--tw-bg-opacity));
+  .vc-week__day {
+    color: var(--primary) !important;
   }
-  [data-vc-theme=dark] .vc-date.vc-data-available .vc-date__btn {
-    --tw-bg-opacity: 1;
-    background-color: rgb(30 41 59 / var(--tw-bg-opacity));
+  button {
+    background-color: transparent !important;
+    color: var(--on-surface) !important;
   }
-  [data-vc-theme=light] .vc-date.vc-data-unavailable .vc-date__btn {
-    --tw-bg-opacity: 0;
-    background-color: rgb(241 245 249 / var(--tw-bg-opacity));
-    border: 3px solid rgb(241 245 249);
+  button:hover {
+    background-color: var(--surface-container-low) !important;
   }
-  [data-vc-theme=dark] .vc-date.vc-data-unavailable .vc-date__btn {
-    --tw-bg-opacity: 0;
-    background-color: rgb(30 41 59 / var(--tw-bg-opacity));
-    border: 3px solid rgb(30 41 59);
+  .vc-date.vc-data-available .vc-date__btn {
+    background-color: var(--surface-container-low) !important;
   }
   .vc-date[data-vc-date-selected] .vc-date__btn {
     background-color: var(--primary) !important;
-    border: none !important;
+    color: var(--on-primary) !important;
+  }
+  .vc-arrow {
+    padding: 0;
+    border-radius: 50%;
+  }
+  .vc-arrow:before {
+    display: block;
+    position: relative;
+    background: var(--on-surface) !important;
+    -webkit-mask-image: url("data:image/svg+xml;charset=UTF-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><title>chevron-down</title><path d='M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z' /></svg>") !important;
+    mask-image: url("data:image/svg+xml;charset=UTF-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><title>chevron-down</title><path d='M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z' /></svg>") !important;
+    mask-repeat: no-repeat;
+  }
+  .vc-arrow:hover:before {
+    background: var(--primary) !important;
+  }
+  .vc-dates__row {
+    grid-gap: 2px;
   }
   .vc-date.vc-data-available:hover .vc-date__popup {
     opacity: 1 !important;
@@ -100,20 +126,18 @@ export const calendarStyle = `
   .vc-item-popup {
     padding: 8px;
     // max-width: 300px;
-    background-color: #fff;
-    border-radius: 4px;
+    background-color: var(--surface-container-lowest);
+    border-radius: 0.75rem;
   }
   .v-date_popup {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  }
-  [data-vc-theme=dark] .vc-item-popup {
-    background-color: #1e293b;
-    color: #fff;
   }
   .vc-date__popup {
     max-width: 300px !important;
     left: 0px !important;
     padding: 0.5rem !important;
+    background-color: var(--surface-container-lowest) !important;
+    color: var(--on-surface) !important;
   }
   .vc-item-popup__item {
     margin-bottom: 12px;
@@ -130,7 +154,7 @@ export const calendarStyle = `
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background-color: var(--primary-color, var(--primary, #007bff));
+    background-color: var(--primary-color, var(--primary, #004170));
     margin-right: 8px;
     margin-top: 4px;
     flex-shrink: 0;
@@ -146,19 +170,13 @@ export const calendarStyle = `
   }
   .vc-item-popup__meta {
     margin-top: 2px;
-    color: #333;
+    color: var(--on-surface);
     font-size: 0.9em;
-  }
-  [data-vc-theme=dark] .vc-item-popup__meta {
-    color: #cbd5e1;
   }
   .vc-item-popup__more {
     margin-top: 4px;
     color: #999;
     font-size: 0.9em;
-  }
-  [data-vc-theme=dark] .vc-item-popup__more {
-    color: #94a3b8;
   }
 `;
 

--- a/elements/timecontrol/src/helpers/inject-calendar-styles.js
+++ b/elements/timecontrol/src/helpers/inject-calendar-styles.js
@@ -100,7 +100,9 @@ export const calendarStyle = `
     color: var(--on-primary) !important;
   }
   .vc-date[data-vc-date-month="prev"] button,
-  .vc-date[data-vc-date-month="next"] button {
+  .vc-date[data-vc-date-month="next"] button,
+  .vc-date[data-vc-date-month="prev"] .vc-day__dots,
+  .vc-date[data-vc-date-month="next"] .vc-day__dots {
     opacity: 0.5 !important;
   }
   .vc-date[data-vc-date-today] button {

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -396,7 +396,7 @@ export class EOxTimeControl extends LitElement {
         ${style}
         ${!this.unstyled && styleEOX}
       </style>
-      <main>
+      <main class="no-padding">
         <slot></slot>
       </main>
     `;


### PR DESCRIPTION
## Implemented changes

This PR fixes support for transparency and dark mode.
- removed hardcoded colors
- adjusted hover/background/text colors to match the rest of EOxElements

## Screenshots/Videos

https://github.com/user-attachments/assets/4f4a09ae-a521-4667-aeca-a9b66947da8b

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
