### PR TITLE
fix: increase version of color-legend-element to 1.4.0

### DIFF
--- a/elements/layercontrol/package.json
+++ b/elements/layercontrol/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@eox/elements-utils": "^1.1.0",
     "@eox/ui": "^1.1.0",
-    "color-legend-element": "^1.3.0",
+    "color-legend-element": "^1.4.0",
     "lit": "^3.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,7 +180,7 @@
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
         "@eox/ui": "^1.1.0",
-        "color-legend-element": "^1.3.0",
+        "color-legend-element": "^1.4.0",
         "lit": "^3.2.0",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
@@ -7856,9 +7856,9 @@
       }
     },
     "node_modules/color-legend-element": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/color-legend-element/-/color-legend-element-1.3.0.tgz",
-      "integrity": "sha512-EkQxQGF0yWp1yd65fw7G26vfzcxbSjTtP9swv/WSKTaYAI08WpzjpJ4BnWO5r6QM8yNxpR0zqlB/f6yr2RL6zA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/color-legend-element/-/color-legend-element-1.4.0.tgz",
+      "integrity": "sha512-OXZABJL746XjAikQPQiVUyz93GzXhyZ01rtfDIE7JrF2h5C6Pc2fk4OA/Lgrp8yLDYogmNbyh4TZnk/BCAYt1A==",
       "license": "MIT",
       "dependencies": {
         "lit": "^2.8.0 || ^3.1.0"


### PR DESCRIPTION
## Implemented changes
- increases version to color-legend-element - adding functionality to configure log10 scale
- 1.5.0 would require node 22 and brings no extra changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
