### PR TITLE
fix: use animationOptions config for fitting drawn features

### DIFF
--- a/elements/map/src/helpers/add-new-feature.js
+++ b/elements/map/src/helpers/add-new-feature.js
@@ -68,9 +68,12 @@ export default function addNewFeature(
   if (!isDraw && features.length) {
     vectorLayer.getSource().addFeatures(features);
 
-    EOxMap.map.getView().fit(vectorLayer.getSource().getExtent(), {
-      duration: animate ? 750 : 0,
-    });
+    EOxMap.map.getView().fit(
+      vectorLayer.getSource().getExtent(),
+      EOxMap.animationOptions || {
+        duration: animate ? 750 : 0,
+      },
+    );
   }
 
   // Convert features to GeoJSON and dispatch custom events for drawing end or feature addition.


### PR DESCRIPTION
## Implemented changes

This PR adds a check if `animationOptions` are currently set on the `eox-map`, and use those for the feature selection animation. If none are set, falling back to previous behaviour.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
