### PR TITLE
fix(style): layer type visibility css var

### DIFF
--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -218,8 +218,12 @@ export class EOxLayerControlLayer extends LitElement {
     return html`
       <style>
         ${this.#styleBasic}
-          ${!this.unstyled && this.#styleEOX}
-          .small.grey-text {
+        ${!this.unstyled &&
+        this
+          .#styleEOX}
+        
+        /* Make sure the CSS variable is applied to the layer type icon */
+        .small.grey-text {
           display: var(--layer-type-visibility);
         }
       </style>

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -219,6 +219,9 @@ export class EOxLayerControlLayer extends LitElement {
       <style>
         ${this.#styleBasic}
         ${!this.unstyled && this.#styleEOX}
+        .small.grey-text {
+          display: var(--layer-type-visibility);
+        }
       </style>
       ${when(
         this.layer,

--- a/elements/layercontrol/src/components/layer.js
+++ b/elements/layercontrol/src/components/layer.js
@@ -218,8 +218,8 @@ export class EOxLayerControlLayer extends LitElement {
     return html`
       <style>
         ${this.#styleBasic}
-        ${!this.unstyled && this.#styleEOX}
-        .small.grey-text {
+          ${!this.unstyled && this.#styleEOX}
+          .small.grey-text {
           display: var(--layer-type-visibility);
         }
       </style>


### PR DESCRIPTION
## Implemented changes

This PR fixes the `--layer-type-visibility` CSS variable, since its functionality was broken after previous refactoring.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
