### PR TITLE
setting the tooltip offset

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -63,7 +63,7 @@ export class EOxSelectInteraction {
             // @ts-expect-error - Type 'Element' is missing the following properties from type 'HTMLElement'
             element: this.tooltipElement,
             position: undefined,
-            offset: [0, 0],
+            offset: [-5, -5],
             positioning: "top-left",
             className: "eox-map-tooltip",
             id: "eox-map-tooltip",


### PR DESCRIPTION
## Implemented changes

<!-- description of implemented changes -->
This PR introduce a calculated shift in the tooltip location, when mouse interact with a feature ( e.g click , pointer move) the tooltip is rendered in the mouse pointer location, this PR offsets the tooltip -5 px in x axis and -5 px in y axis. 

## Screenshots/Videos
Original behaviour:

<img width="151" height="126" alt="Screenshot from 2026-05-19 18-45-03" src="https://github.com/user-attachments/assets/a075ed1c-d7f5-4e43-96dd-4c7f66825d2c" />


Current behaviour:
<img width="151" height="126" alt="Screenshot from 2026-05-19 18-45-15" src="https://github.com/user-attachments/assets/6b777a1f-bf5a-418e-aaa2-5c1d1cc4d17b" />

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
