### PR TITLE
fix: zoomExtent and sync race condition

### DIFF
--- a/elements/map/src/methods/map/setters.js
+++ b/elements/map/src/methods/map/setters.js
@@ -64,13 +64,17 @@ export function setZoomExtentMethod(extent, EOxMap) {
   // If the extent is not provided or is empty, exit the function
   if (!extent || !extent.length) return undefined;
 
-  const view = EOxMap.map.getView();
-
-  // Cancel any ongoing animations on the map view to ensure a smooth transition
-  cancelAnimation(view);
+  // @ts-expect-error - _requestedZoomExtent is a custom property for internal state management
+  EOxMap._requestedZoomExtent = extent;
 
   // Fit the map view to the extent asynchronously
-  setTimeout(() => view.fit(extent, EOxMap.animationOptions), 0);
+  setTimeout(() => {
+    const view = EOxMap.map.getView();
+
+    // Cancel any ongoing animations on the map view to ensure a smooth transition
+    cancelAnimation(view);
+    view.fit(extent, EOxMap.animationOptions);
+  }, 0);
 
   // Return the extent that was fitted
   return extent;
@@ -435,6 +439,11 @@ export function setSyncMethod(sync, EOxMap) {
           originMap.map.setView(EOxMap.map.getView());
         } else {
           EOxMap.map.setView(originMap.map.getView());
+        }
+        // @ts-expect-error - _requestedZoomExtent is a custom property for internal state management
+        if (EOxMap._requestedZoomExtent) {
+          // @ts-expect-error - _requestedZoomExtent is a custom property for internal state management
+          setZoomExtentMethod(EOxMap._requestedZoomExtent, EOxMap);
         }
       }
     });


### PR DESCRIPTION
## Implemented changes

Fixed a race condition where `zoomExtent` failed on synced maps due to the View object being replaced during synchronization. The requested extent is now stored internally and re-applied after sync to ensure the correct area is fitted on the active view.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
