### PR TITLE
fix: prevent keydown listener accumulation

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -9,6 +9,7 @@ import {
   emitDrawnFeaturesMethod,
   createSelectHandler,
   handleLayerId,
+  onKeyDownMethod,
 } from "./methods/draw";
 import { DUMMY_GEO_JSON } from "./enums/index.js";
 import {
@@ -99,6 +100,11 @@ export class EOxDrawTools extends LitElement {
    * @type Array<import("ol").Feature>
    */
   #drawnFeatures = [];
+
+  /**
+   * @type {(e: KeyboardEvent) => void}
+   */
+  #onKeyDownListener = (e) => onKeyDownMethod(e, this);
 
   constructor() {
     super();
@@ -450,6 +456,7 @@ export class EOxDrawTools extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    document.addEventListener("keydown", this.#onKeyDownListener);
     if (this.drawLayer && this.eoxMap) {
       const { reset } = initLayerMethod(this, this.multipleFeatures);
       this.resetLayer = reset;
@@ -458,6 +465,7 @@ export class EOxDrawTools extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    document.removeEventListener("keydown", this.#onKeyDownListener);
     this.resetLayer?.(this);
   }
   // Render method for UI display

--- a/elements/drawtools/src/methods/draw/index.js
+++ b/elements/drawtools/src/methods/draw/index.js
@@ -9,3 +9,4 @@ export { default as createSelectHandler } from "./create-select-handler"; // Fac
 export { default as initSelection } from "./init-selection"; // Initializes selection interactions
 export { default as handleLayerId } from "./handle-layer-id"; // handle switching between selection and drawing
 export { default as initMeasuring, updateMeasure } from "./init-measuring"; // Initializes measuring logic
+export { default as onKeyDownMethod } from "./on-key-down.js"; // Handles keydown events

--- a/elements/drawtools/src/methods/draw/on-key-down.js
+++ b/elements/drawtools/src/methods/draw/on-key-down.js
@@ -1,0 +1,16 @@
+/**
+ * Handles keydown events for the drawing tool.
+ * Specifically, it aborts the drawing process when the Escape key is pressed.
+ *
+ * @param {KeyboardEvent} event - The keyboard event.
+ * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
+ */
+const onKeyDownMethod = (event, EoxDrawTool) => {
+  if (event.key === "Escape" && EoxDrawTool.currentlyDrawing) {
+    EoxDrawTool.draw?.setActive(false);
+    EoxDrawTool.currentlyDrawing = false;
+    EoxDrawTool.requestUpdate();
+  }
+};
+
+export default onKeyDownMethod;

--- a/elements/drawtools/src/methods/draw/start-drawing.js
+++ b/elements/drawtools/src/methods/draw/start-drawing.js
@@ -23,15 +23,6 @@ const startDrawingMethod = (EoxDrawTool) => {
   initializeDrawing();
   // Update the drawing status
   updateDrawingStatus();
-
-  // Abort drawing on Esc key
-  document.addEventListener("keydown", ({ key }) => {
-    if (key === "Escape" && EoxDrawTool.currentlyDrawing) {
-      EoxDrawTool.draw?.setActive(false);
-      EoxDrawTool.currentlyDrawing = false;
-      EoxDrawTool.requestUpdate();
-    }
-  });
 };
 
 export default startDrawingMethod;

--- a/elements/drawtools/test/cases/abort-drawing-with-escape.js
+++ b/elements/drawtools/test/cases/abort-drawing-with-escape.js
@@ -1,0 +1,20 @@
+import { TEST_SELECTORS } from "../../src/enums";
+const { drawTools } = TEST_SELECTORS;
+
+/**
+ * Tests if drawing is aborted when the Escape key is pressed.
+ */
+const abortDrawingWithEscapeTest = () => {
+  cy.get(drawTools).shadow().find('[data-cy="drawBtn"]').click();
+  cy.get(drawTools).should(([$el]) => {
+    expect($el.currentlyDrawing).to.be.true;
+  });
+
+  cy.document().trigger("keydown", { key: "Escape" });
+
+  cy.get(drawTools).should(([$el]) => {
+    expect($el.currentlyDrawing).to.be.false;
+  });
+};
+
+export default abortDrawingWithEscapeTest;

--- a/elements/drawtools/test/cases/index.js
+++ b/elements/drawtools/test/cases/index.js
@@ -10,3 +10,4 @@ export { default as featureListTest } from "./feature-list";
 export { default as measureTest } from "./measure";
 export { default as layerIdWithMeasure } from "./layer-id-with-measure";
 export { default as drawUpdateEventTest } from "./drawupdate-event";
+export { default as abortDrawingWithEscapeTest } from "./abort-drawing-with-escape";

--- a/elements/drawtools/test/general.cy.js
+++ b/elements/drawtools/test/general.cy.js
@@ -12,6 +12,7 @@ import {
   measureTest,
   layerIdWithMeasure,
   drawUpdateEventTest,
+  abortDrawingWithEscapeTest,
 } from "./cases";
 
 import { TEST_SELECTORS } from "../src/enums";
@@ -61,4 +62,7 @@ describe("Drawtools", () => {
   // Test case to ensure drawupdate event is fired exactly once
   it("ensures drawupdate event is fired exactly once", () =>
     drawUpdateEventTest());
+
+  // Test case to ensure drawing is aborted on Escape key
+  it("aborts drawing on Escape key", () => abortDrawingWithEscapeTest());
 });


### PR DESCRIPTION
## Implemented changes

Moves the `keydown` event listener for the Escape key from the `startDrawing` method to the component's lifecycle (`connectedCallback`/`disconnectedCallback`). This prevents multiple listeners from accumulating every time a drawing is initiated.                 

Changes:                                    
 - Extracted logic to `onKeyDownMethod`.              
 - Properly manages listener lifecycle.             
 - Added regression test for aborting drawing via Escape key.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
