### PR TITLE
fix(style): date picker sizing

### DIFF
--- a/elements/timecontrol/src/helpers/inject-calendar-styles.js
+++ b/elements/timecontrol/src/helpers/inject-calendar-styles.js
@@ -26,6 +26,12 @@ export const calendarStyle = `
   }
   .vc:not(body > .vc) {
     background-color: transparent !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    border: none !important;
+  }
+  .vc, .vc * {
+    box-sizing: border-box !important;
   }
   .vc:is(body > .vc) {
     background-color: var(--surface-container-lowest);

--- a/elements/timecontrol/src/styles/style.js
+++ b/elements/timecontrol/src/styles/style.js
@@ -1,5 +1,9 @@
 export const style = `
 :host {
   display: block;
+  box-sizing: border-box;
+}
+.timecontrol-calendar-input {
+  width: 100%;
 }
 `;


### PR DESCRIPTION
## Implemented changes

This PR makes style improvements to the date picker component in order to make it more usable for containers of different widths.
- enforcing `box-sizing: border-box` 
- setting width to 100% for better layout consistency

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
