### PR TITLE
fix: date range filter in external search mode

### DIFF
--- a/elements/itemfilter/src/components/filters/range.js
+++ b/elements/itemfilter/src/components/filters/range.js
@@ -128,8 +128,12 @@ export class EOxItemFilterRange extends LitElement {
                 },
               ]}
               .initDate=${[
-                dayjs(this.filterObject.state.min || this.filterObject.min),
-                dayjs(this.filterObject.state.max || this.filterObject.max),
+                dayjs(
+                  this.filterObject.state.min || this.filterObject.min,
+                ).format(),
+                dayjs(
+                  this.filterObject.state.max || this.filterObject.max,
+                ).format(),
               ]}
               @select=${(e) =>
                 rangeInputHandlerMethod(

--- a/elements/itemfilter/src/methods/filters/range.js
+++ b/elements/itemfilter/src/methods/filters/range.js
@@ -19,7 +19,10 @@ export function resetRangeMethod(EOxItemFilterRange) {
      */
     const eleTimeControl = EOxItemFilterRange.querySelector("eox-timecontrol");
     if (eleTimeControl) {
-      eleTimeControl.dateChange([dayjs(min), dayjs(max)], eleTimeControl);
+      eleTimeControl.dateChange(
+        [dayjs(min).format(), dayjs(max).format()],
+        eleTimeControl,
+      );
     }
 
     /**

--- a/elements/itemfilter/test/cases/filters/date-range-filter.js
+++ b/elements/itemfilter/test/cases/filters/date-range-filter.js
@@ -67,3 +67,85 @@ export function dateRangeFilterTest() {
       cy.contains("Old").should("not.exist");
     });
 }
+
+/**
+ * Test case for date range filter integration with external search
+ */
+export function externalDateRangeFilterTest() {
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.items = [];
+    eoxItemFilter.externalFilter = (items, filters) => {
+      const dummyItems = [
+        { title: "Old", timestamp: "2021-01-01" },
+        { title: "New", timestamp: "2023-01-01" },
+      ];
+      return {
+        url: "fake-endpoint",
+        fetchFn: () => {
+          const dateFilter = filters.timestamp;
+          if (
+            dateFilter &&
+            dateFilter.state &&
+            (dateFilter.state.min || dateFilter.state.max)
+          ) {
+            const minVal = dateFilter.state.min
+              ? new Date(dateFilter.state.min).getTime()
+              : -Infinity;
+            const maxVal = dateFilter.state.max
+              ? new Date(dateFilter.state.max).getTime()
+              : Infinity;
+            return dummyItems.filter((item) => {
+              const itemTime = new Date(item.timestamp).getTime();
+              return itemTime >= minVal && itemTime <= maxVal;
+            });
+          }
+          return dummyItems;
+        },
+      };
+    };
+    eoxItemFilter.filterProperties = [
+      {
+        key: "timestamp",
+        type: "range",
+        format: "date",
+        expanded: true,
+        min: "2020-01-01",
+        max: "2024-12-31",
+      },
+    ];
+  });
+
+  cy.get("eox-itemfilter", { includeShadowDom: true })
+    .find("eox-itemfilter-range", { includeShadowDom: true })
+    .find("eox-timecontrol", { includeShadowDom: true })
+    .should("exist");
+
+  // Manually trigger a change from the timecontrol to simulate a user selection
+  cy.get("eox-itemfilter", { includeShadowDom: true })
+    .find("eox-itemfilter-range", { includeShadowDom: true })
+    .find("eox-timecontrol", { includeShadowDom: true })
+    .then(($timecontrol) => {
+      const startDate = new Date("2022-01-01T00:00:00Z");
+      const endDate = new Date("2024-01-01T00:00:00Z");
+
+      $timecontrol[0].dispatchEvent(
+        new CustomEvent("select", {
+          detail: {
+            date: [startDate, endDate],
+          },
+        }),
+      );
+    });
+
+  // Check results after filtering: only "New" (2023-01-01) should exist, not "Old" (2021-01-01)
+  cy.get("eox-itemfilter")
+    .shadow()
+    .find("eox-itemfilter-results")
+    .find("ul#results")
+    .within(() => {
+      cy.get("li").should("have.length", 1);
+      cy.contains("New");
+      cy.contains("Old").should("not.exist");
+    });
+}

--- a/elements/itemfilter/test/cases/filters/index.js
+++ b/elements/itemfilter/test/cases/filters/index.js
@@ -1,5 +1,8 @@
 // Exported test methods
 
 export { default as filterkeysTest } from "./filter-keys";
-export { dateRangeFilterTest } from "./date-range-filter";
+export {
+  dateRangeFilterTest,
+  externalDateRangeFilterTest,
+} from "./date-range-filter";
 export { rangeFilterTest } from "./range-filter";

--- a/elements/itemfilter/test/date-range-filter.cy.js
+++ b/elements/itemfilter/test/date-range-filter.cy.js
@@ -1,5 +1,8 @@
 import "../src/main";
-import { dateRangeFilterTest } from "./cases/filters/";
+import {
+  dateRangeFilterTest,
+  externalDateRangeFilterTest,
+} from "./cases/filters/";
 
 describe("Item Filter Date Range", () => {
   beforeEach(() => {
@@ -15,4 +18,7 @@ describe("Item Filter Date Range", () => {
 
   it("should filter items using the date range picker", () =>
     dateRangeFilterTest());
+
+  it("should filter items using the date range picker with external search", () =>
+    externalDateRangeFilterTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR fixes a runtime `TypeError` (`utc is not a function` at `eox-timecontrol.js`) when using the `<eox-itemfilter>` date range filter under **external search** mode (where items are not present on initialization).

### Root Cause
In standard operations, `eox-timecontrol` extends its own copy of `dayjs` with the `utc` and `timezone` plugins. However, when `<eox-itemfilter-range>` was passing full `dayjs` instances (from `eox-itemfilter`'s internal dependency bundle) to `eox-timecontrol`'s `.initDate` property and `.dateChange()` methods, `eox-timecontrol` cloned them. Because the cloned instances retained `eox-itemfilter`'s unextended prototype context, they did not possess the `.utc()` method, leading to a fatal crash.

### Solution
- **Strict Separation of Boundaries**: Modified both `elements/itemfilter/src/components/filters/range.js` and `elements/itemfilter/src/methods/filters/range.js` to format raw `dayjs` instances into standard ISO-8601 strings (`.format()`) before passing them across package/module boundaries to `<eox-timecontrol>`.
- **Added Automated Test**: Added a new automated test case (`should filter items using the date range picker with external search`) inside `elements/itemfilter/test/date-range-filter.cy.js` to ensure date range filtering works seamlessly under external search mode without any cross-bundle collisions.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
