### PR TITLE
feat: add stopDrawing method

### DIFF
--- a/elements/drawtools/src/main.js
+++ b/elements/drawtools/src/main.js
@@ -4,6 +4,7 @@ import "./components/controller";
 import { styleEOX } from "./style.eox";
 import {
   startDrawingMethod,
+  stopDrawingMethod,
   initLayerMethod,
   discardDrawingMethod,
   emitDrawnFeaturesMethod,
@@ -41,6 +42,7 @@ import {
  * ## Methods
  *
  * - `startDrawing`: Triggers starting the drawing interaction on the map.
+ * - `stopDrawing`: Triggers stopping the drawing interaction on the map (same as pressing the Escape key).
  * - `discardDrawing`: Triggers discarding/stopping the drawing interaction and deleting the drawn shapes.
  * - `removeFeature`: Removes a feature from the drawn features.
  * - `removeFeatureByIndex`: Removes a feature from the drawn features by its index.
@@ -326,6 +328,13 @@ export class EOxDrawTools extends LitElement {
    */
   startDrawing() {
     startDrawingMethod(this);
+  }
+
+  /**
+   * Triggers stopping the drawing interaction on the map (same as pressing the Escape key).
+   */
+  stopDrawing() {
+    stopDrawingMethod(this);
   }
 
   /**

--- a/elements/drawtools/src/methods/draw/index.js
+++ b/elements/drawtools/src/methods/draw/index.js
@@ -10,6 +10,7 @@ export { default as initSelection } from "./init-selection"; // Initializes sele
 export { default as handleLayerId } from "./handle-layer-id"; // handle switching between selection and drawing
 export { default as initMeasuring, updateMeasure } from "./init-measuring"; // Initializes measuring logic
 export { default as onKeyDownMethod } from "./on-key-down.js"; // Handles keydown events
+export { default as stopDrawingMethod } from "./stop-drawing.js"; // Stops the drawing process
 export {
   removeFeatureMethod,
   removeFeatureByIndexMethod,

--- a/elements/drawtools/src/methods/draw/on-key-down.js
+++ b/elements/drawtools/src/methods/draw/on-key-down.js
@@ -1,3 +1,5 @@
+import stopDrawingMethod from "./stop-drawing";
+
 /**
  * Handles keydown events for the drawing tool.
  * Specifically, it aborts the drawing process when the Escape key is pressed.
@@ -6,10 +8,8 @@
  * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
  */
 const onKeyDownMethod = (event, EoxDrawTool) => {
-  if (event.key === "Escape" && EoxDrawTool.currentlyDrawing) {
-    EoxDrawTool.draw?.setActive(false);
-    EoxDrawTool.currentlyDrawing = false;
-    EoxDrawTool.requestUpdate();
+  if (event.key === "Escape") {
+    stopDrawingMethod(EoxDrawTool);
   }
 };
 

--- a/elements/drawtools/src/methods/draw/stop-drawing.js
+++ b/elements/drawtools/src/methods/draw/stop-drawing.js
@@ -1,0 +1,15 @@
+/**
+ * Stops the drawing interaction on the map.
+ * This mimics the behavior of pressing the Escape key.
+ *
+ * @param {import("../../main").EOxDrawTools} EoxDrawTool - The drawing tool instance.
+ */
+const stopDrawingMethod = (EoxDrawTool) => {
+  if (EoxDrawTool.currentlyDrawing) {
+    EoxDrawTool.draw?.setActive(false);
+    EoxDrawTool.currentlyDrawing = false;
+    EoxDrawTool.requestUpdate();
+  }
+};
+
+export default stopDrawingMethod;

--- a/elements/drawtools/test/cases/index.js
+++ b/elements/drawtools/test/cases/index.js
@@ -11,4 +11,5 @@ export { default as measureTest } from "./measure";
 export { default as layerIdWithMeasure } from "./layer-id-with-measure";
 export { default as drawUpdateEventTest } from "./drawupdate-event";
 export { default as abortDrawingWithEscapeTest } from "./abort-drawing-with-escape";
+export { default as stopDrawingMethodTest } from "./stop-drawing-method";
 export { default as removeFeatureTest } from "./remove-feature";

--- a/elements/drawtools/test/cases/stop-drawing-method.js
+++ b/elements/drawtools/test/cases/stop-drawing-method.js
@@ -1,0 +1,22 @@
+import { TEST_SELECTORS } from "../../src/enums";
+const { drawTools } = TEST_SELECTORS;
+
+/**
+ * Tests if drawing is stopped when the stopDrawing method is called.
+ */
+const stopDrawingMethodTest = () => {
+  cy.get(drawTools).shadow().find('[data-cy="drawBtn"]').click();
+  cy.get(drawTools).should(([$el]) => {
+    expect($el.currentlyDrawing).to.be.true;
+  });
+
+  cy.get(drawTools).then(([$el]) => {
+    $el.stopDrawing();
+  });
+
+  cy.get(drawTools).should(([$el]) => {
+    expect($el.currentlyDrawing).to.be.false;
+  });
+};
+
+export default stopDrawingMethodTest;

--- a/elements/drawtools/test/general.cy.js
+++ b/elements/drawtools/test/general.cy.js
@@ -13,6 +13,7 @@ import {
   layerIdWithMeasure,
   drawUpdateEventTest,
   abortDrawingWithEscapeTest,
+  stopDrawingMethodTest,
   removeFeatureTest,
 } from "./cases";
 
@@ -66,6 +67,9 @@ describe("Drawtools", () => {
 
   // Test case to ensure drawing is aborted on Escape key
   it("aborts drawing on Escape key", () => abortDrawingWithEscapeTest());
+
+  // Test case to ensure drawing is stopped programmatically
+  it("stops drawing programmatically", () => stopDrawingMethodTest());
 
   // Test case to ensure features can be removed programmatically
   it("removes features programmatically", () => removeFeatureTest());


### PR DESCRIPTION
## Implemented changes

This PR introduces a public `stopDrawing()` method to the `eox-drawtools` element, allowing developers to programmatically abort the current drawing interaction. This mimics the behavior of pressing the **Escape** key.

### Changes:
- **Logic Extraction**: Created `stop-drawing.js` method in `src/methods/draw/` to follow the repository's logic delegation pattern.
- **Component API**: Exposed `stopDrawing()` on the `EOxDrawTools` class in `src/main.js`.
- **Refactoring**: Updated the `Escape` key listener in `src/methods/draw/on-key-down.js` to use the new shared logic.
- **Documentation**: Added JSDoc for the new method to ensure it appears in the "Methods" section of the Storybook documentation.
- **Testing**: Added a Cypress test case `test/cases/stop-drawing-method.js` to verify that calling the method correctly updates the `currentlyDrawing` state and deactivates the interaction.

### Usage:
```javascript
const drawTools = document.querySelector("eox-drawtools");
drawTools.stopDrawing();
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
