### PR TITLE
fix(style): harmonize list padding

### DIFF
--- a/elements/itemfilter/src/components/filters/selector.js
+++ b/elements/itemfilter/src/components/filters/selector.js
@@ -201,7 +201,7 @@ export class EOxSelector extends LitElement {
           html`<div class="autocomplete-container">
             <div
               class="autocomplete-container-wrapper field small no-round"
-              style="margin-left: var(--list-padding)"
+              style="margin-left: var(--_list-padding)"
             >
               <input
                 autocomplete="off"

--- a/elements/itemfilter/src/components/filters/spatial.js
+++ b/elements/itemfilter/src/components/filters/spatial.js
@@ -88,7 +88,7 @@ class EOxItemFilterSpatial extends LitElement {
       this.filterObject,
       () => html`
         <div
-          style="margin-left: var(--list-padding); padding-right: var(--padding)"
+          style="margin-left: var(--_list-padding); padding-right: var(--_padding)"
         >
           <nav class="no-margin wrap">
             ${map(

--- a/elements/itemfilter/src/components/filters/text.js
+++ b/elements/itemfilter/src/components/filters/text.js
@@ -114,7 +114,7 @@ export class EOxItemFilterText extends LitElement {
         <div class="text-container">
           <div
             class="text-container-wrapper field small"
-            style="margin-left: var(--list-padding)"
+            style="margin-left: var(--_list-padding)"
           >
             <input
               type="text"
@@ -131,7 +131,9 @@ export class EOxItemFilterText extends LitElement {
             />
           </div>
         </div>
-        <small class="error-validation" style="margin-left: var(--list-padding)"
+        <small
+          class="error-validation"
+          style="margin-left: var(--_list-padding)"
           >${this.filterObject.validation && this.isValid === false
             ? this.filterObject.validation.message
             : ""}</small


### PR DESCRIPTION
## Implemented changes

This PR harmonizes the list paddings in text, selector and spatial filters.

## Screenshots/Videos

<img width="395" height="350" alt="image" src="https://github.com/user-attachments/assets/6261cf98-e9bd-4073-bd0d-f6b73aa036d3" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
