### PR TITLE
feat: picker UI for date range filter

### DIFF
--- a/elements/itemfilter/package.json
+++ b/elements/itemfilter/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@eox/elements-utils": "^1.1.0",
-    "@eox/timecontrol": "2.4.0",
     "@eox/ui": "^1.1.0",
     "@floating-ui/dom": "^1.6.8",
     "@turf/boolean-intersects": "^7.3.5",
@@ -55,6 +54,7 @@
   },
   "peerDependencies": {
     "@eox/layout": "*",
-    "@eox/map": ">=2.0.0 || >=2.1.0-dev.1"
+    "@eox/map": ">=2.0.0 || >=2.1.0-dev.1",
+    "@eox/timecontrol": ">=2.0.0"
   }
 }

--- a/elements/itemfilter/package.json
+++ b/elements/itemfilter/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@eox/elements-utils": "^1.1.0",
+    "@eox/timecontrol": "2.4.0",
     "@eox/ui": "^1.1.0",
     "@floating-ui/dom": "^1.6.8",
     "@turf/boolean-intersects": "^7.3.5",

--- a/elements/itemfilter/src/components/filters/range.js
+++ b/elements/itemfilter/src/components/filters/range.js
@@ -122,20 +122,16 @@ export class EOxItemFilterRange extends LitElement {
                 },
               ]}
               .initDate=${[
-                dayjs.unix(
-                  this.filterObject.state.min || this.filterObject.min,
-                ),
-                dayjs.unix(
-                  this.filterObject.state.max || this.filterObject.max,
-                ),
+                dayjs(this.filterObject.state.min || this.filterObject.min),
+                dayjs(this.filterObject.state.max || this.filterObject.max),
               ]}
               @select=${(e) =>
                 rangeInputHandlerMethod(
                   new CustomEvent("values", {
                     detail: {
                       values: [
-                        dayjs(e.detail.date[0]).unix(),
-                        dayjs(e.detail.date[1]).unix(),
+                        dayjs(e.detail.date[0]).valueOf(),
+                        dayjs(e.detail.date[1]).valueOf(),
                       ],
                     },
                   }),

--- a/elements/itemfilter/src/components/filters/range.js
+++ b/elements/itemfilter/src/components/filters/range.js
@@ -3,7 +3,6 @@ import { when } from "lit/directives/when.js";
 import _debounce from "lodash.debounce";
 import "toolcool-range-slider";
 import dayjs from "dayjs";
-import "@eox/timecontrol";
 import { DATE_TIME_FORMAT } from "../../enums/index.js";
 import {
   rangeInputHandlerMethod,

--- a/elements/itemfilter/src/components/filters/range.js
+++ b/elements/itemfilter/src/components/filters/range.js
@@ -108,11 +108,19 @@ export class EOxItemFilterRange extends LitElement {
           isDate(this.filterObject),
           () => html`
             <eox-timecontrol
-              .controlValues=${(
-                this.filterObject.filterKeys ||
-                this.suggestions ||
-                []
-              ).map((item) => ({ timeControlValues: [item] }))}
+              .controlValues=${[
+                {
+                  id: this.filterObject.key,
+                  title: this.filterObject.title || "Filter",
+                  timeControlValues: (
+                    this.filterObject.filterKeys ||
+                    this.suggestions ||
+                    []
+                  ).map((item) =>
+                    typeof item === "object" ? item : { date: item },
+                  ),
+                },
+              ]}
               .initDate=${[
                 dayjs.unix(
                   this.filterObject.state.min || this.filterObject.min,
@@ -140,6 +148,7 @@ export class EOxItemFilterRange extends LitElement {
               <eox-timecontrol-picker
                 popup
                 range
+                show-dots
                 .position=${["bottom", "left"]}
               ></eox-timecontrol-picker>
             </eox-timecontrol>

--- a/elements/itemfilter/src/components/filters/range.js
+++ b/elements/itemfilter/src/components/filters/range.js
@@ -2,11 +2,15 @@ import { LitElement, html } from "lit";
 import { when } from "lit/directives/when.js";
 import _debounce from "lodash.debounce";
 import "toolcool-range-slider";
+import dayjs from "dayjs";
+import "@eox/timecontrol";
+import { DATE_TIME_FORMAT } from "../../enums/index.js";
 import {
   rangeInputHandlerMethod,
   rangeLabelMethod,
   resetRangeMethod,
 } from "../../methods/filters/index.js";
+import { isDate } from "../../helpers/index.js";
 
 /**
  * EOxItemFilterRange is a custom web component that provides a range slider for filtering items.
@@ -16,12 +20,14 @@ import {
  * @module EOxItemFilterRange
  * @extends LitElement
  * @property {Object} filterObject - The filter object containing state and range limits.
+ * @property {Array} suggestions - The list of suggestions for the selector.
  * @property {Number} tabIndex - The tab index for the input elements.
  */
 export class EOxItemFilterRange extends LitElement {
   // Define properties with defaults and types
   static properties = {
     filterObject: { attribute: false, type: Object },
+    suggestions: { attribute: false, type: Array },
     tabIndex: { attribute: false, type: Number },
   };
 
@@ -32,6 +38,11 @@ export class EOxItemFilterRange extends LitElement {
      * @type Object
      */
     this.filterObject = {};
+
+    /**
+     * @type Array
+     */
+    this.suggestions = [];
 
     /**
      * @type Boolean
@@ -94,20 +105,61 @@ export class EOxItemFilterRange extends LitElement {
     return when(
       this.filterObject,
       () => html`
-        <div
-          style="margin-left: var(--list-padding); display: flex; gap: .5rem; align-items: center;"
-        >
-          ${this.#label("min", "before")}
-          <tc-range-slider
-            min="${this.filterObject.min}"
-            max="${this.filterObject.max}"
-            value1="${this.filterObject.state.min || this.filterObject.min}"
-            value2="${this.filterObject.state.max || this.filterObject.max}"
-            step="${this.filterObject.step || 1}"
-            @change=${this.debouncedInputHandler}
-          ></tc-range-slider>
-          ${this.#label("max", "after")}
-        </div>
+        ${when(
+          isDate(this.filterObject),
+          () => html`
+            <eox-timecontrol
+              .controlValues=${(
+                this.filterObject.filterKeys ||
+                this.suggestions ||
+                []
+              ).map((item) => ({ timeControlValues: [item] }))}
+              .initDate=${[
+                dayjs.unix(
+                  this.filterObject.state.min || this.filterObject.min,
+                ),
+                dayjs.unix(
+                  this.filterObject.state.max || this.filterObject.max,
+                ),
+              ]}
+              @select=${(e) =>
+                rangeInputHandlerMethod(
+                  new CustomEvent("values", {
+                    detail: {
+                      values: [
+                        dayjs(e.detail.date[0]).unix(),
+                        dayjs(e.detail.date[1]).unix(),
+                      ],
+                    },
+                  }),
+                  this,
+                )}
+            >
+              <eox-timecontrol-date
+                .format=${DATE_TIME_FORMAT}
+              ></eox-timecontrol-date>
+              <eox-timecontrol-picker
+                popup
+                range
+                .position=${["bottom", "left"]}
+              ></eox-timecontrol-picker>
+            </eox-timecontrol>
+          `,
+          () => html`
+            <div style="display: flex; gap: .5rem; align-items: center;">
+              ${this.#label("min", "before")}
+              <tc-range-slider
+                min="${this.filterObject.min}"
+                max="${this.filterObject.max}"
+                value1="${this.filterObject.state.min || this.filterObject.min}"
+                value2="${this.filterObject.state.max || this.filterObject.max}"
+                step="${this.filterObject.step || 1}"
+                @change=${this.debouncedInputHandler}
+              ></tc-range-slider>
+              ${this.#label("max", "after")}
+            </div>
+          `,
+        )}
       `,
     );
   }

--- a/elements/itemfilter/src/enums/config.js
+++ b/elements/itemfilter/src/enums/config.js
@@ -117,3 +117,5 @@ export const ELEMENT_PROPERTIES = [
   "expandMultipleResults",
   "items",
 ];
+
+export const DATE_TIME_FORMAT = "YYYY-MM-DD";

--- a/elements/itemfilter/src/enums/index.js
+++ b/elements/itemfilter/src/enums/index.js
@@ -1,1 +1,1 @@
-export { ELEMENT_CONFIG, ELEMENT_PROPERTIES } from "./config";
+export { ELEMENT_CONFIG, ELEMENT_PROPERTIES, DATE_TIME_FORMAT } from "./config";

--- a/elements/itemfilter/src/helpers/filter-client.js
+++ b/elements/itemfilter/src/helpers/filter-client.js
@@ -100,7 +100,7 @@ export const filter = async (items, filters, config) => {
       for (const [key, value] of Object.entries(rangeFilters)) {
         // Function to parse value based on format
         const parseValue = (input) => {
-          return value.format === "date" ? dayjs(input).unix() : input;
+          return value.format === "date" ? dayjs(input).valueOf() : input;
         };
         const rangeValue = getValue(key, results[i]);
         if (rangeValue) {

--- a/elements/itemfilter/src/helpers/index.js
+++ b/elements/itemfilter/src/helpers/index.js
@@ -11,3 +11,4 @@ export { default as toggleAccordion } from "./toggle-accordion";
 export { default as getValue } from "./get-value";
 export { default as capitalize } from "./capitalize";
 export { default as mergeHighlightIndices } from "./merge-highlight-indices";
+export { default as isDate } from "./is-date";

--- a/elements/itemfilter/src/helpers/is-date.js
+++ b/elements/itemfilter/src/helpers/is-date.js
@@ -1,0 +1,9 @@
+/**
+ * Checks if the filterObject format is date-like.
+ *
+ * @param {Object} filterObject - The filter object.
+ * @returns {boolean} True if it is a date, otherwise false.
+ */
+export default function isDate(filterObject) {
+  return Boolean(filterObject.format === "date");
+}

--- a/elements/itemfilter/src/methods/filters/range.js
+++ b/elements/itemfilter/src/methods/filters/range.js
@@ -21,10 +21,7 @@ export function resetRangeMethod(EOxItemFilterRange) {
      */
     const eleTimeControl = EOxItemFilterRange.querySelector("eox-timecontrol");
     if (eleTimeControl) {
-      eleTimeControl.dateChange(
-        [dayjs.unix(min), dayjs.unix(max)],
-        eleTimeControl,
-      );
+      eleTimeControl.dateChange([dayjs(min), dayjs(max)], eleTimeControl);
     }
 
     /**
@@ -65,7 +62,7 @@ export function rangeInputHandlerMethod(evt, EOxItemFilterRange) {
   if (EOxItemFilterRange.filterObject.dirty) {
     EOxItemFilterRange.filterObject.stringifiedState =
       EOxItemFilterRange.filterObject.format === "date"
-        ? `${dayjs.unix(min).format(DATE_TIME_FORMAT)} - ${dayjs.unix(max).format(DATE_TIME_FORMAT)}`
+        ? `${dayjs(min).format(DATE_TIME_FORMAT)} - ${dayjs(max).format(DATE_TIME_FORMAT)}`
         : `${min} - ${max}`;
   }
 
@@ -91,7 +88,7 @@ export function rangeInputHandlerMethod(evt, EOxItemFilterRange) {
 export function rangeLabelMethod(val, pos, EOxItemFilterRange) {
   const filteredVal = EOxItemFilterRange.filterObject.state[val];
   const label = isDate(EOxItemFilterRange.filterObject)
-    ? dayjs.unix(filteredVal).format(DATE_TIME_FORMAT)
+    ? dayjs(filteredVal).format(DATE_TIME_FORMAT)
     : filteredVal;
   return html`<div class="range-${pos}">${label}</div>`;
 }

--- a/elements/itemfilter/src/methods/filters/range.js
+++ b/elements/itemfilter/src/methods/filters/range.js
@@ -1,8 +1,7 @@
-import { resetFilter } from "../../helpers/index.js";
+import { resetFilter, isDate } from "../../helpers/index.js";
 import dayjs from "dayjs";
 import { html } from "lit";
-
-const DATE_TIME_FORMAT = "ddd, D MMM YYYY HH:mm:ss";
+import { DATE_TIME_FORMAT } from "../../enums/index.js";
 
 /**
  * Resets the range filter to its default state and requests an update.
@@ -14,15 +13,29 @@ export function resetRangeMethod(EOxItemFilterRange) {
     EOxItemFilterRange.filterObject,
   );
   if (EOxItemFilterRange.filterObject) {
+    const min = EOxItemFilterRange.filterObject.min;
+    const max = EOxItemFilterRange.filterObject.max;
+
+    /**
+     * @type {import("@eox/timecontrol").EOxTimeControl}
+     */
+    const eleTimeControl = EOxItemFilterRange.querySelector("eox-timecontrol");
+    if (eleTimeControl) {
+      eleTimeControl.dateChange(
+        [dayjs.unix(min), dayjs.unix(max)],
+        eleTimeControl,
+      );
+    }
+
     /**
      * @type {import("toolcool-range-slider").RangeSlider}
      */
     const eleTCRangeSlider =
       EOxItemFilterRange.querySelector("tc-range-slider");
-    const min = EOxItemFilterRange.filterObject.min;
-    const max = EOxItemFilterRange.filterObject.max;
-    if (eleTCRangeSlider.value1 !== min) eleTCRangeSlider.value1 = min;
-    if (eleTCRangeSlider.value2 !== max) eleTCRangeSlider.value2 = max;
+    if (eleTCRangeSlider) {
+      if (eleTCRangeSlider.value1 !== min) eleTCRangeSlider.value1 = min;
+      if (eleTCRangeSlider.value2 !== max) eleTCRangeSlider.value2 = max;
+    }
   }
   EOxItemFilterRange.requestUpdate();
 }
@@ -76,9 +89,8 @@ export function rangeInputHandlerMethod(evt, EOxItemFilterRange) {
  * @returns {import("lit").HTMLTemplateResult}
  */
 export function rangeLabelMethod(val, pos, EOxItemFilterRange) {
-  const isDate = Boolean(EOxItemFilterRange.filterObject.format === "date");
   const filteredVal = EOxItemFilterRange.filterObject.state[val];
-  const label = isDate
+  const label = isDate(EOxItemFilterRange.filterObject)
     ? dayjs.unix(filteredVal).format(DATE_TIME_FORMAT)
     : filteredVal;
   return html`<div class="range-${pos}">${label}</div>`;

--- a/elements/itemfilter/src/methods/itemfilter/create-filter.js
+++ b/elements/itemfilter/src/methods/itemfilter/create-filter.js
@@ -59,6 +59,9 @@ function createFilterMethod(filterObject, tabIndex, EOxItemFilter) {
           .tabIndex=${tabIndex}
           .filterObject=${filterObject}
           slot="filter"
+          .suggestions="${uniq(
+            flatMap(EOxItemFilter.items, filterObject.key),
+          ).filter((i) => i)}"
           .unstyled=${EOxItemFilter.unstyled}
           @filter=${() => EOxItemFilter.search()}
         ></eox-itemfilter-range>

--- a/elements/itemfilter/src/methods/itemfilter/filter-apply.js
+++ b/elements/itemfilter/src/methods/itemfilter/filter-apply.js
@@ -22,7 +22,7 @@ function filterApplyMethod(config, items, EOxItemFilter) {
       // Function to parse values based on their format
       const parseValue = (value) => {
         return filterProperty.format === "date"
-          ? dayjs(value).unix()
+          ? dayjs(value).valueOf()
           : parseFloat(value);
       };
 

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -228,6 +228,8 @@ nav.title-nav {
 }
 eox-itemfilter-range {
   display: block;
+  margin-left: var(--_list-padding);
+  padding-right: var(--_padding);
 }
 .range-wrapper {
   margin-left: var(--_list-padding);

--- a/elements/itemfilter/stories/date-range-filter.js
+++ b/elements/itemfilter/stories/date-range-filter.js
@@ -1,0 +1,40 @@
+import { html } from "lit";
+
+/**
+ * Story for the Date Range Filter.
+ * Demonstrates the integration of `eox-timecontrol` within `eox-itemfilter`
+ * when a filter property has `type: "range"` and `format: "date"`.
+ *
+ * @returns {Object} The story configuration.
+ */
+function DateRangeFilterStory() {
+  const items = [
+    { title: "Item 1", timestamp: "2021-01-01" },
+    { title: "Item 2", timestamp: "2021-02-01" },
+    { title: "Item 3", timestamp: "2021-03-01" },
+    { title: "Item 4", timestamp: "2021-04-01" },
+  ];
+
+  return {
+    render: (args) =>
+      html`<eox-itemfilter
+        .items=${args.items}
+        .filterProperties=${args.filterProperties}
+      ></eox-itemfilter>`,
+    args: {
+      storyCodeBefore: `import "@eox/timecontrol/dist/eox-timecontrol.js";`,
+      filterProperties: [
+        {
+          key: "timestamp",
+          title: "Date Range",
+          type: "range",
+          format: "date",
+          expanded: true,
+        },
+      ],
+      items,
+    },
+  };
+}
+
+export default DateRangeFilterStory;

--- a/elements/itemfilter/stories/date-range-filter.js
+++ b/elements/itemfilter/stories/date-range-filter.js
@@ -10,9 +10,9 @@ import { html } from "lit";
 function DateRangeFilterStory() {
   const items = [
     { title: "Item 1", timestamp: "2021-01-01" },
-    { title: "Item 2", timestamp: "2021-02-01" },
-    { title: "Item 3", timestamp: "2021-03-01" },
-    { title: "Item 4", timestamp: "2021-04-01" },
+    { title: "Item 2", timestamp: "2021-01-10" },
+    { title: "Item 3", timestamp: "2021-01-20" },
+    { title: "Item 4", timestamp: "2021-01-30" },
   ];
 
   return {

--- a/elements/itemfilter/stories/index.js
+++ b/elements/itemfilter/stories/index.js
@@ -9,5 +9,6 @@ export { default as NestedPropertyStory } from "./nested-property"; // Item filt
 export { default as ExternalStory, ExternalFetchFnStory } from "./external"; // Item filter with external endpoint
 export { default as CardDisplayStory } from "./card-display";
 export { default as CSSVariablesStory } from "./css-variables";
+export { default as DateRangeFilterStory } from "./date-range-filter";
 export { default as ResultActionStory } from "./result-action";
 export { ResultSortingStory } from "./result-sorting";

--- a/elements/itemfilter/stories/itemfilter.stories.js
+++ b/elements/itemfilter/stories/itemfilter.stories.js
@@ -4,6 +4,7 @@ import {
   AutoSpreadStory,
   CardDisplayStory,
   CSSVariablesStory,
+  DateRangeFilterStory,
   ExternalStory,
   ExternalFetchFnStory,
   InlineModeStory,
@@ -24,6 +25,27 @@ export default {
  * A basic example for an item filter configuration, demonstrating all major filter types (`text`, `select`, `multiselect`, `range`, `spatial`) and result aggregation by property.
  */
 export const Primary = PrimaryStory();
+
+/**
+ * Demonstrates the date range filter, which uses `eox-timecontrol` to provide a calendar-based interface for filtering items by date.
+ * To use this, set the filter `type` to `"range"` and `format` to `"date"`.
+ *
+ * **Note: You also need to import `@eox/timecontrol` in your application to use this feature.**
+ *
+ * ```html
+ * <eox-itemfilter
+ *   .items=${[ ... ]}
+ *   .filterProperties=${[
+ *     {
+ *       key: "timestamp",
+ *       type: "range",
+ *       format: "date",
+ *     }
+ *   ]}
+ * ></eox-itemfilter>
+ * ```
+ */
+export const DateRangeFilter = DateRangeFilterStory();
 
 /**
  * Using `inlineMode`, the itemfilter is rendered in a single input field, ideal for compact UIs or toolbars. Results are hidden until a filter is applied.

--- a/elements/itemfilter/test/cases/filters/date-range-filter.js
+++ b/elements/itemfilter/test/cases/filters/date-range-filter.js
@@ -1,0 +1,69 @@
+/**
+ * Test case for date range filter integration
+ */
+export function dateRangeFilterTest() {
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.items = [
+      { title: "Old", timestamp: "2021-01-01" },
+      { title: "New", timestamp: "2023-01-01" },
+    ];
+    eoxItemFilter.filterProperties = [
+      {
+        key: "timestamp",
+        type: "range",
+        format: "date",
+        expanded: true,
+      },
+    ];
+  });
+
+  cy.get("eox-itemfilter", { includeShadowDom: true })
+    .find("eox-itemfilter-range", { includeShadowDom: true })
+    .find("eox-timecontrol", { includeShadowDom: true })
+    .should("exist");
+
+  cy.get("eox-itemfilter", { includeShadowDom: true })
+    .find("eox-itemfilter-range", { includeShadowDom: true })
+    .find("eox-timecontrol-picker", { includeShadowDom: true })
+    .should("exist");
+
+  // Check initial results (both items should be visible as filter covers all)
+  cy.get("eox-itemfilter")
+    .shadow()
+    .find("eox-itemfilter-results")
+    .find("ul#results")
+    .children()
+    .should("have.length", 2);
+
+  // Manually trigger a change from the timecontrol to simulate a user selection
+  cy.get("eox-itemfilter", { includeShadowDom: true })
+    .find("eox-itemfilter-range", { includeShadowDom: true })
+    .find("eox-timecontrol", { includeShadowDom: true })
+    .then(($timecontrol) => {
+      // Simulate selecting a range that only includes the "New" item
+      // New item is 2023-01-01
+      // Range: 2022-01-01 to 2024-01-01
+      const startDate = new Date("2022-01-01T00:00:00Z");
+      const endDate = new Date("2024-01-01T00:00:00Z");
+
+      $timecontrol[0].dispatchEvent(
+        new CustomEvent("select", {
+          detail: {
+            date: [startDate, endDate],
+          },
+        }),
+      );
+    });
+
+  // Check results after filtering
+  cy.get("eox-itemfilter")
+    .shadow()
+    .find("eox-itemfilter-results")
+    .find("ul#results")
+    .within(() => {
+      cy.get("li").should("have.length", 1);
+      cy.contains("New");
+      cy.contains("Old").should("not.exist");
+    });
+}

--- a/elements/itemfilter/test/cases/filters/index.js
+++ b/elements/itemfilter/test/cases/filters/index.js
@@ -1,3 +1,4 @@
 // Exported test methods
 
 export { default as filterkeysTest } from "./filter-keys";
+export { dateRangeFilterTest } from "./date-range-filter";

--- a/elements/itemfilter/test/date-range-filter.cy.js
+++ b/elements/itemfilter/test/date-range-filter.cy.js
@@ -1,0 +1,18 @@
+import "../src/main";
+import { dateRangeFilterTest } from "./cases/filters/";
+
+describe("Item Filter Date Range", () => {
+  beforeEach(() => {
+    cy.mount(`<eox-itemfilter></eox-itemfilter>`)
+      .as("eox-itemfilter")
+      .then(($el) => {
+        const eoxItemFilter = $el[0];
+        Object.assign(eoxItemFilter, {
+          titleProperty: "title",
+        });
+      });
+  });
+
+  it("should filter items using the date range picker", () =>
+    dateRangeFilterTest());
+});

--- a/elements/timecontrol/src/methods/picker/get-selected-dates.js
+++ b/elements/timecontrol/src/methods/picker/get-selected-dates.js
@@ -25,18 +25,28 @@ export default function getSelectedDatesMethod(
   range,
   showUTC,
 ) {
-  if (!selectedDateRange) return null;
+  if (!selectedDateRange || !selectedDateRange[0]) return null;
   const start = showUTC
     ? dayjs(selectedDateRange[0]).utc()
     : dayjs(selectedDateRange[0]);
-  const end = showUTC
-    ? dayjs(selectedDateRange[1]).utc()
-    : dayjs(selectedDateRange[1]);
-  const startDateFormatted = start.format(TIME_CONTROL_DATE_FORMAT);
-  const endDateFormatted = end.format(TIME_CONTROL_DATE_FORMAT);
-  const selectedDates = range
-    ? [startDateFormatted, endDateFormatted]
-    : [startDateFormatted];
+
+  const selectedDates = [];
+
+  // If a range is requested and the end date is provided, fill in all days
+  if (range && selectedDateRange[1]) {
+    const end = showUTC
+      ? dayjs(selectedDateRange[1]).utc()
+      : dayjs(selectedDateRange[1]);
+
+    let current = start;
+    while (!current.isAfter(end, "day")) {
+      selectedDates.push(current.format(TIME_CONTROL_DATE_FORMAT));
+      current = current.add(1, "day");
+    }
+  } else {
+    // Fallback if it's a single date selection or the user hasn't clicked the second date yet
+    selectedDates.push(start.format(TIME_CONTROL_DATE_FORMAT));
+  }
 
   return {
     dates: selectedDates,

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,6 @@
       "version": "1.16.0",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
-        "@eox/timecontrol": "2.4.0",
         "@eox/ui": "^1.1.0",
         "@floating-ui/dom": "^1.6.8",
         "@turf/boolean-intersects": "^7.3.5",
@@ -148,7 +147,8 @@
       },
       "peerDependencies": {
         "@eox/layout": "*",
-        "@eox/map": ">=2.0.0 || >=2.1.0-dev.1"
+        "@eox/map": ">=2.0.0 || >=2.1.0-dev.1",
+        "@eox/timecontrol": ">=2.0.0"
       }
     },
     "elements/jsonform": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
     },
     "elements/drawtools": {
       "name": "@eox/drawtools",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
         "@eox/ui": "^1.1.0",
@@ -124,6 +124,7 @@
       "version": "1.16.0",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
+        "@eox/timecontrol": "2.4.0",
         "@eox/ui": "^1.1.0",
         "@floating-ui/dom": "^1.6.8",
         "@turf/boolean-intersects": "^7.3.5",
@@ -176,7 +177,7 @@
     },
     "elements/layercontrol": {
       "name": "@eox/layercontrol",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
         "@eox/ui": "^1.1.0",
@@ -212,7 +213,7 @@
     },
     "elements/map": {
       "name": "@eox/map",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
         "@eox/ui": "^1.1.0",


### PR DESCRIPTION
## Implemented changes

This PR introduces a date picker UI to date range filtering by integrating the `@eox/timecontrol` library. When a filter object is designated as a date, the component now dynamically renders a time picker interface in place of the standard range slider, allowing users to pick ranges across calendar days.

### Key Changes

#### Component & UI Enhancements

* **Conditional Time Control Rendering:** Updated `range.js` to conditionally render `<eox-timecontrol>` when the filter format is identified as a date.
* **Property Additions:** Added `.suggestions` passing to the range component to populate available time control options.
* **Styling Adjustments:** Added minor CSS structural fixes (`.range-wrapper`) in `style.eox.js`.

#### Logic & Core Methods

* **Date Range Array Expansion:** Refactored `get-selected-dates.js` in the timecontrol picker to populate and return an array of *all consecutive days* within a selected range, rather than just returning the start and end bounds.
* **Filter Reset Integration:** Updated `resetRangeMethod` to check for the existence of `<eox-timecontrol>` and programmatically reset its dates using `dayjs.unix` timestamps when a user clears filters.
* **Event Handling:** Hooked up the `@select` event from the time control picker to dispatch standard Unix timestamp values back to the range input handler.

#### Helpers & Enums

* **New Helper:** Created `isDate()` to cleanly check if a filter object format is set to `"date"`.
* **Standardized Formats:** Centralized the `DATE_TIME_FORMAT` string (`YYYY-MM-DD`) into the enums configuration to maintain consistent formatting across components.

#### Dependencies

* Added `@eox/timecontrol: 2.4.0` to the project's dependencies.

#### Follow-up / further enhancements:
- Display time #2339
- Make string editable #2340

## Screenshots/Videos

<img width="364" height="396" alt="image" src="https://github.com/user-attachments/assets/2afed095-99d8-4bbb-a7d4-e9f3772d8407" />

<img width="366" height="528" alt="image" src="https://github.com/user-attachments/assets/ec512517-2639-4e70-aefc-916200ad308c" />


https://github.com/user-attachments/assets/c1317c0e-80df-4672-ac0b-a077c7f28083


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
