### PR TITLE
fix: populate all intermediate dates for range highlighting

### DIFF
--- a/elements/timecontrol/src/methods/picker/get-selected-dates.js
+++ b/elements/timecontrol/src/methods/picker/get-selected-dates.js
@@ -25,18 +25,28 @@ export default function getSelectedDatesMethod(
   range,
   showUTC,
 ) {
-  if (!selectedDateRange) return null;
+  if (!selectedDateRange || !selectedDateRange[0]) return null;
   const start = showUTC
     ? dayjs(selectedDateRange[0]).utc()
     : dayjs(selectedDateRange[0]);
-  const end = showUTC
-    ? dayjs(selectedDateRange[1]).utc()
-    : dayjs(selectedDateRange[1]);
-  const startDateFormatted = start.format(TIME_CONTROL_DATE_FORMAT);
-  const endDateFormatted = end.format(TIME_CONTROL_DATE_FORMAT);
-  const selectedDates = range
-    ? [startDateFormatted, endDateFormatted]
-    : [startDateFormatted];
+
+  const selectedDates = [];
+
+  // If a range is requested and the end date is provided, fill in all days
+  if (range && selectedDateRange[1]) {
+    const end = showUTC
+      ? dayjs(selectedDateRange[1]).utc()
+      : dayjs(selectedDateRange[1]);
+
+    let current = start;
+    while (!current.isAfter(end, "day")) {
+      selectedDates.push(current.format(TIME_CONTROL_DATE_FORMAT));
+      current = current.add(1, "day");
+    }
+  } else {
+    // Fallback if it's a single date selection or the user hasn't clicked the second date yet
+    selectedDates.push(start.format(TIME_CONTROL_DATE_FORMAT));
+  }
 
   return {
     dates: selectedDates,


### PR DESCRIPTION
## Implemented changes

### Summary

Updates `getSelectedDatesMethod` to generate and return every sequential date within a selected range, rather than just the start and end boundary dates.

### Why

Vanilla Calendar Pro requires an array containing all individual dates within a range to render the selection highlighting correctly. Passing only the start and end dates (e.g. as `initDate property`) caused the days in between to remain unhighlighted.

### Changes

* Added a `while` loop using Day.js to populate all dates between `start` and `end` (inclusive).
* Introduced a guard check to safely handle single-date selections or mid-selection states (where `range` is active but `endDate` is not yet picked).

## Screenshots/Videos

### Before

<img width="270" height="299" alt="image" src="https://github.com/user-attachments/assets/98728cb4-22a6-4b27-a6f9-e155d56c6647" />


### After

<img width="267" height="293" alt="image" src="https://github.com/user-attachments/assets/d8c8d386-06df-4084-9d2f-6a3a7696d047" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
