### PR TITLE
chore(deps): 7-day package quarantine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     versioning-strategy: increase-if-necessary
     groups:
@@ -31,3 +33,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 ignore-scripts=true
+min-release-age=10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ If any answer is "I don't know," stop. Ask a clarifying question. Do not guess.
 - **Security Hardening**: `ignore-scripts=true` is enabled in `.npmrc`. This means:
   - `postinstall` scripts (like Cypress binary download) are skipped. Run `npx cypress install` manually for local testing.
   - `prepack` scripts are skipped. When publishing or testing packaging, manually run `npm run types:generate`.
+- **Package Quarantine**: `min-release-age=7` (days) is set in `.npmrc` to prevent the use of brand-new, potentially unverified package versions.
 - **Component framework:** [Lit](https://lit.dev/) (v3.2+)
 - **Language:** JavaScript with JSDoc type annotations (NOT TypeScript source files)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ npm install
 npx cypress install
 ```
 
+Additionally, we enforce a **7-day quarantine for fresh packages** (`min-release-age=7` in `.npmrc`). Avoid updating to versions released less than 7 days ago unless there is an urgent security fix.
+
 ### 2. Monorepo Structure
 
 - Each package (element) is located in the `/elements` directory.


### PR DESCRIPTION
## Implemented changes

 This PR introduces a mandatory 7-day quarantine for new package versions. Enforced a 7-day delay for new package versions via min-release-age=7 in .npmrc and a mirroring cooldown in dependabot.yml.        

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
