### PR TITLE
fix: filter state loss on mode toggle

### DIFF
--- a/elements/itemfilter/src/components/filters/selector.js
+++ b/elements/itemfilter/src/components/filters/selector.js
@@ -109,6 +109,11 @@ export class EOxSelector extends LitElement {
    * @param {Map} changedProperties - The properties that have changed.
    */
   updated(changedProperties) {
+    if (changedProperties.has("filterObject") && this.filterObject.state) {
+      this.selectedItems = Object.keys(this.filterObject.state)
+        .map((item) => (this.filterObject.state[item] ? item : null))
+        .filter((item) => Boolean(item));
+    }
     updatedSelectorMethod(changedProperties, this);
   }
 

--- a/elements/itemfilter/src/main.js
+++ b/elements/itemfilter/src/main.js
@@ -420,13 +420,39 @@ export class EOxItemFilter extends LitElement {
    * @param {Map} changedProperties - The properties that have changed.
    */
   updated(changedProperties) {
-    ELEMENT_PROPERTIES.map((property) => {
+    let shouldReapply = false;
+    let shouldSearch = false;
+
+    ELEMENT_PROPERTIES.forEach((property) => {
       if (changedProperties.has(property)) {
-        this.firstUpdated(undefined);
-        return true;
+        this.#config[property] = this[property];
+        if (
+          [
+            "items",
+            "filterProperties",
+            "idProperty",
+            "aggregateResults",
+            "fuseConfig",
+            "matchAllWhenEmpty",
+            "externalFilter",
+          ].includes(property)
+        ) {
+          shouldReapply = true;
+        } else if (property === "resultSorting") {
+          shouldSearch = true;
+        }
       }
-      return false;
     });
+
+    if (shouldReapply) {
+      this.#items =
+        this.items?.map((i, index) =>
+          Object.assign({ id: i[this.idProperty] || `item-${index}` }, i),
+        ) || [];
+      this.apply();
+    } else if (shouldSearch) {
+      this.search();
+    }
   }
 
   /**

--- a/elements/itemfilter/src/methods/itemfilter/filter-apply.js
+++ b/elements/itemfilter/src/methods/itemfilter/filter-apply.js
@@ -78,6 +78,7 @@ function filterApplyMethod(config, items, EOxItemFilter) {
 
       // Combine filter properties into the filter object
       const filterKey = filterProperty.key || filterProperty.keys.join("|");
+      const existingFilter = EOxItemFilter.filters[filterKey];
       let isDirty = undefined;
       if (filterProperty.state) {
         if (filterProperty.type === "range") {
@@ -110,7 +111,7 @@ function filterApplyMethod(config, items, EOxItemFilter) {
       EOxItemFilter.filters[filterKey] = Object.assign(
         {
           type: filterProperty.type || "multiselect",
-          dirty: isDirty,
+          dirty: isDirty || existingFilter?.dirty,
           key: filterKey,
         },
         filterProperty.type === "range"
@@ -131,8 +132,16 @@ function filterApplyMethod(config, items, EOxItemFilter) {
             ? dayjs(val).valueOf()
             : parseFloat(val);
         };
-        const min = parseVal(filterProperty.state.min);
-        const max = parseVal(filterProperty.state.max);
+        const min = parseVal(
+          filterProperty.state?.min !== undefined
+            ? filterProperty.state.min
+            : existingFilter?.state?.min,
+        );
+        const max = parseVal(
+          filterProperty.state?.max !== undefined
+            ? filterProperty.state.max
+            : existingFilter?.state?.max,
+        );
         EOxItemFilter.filters[filterKey].stringifiedState =
           filterProperty.format === "date"
             ? `${dayjs(min).format(DATE_TIME_FORMAT)} - ${dayjs(max).format(DATE_TIME_FORMAT)}`
@@ -141,6 +150,7 @@ function filterApplyMethod(config, items, EOxItemFilter) {
       EOxItemFilter.filters[filterKey].state = Object.assign(
         {},
         filterKeys,
+        existingFilter?.state || {},
         filterProperty.state,
       );
     });

--- a/elements/itemfilter/test/cases/general/index.js
+++ b/elements/itemfilter/test/cases/general/index.js
@@ -15,5 +15,6 @@ export { default as imageTest } from "./image";
 export { default as validationTest } from "./validation";
 export { default as slotRenderTest } from "./slots";
 export { default as resultsActionTest } from "./results-action";
+export { default as inlineModeToggleTest } from "./inline-mode-toggle";
 export { resultSortingTest } from "./result-sorting";
 export { default as resultAggregationTest } from "./results-aggregation";

--- a/elements/itemfilter/test/cases/general/inline-mode-toggle.js
+++ b/elements/itemfilter/test/cases/general/inline-mode-toggle.js
@@ -1,0 +1,64 @@
+/**
+ * Tests that currently selected filters are preserved when toggling inlineMode back and forth.
+ */
+const inlineModeToggleTest = () => {
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+
+    // Interact with filters to change state
+    cy.get("eox-itemfilter")
+      .shadow()
+      .within(() => {
+        cy.get("eox-itemfilter-select").within(() => {
+          cy.get('[type="checkbox"]').first().check({ force: true });
+        });
+      });
+
+    // Verify checkbox is checked
+    cy.get("eox-itemfilter")
+      .shadow()
+      .within(() => {
+        cy.get("eox-itemfilter-select").within(() => {
+          cy.get('[type="checkbox"]').first().should("be.checked");
+        });
+      });
+
+    // Toggle inline mode to true
+    cy.wrap(eoxItemFilter).then((el) => {
+      el.inlineMode = true;
+    });
+
+    // Manually trigger change in filterProperties (which happens in many frameworks on re-render)
+    cy.wrap(eoxItemFilter).then((el) => {
+      el.filterProperties = [
+        {
+          keys: ["title", "themes"],
+          title: "Search",
+          type: "text",
+          expanded: true,
+          validation: {
+            pattern: ".{0,10}",
+            message: "Maximum 10 characters",
+          },
+        },
+        { key: "themes", expanded: true },
+      ];
+    });
+
+    // Toggle inline mode back to false
+    cy.wrap(eoxItemFilter).then((el) => {
+      el.inlineMode = false;
+    });
+
+    // Verify the checkbox is still checked (the filter was not lost)
+    cy.get("eox-itemfilter")
+      .shadow()
+      .within(() => {
+        cy.get("eox-itemfilter-select").within(() => {
+          cy.get('[type="checkbox"]').first().should("be.checked");
+        });
+      });
+  });
+};
+
+export default inlineModeToggleTest;

--- a/elements/itemfilter/test/general.cy.js
+++ b/elements/itemfilter/test/general.cy.js
@@ -19,6 +19,7 @@ import {
   resultsActionTest,
   resultSortingTest,
   resultAggregationTest,
+  inlineModeToggleTest,
 } from "./cases/general/";
 
 /**
@@ -155,4 +156,10 @@ describe("Item Filter Config", () => {
    * Test case to verify result sorting.
    */
   it("should sort results based on configuration", () => resultSortingTest());
+
+  /**
+   * Test case to verify preservation of active filters when toggling inlineMode back and forth.
+   */
+  it("should preserve active filters when toggling inlineMode back and forth", () =>
+    inlineModeToggleTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR fixes an issue where currently selected filters were lost when switching between "normal" and `inlineMode`, specifically during browser window resizing or property updates.

### Changes
- **Filter State Preservation**: Modified `filterApplyMethod` in `filter-apply.js` to merge existing filter states with new configurations. This ensures that user selections are not wiped out when the component re-applies filters due to property changes (like `filterProperties` or `items` being updated during a re-render).
- **Selector Component Sync**: Updated `EOxSelector` in `selector.js` to reactively update its internal `selectedItems` state whenever its `filterObject` property is changed. This ensures the checkbox/radio UI stays in sync with the underlying filter state.
- **Range Filter Fix**: Improved range filter state preservation to correctly handle `min`/`max` values during updates.
- **New Test Case**: Enhanced the `inline-mode-toggle` test case to specifically verify that filters remain active even after a property update during the mode switch.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
