### PR TITLE
fix(style): sizing of spatial filter radio buttons

### DIFF
--- a/elements/itemfilter/src/components/filters/spatial.js
+++ b/elements/itemfilter/src/components/filters/spatial.js
@@ -87,8 +87,10 @@ class EOxItemFilterSpatial extends LitElement {
     return when(
       this.filterObject,
       () => html`
-        <div style="margin-left: var(--list-padding)">
-          <nav class="vertical-margin small-margin wrap">
+        <div
+          style="margin-left: var(--list-padding); padding-right: var(--padding)"
+        >
+          <nav class="no-margin wrap">
             ${map(
               ["intersects", "within"],
               (mode) => html`
@@ -102,7 +104,7 @@ class EOxItemFilterSpatial extends LitElement {
                     value="${mode}"
                     @click=${() => this.#handleClick(mode)}
                   />
-                  <span>${mode} filter geometry</span>
+                  <span style="font-size: x-small">${mode} geometry</span>
                 </label>
               `,
             )}
@@ -116,7 +118,7 @@ class EOxItemFilterSpatial extends LitElement {
               this.filterObject.stringifiedState = "Polygon";
               this.dispatchEvent(new CustomEvent("filter"));
             }}"
-          ></eox-itemfilter-spatial>
+          ></eox-itemfilter-spatial-filter>
         </div>
       `,
     );


### PR DESCRIPTION
## Implemented changes

This improves the layout of the spatial filter by reducing the size of the radio buttons and labels.

Partially addresses https://github.com/EOX-A/EOxElements/issues/1327.

## Screenshots/Videos

### Before
<img width="354" height="386" alt="image" src="https://github.com/user-attachments/assets/cbf1f1a3-34c6-4960-bb8b-d38eb6a2e265" />

### After
<img width="351" height="376" alt="image" src="https://github.com/user-attachments/assets/a3fbd65a-a4ed-4247-951c-0129928af62e" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
