### PR TITLE
chore(docs): cleanup public API and methods documentation

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -36,7 +36,15 @@ import {
  *
  * Usage examples and visual demos are available in Storybook stories, including scenarios for multi-feature drawing, feature modification, selection, import/export, continuous drawing, format and projection control, and style customization.
  *
+ * ## Methods
+ *
+ * - `startDrawing`: Triggers starting the drawing interaction on the map.
+ * - `discardDrawing`: Triggers discarding/stopping the drawing interaction and deleting the drawn shapes.
+ *
+ * Usage: `document.querySelector("eox-drawtools").startDrawing();`
+ *
  * @element eox-drawtools
+ * @fires {CustomEvent} drawupdate - Fires whenever features are added, modified or discarded
  */
 export class EOxDrawTools extends LitElement {
   // Define properties with defaults and types
@@ -252,6 +260,7 @@ export class EOxDrawTools extends LitElement {
   /**
    * Used internally to update the drawnFeatures state without overwriting the map layer source.
    * @param {Array<import("ol").Feature>} features
+   * @ignore
    */
   setDrawnFeaturesInternal(features) {
     this.#internalUpdate = true;
@@ -309,15 +318,14 @@ export class EOxDrawTools extends LitElement {
   }
 
   /**
-   * @onClick Event handler triggered to start drawing on the map.
+   * Triggers starting the drawing interaction on the map.
    */
   startDrawing() {
     startDrawingMethod(this);
   }
 
   /**
-   * @onClick Event handler triggered to discard/stop drawing
-   * on the map and delete the drawn shapes.
+   * Triggers discarding/stopping the drawing interaction and deleting the drawn shapes.
    */
   discardDrawing() {
     discardDrawingMethod(this);
@@ -327,6 +335,7 @@ export class EOxDrawTools extends LitElement {
    * @param {string} text - The string representation of the features to be parsed.
    * @param {boolean} replaceFeatures - A boolean flag indicating whether to replace the existing features.
    * @param {boolean} animate - A boolean flag indicating whether to animate the map on feature change.
+   * @ignore
    */
   handleFeatureChange(text, replaceFeatures = false, animate = true) {
     this.eoxMap.parseTextToFeature(
@@ -340,6 +349,7 @@ export class EOxDrawTools extends LitElement {
 
   /**
    * @param {DragEvent | InputEvent & { target: HTMLInputElement }} evt - The event object from the file input interaction.
+   * @ignore
    */
   handleFilesChange(evt) {
     handleFiles(evt, this);
@@ -347,6 +357,7 @@ export class EOxDrawTools extends LitElement {
 
   /**
    * @event onModifyEnd triggered when the modification of a shape is completed.
+   * @ignore
    */
   onModifyEnd() {
     this.emitDrawnFeatures();
@@ -354,6 +365,7 @@ export class EOxDrawTools extends LitElement {
 
   /**
    * Update #geoJSON with stringify feature.
+   * @ignore
    */
   updateGeoJSON() {
     this.#geoJSON = JSON.stringify(
@@ -365,6 +377,7 @@ export class EOxDrawTools extends LitElement {
 
   /**
    * Triggers different events when the drawing of a shape is completed.
+   * @ignore
    */
   emitDrawnFeatures() {
     /**
@@ -383,6 +396,7 @@ export class EOxDrawTools extends LitElement {
 
   /**
    * Overrides createRenderRoot to handle shadow DOM creation based on the noShadow property.
+   * @ignore
    */
   createRenderRoot() {
     return this.noShadow ? this : super.createRenderRoot();
@@ -391,6 +405,7 @@ export class EOxDrawTools extends LitElement {
   /**
    * initializes the EOxMap and OlMap instances
    * And stores them in the private properties #eoxMap and #olMap, respectively.
+   * @ignore
    */
   updateLayer() {
     if (this.resetLayer) {
@@ -409,6 +424,7 @@ export class EOxDrawTools extends LitElement {
    * initializes the EOxMap and OlMap instances
    * And stores them in the private properties #eoxMap and #olMap, respectively.
    * It then calls requestUpdate to trigger a re-render.
+   * @ignore
    */
   firstUpdated() {
     this.updateLayer();
@@ -424,6 +440,7 @@ export class EOxDrawTools extends LitElement {
     this.requestUpdate();
   }
 
+  /** @ignore */
   updated(changedProperties) {
     const hasOldValue = (prop) =>
       changedProperties.has(prop) && changedProperties.get(prop) !== undefined;
@@ -454,6 +471,7 @@ export class EOxDrawTools extends LitElement {
     this.requestUpdate("eoxMap", oldValue);
   }
 
+  /** @ignore */
   connectedCallback() {
     super.connectedCallback();
     document.addEventListener("keydown", this.#onKeyDownListener);
@@ -463,6 +481,7 @@ export class EOxDrawTools extends LitElement {
     }
   }
 
+  /** @ignore */
   disconnectedCallback() {
     super.disconnectedCallback();
     document.removeEventListener("keydown", this.#onKeyDownListener);


### PR DESCRIPTION
## Implemented changes
This PR cleans up the methods and events documentation.

Changes:
 - Added `## Methods` section to eox-drawtools JSDoc for `startDrawing` and `discardDrawing`.               
 - Applied `@ignore` to all internal and lifecycle methods to hide them from Storybook documentation. 
 - Added `@fires` tag for drawupdate event.           
 - Standardized JSDoc across the component to follow the logic extraction pattern. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
