### PR TITLE
fix: display date picker in inline mode within filter div

### DIFF
--- a/elements/itemfilter/src/components/filters/range.js
+++ b/elements/itemfilter/src/components/filters/range.js
@@ -28,6 +28,7 @@ export class EOxItemFilterRange extends LitElement {
     filterObject: { attribute: false, type: Object },
     suggestions: { attribute: false, type: Array },
     tabIndex: { attribute: false, type: Number },
+    inlineMode: { attribute: "inline-mode", type: Boolean },
   };
 
   constructor() {
@@ -47,6 +48,11 @@ export class EOxItemFilterRange extends LitElement {
      * @type Boolean
      */
     this.tabIndex = 0;
+
+    /**
+     * @type Boolean
+     */
+    this.inlineMode = false;
 
     /**
      * @type {(evt: CustomEvent<any>) => void}
@@ -142,7 +148,10 @@ export class EOxItemFilterRange extends LitElement {
                 .format=${DATE_TIME_FORMAT}
               ></eox-timecontrol-date>
               <eox-timecontrol-picker
-                popup
+                style="${this.inlineMode
+                  ? "margin-bottom: 1rem; display: block;"
+                  : ""}"
+                ?popup=${!this.inlineMode}
                 range
                 show-dots
                 .position=${["bottom", "left"]}

--- a/elements/itemfilter/src/methods/itemfilter/create-filter.js
+++ b/elements/itemfilter/src/methods/itemfilter/create-filter.js
@@ -54,6 +54,7 @@ function createFilterMethod(filterObject, tabIndex, EOxItemFilter) {
       // Return a range filter element
       return html`
         <eox-itemfilter-range
+          .inlineMode=${EOxItemFilter.inlineMode || false}
           id="${filterId}"
           data-type="filter"
           .tabIndex=${tabIndex}

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -109,6 +109,13 @@ eox-itemfilter-expandcontainer > [data-type=filter] {
   overflow-x: hidden;
   max-width: 100%;
 }
+form#itemfilter.inline eox-itemfilter-expandcontainer {
+  max-height: none;
+}
+form#itemfilter.inline eox-itemfilter-expandcontainer > [data-type=filter] {
+  height: auto;
+  overflow: visible;
+}
 [data-type=filter] .title,
 details summary {
   text-transform: var(--_text-transform);


### PR DESCRIPTION
## Implemented changes

This PR moves the date picker into the filter div in inline mode. Since the inline mode div uses popopver API it was the only way to actually show the datepicker, otherwise it would always be underneath.

## Screenshots/Videos

<img width="580" height="431" alt="image" src="https://github.com/user-attachments/assets/7981e1f0-fadc-4d5d-9f4c-f46cbd4a285b" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
