### PR TITLE
feat: support inline GeoJSON features in Vector sources

### DIFF
--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -92,7 +92,7 @@ export function createLayer(EOxMap, layer, createInteractions = true) {
     ...layer,
     ...(layer.type !== "MapboxStyle" &&
       layer.source && {
-        source: createOlSourceFromDefinition(layer.source),
+        source: createOlSourceFromDefinition(layer.source, EOxMap),
       }),
     ...(layer.type === "Group" && { layers: [] }), // Initialize an empty layer collection for group layers
     ...layer.properties,
@@ -139,8 +139,9 @@ export function createLayer(EOxMap, layer, createInteractions = true) {
 /**
  *
  * @param {import("../layers").EoxSource<any>} eoxSource
+ * @param {import("../main").EOxMap} [EOxMap]
  */
-function createOlSourceFromDefinition(eoxSource) {
+function createOlSourceFromDefinition(eoxSource, EOxMap) {
   const availableSources = {
     ...window.eoxMapAdvancedOlSources,
     ...basicOlSources,
@@ -161,8 +162,32 @@ function createOlSourceFromDefinition(eoxSource) {
 
   const tileGrid = generateTileGrid(eoxSource);
 
+  let features;
+  if (eoxSource && eoxSource.features) {
+    if (
+      Array.isArray(eoxSource.features) &&
+      eoxSource.features.length > 0 &&
+      typeof eoxSource.features[0].getGeometry === "function"
+    ) {
+      features = eoxSource.features;
+    } else {
+      let geoJson = eoxSource.features;
+      if (Array.isArray(geoJson)) {
+        geoJson = {
+          type: "FeatureCollection",
+          features: geoJson,
+        };
+      }
+      const format = new GeoJSON();
+      features = format.readFeatures(geoJson, {
+        featureProjection: EOxMap ? EOxMap.OLprojection : "EPSG:3857",
+      });
+    }
+  }
+
   return new NewSource({
     ...eoxSource,
+    ...(features && { features }),
     ...("format" in eoxSource &&
       eoxSource.type !== "WMTS" && {
         // Set the format (e.g., GeoJSON, MVT) for the source
@@ -180,6 +205,7 @@ function createOlSourceFromDefinition(eoxSource) {
     ...("source" in eoxSource && {
       source: createOlSourceFromDefinition(
         /** @type {import("../layers").EoxSource<any>} */ (eoxSource.source),
+        EOxMap,
       ),
     }),
     // Set the format (e.g., GeoJSON, MVT) for the source

--- a/elements/map/src/layers.ts
+++ b/elements/map/src/layers.ts
@@ -133,6 +133,7 @@ export type EoxSource<S extends keyof OLSources> = (S extends "WMTS"
       : OlSourceOption<S>) & {
   type: S;
   projection?: import("ol/proj").ProjectionLike;
+  features?: any;
 };
 
 type SourceProperties<S extends keyof OLSources> = {

--- a/elements/map/stories/index.js
+++ b/elements/map/stories/index.js
@@ -1,5 +1,6 @@
 export { default as PrimaryStory } from "./primary";
 export { default as VectorLayerStory } from "./vector-layer";
+export { default as VectorLayerInlineGeojsonStory } from "./vector-layer-inline-geojson";
 export { default as VectorTileLayerStory } from "./vector-tile-layer";
 export { default as WMSLayerStory } from "./wms-layer";
 export { default as WMTSCapabilitiesLayerStory } from "./wmts-capabilities-layer";

--- a/elements/map/stories/map.stories.js
+++ b/elements/map/stories/map.stories.js
@@ -3,6 +3,7 @@ import { html } from "lit";
 import {
   PrimaryStory,
   VectorLayerStory,
+  VectorLayerInlineGeojsonStory,
   VectorTileLayerStory,
   WMSLayerStory,
   WMTSCapabilitiesLayerStory,
@@ -147,6 +148,13 @@ export const ConfigObject = ConfigObjectStory;
  * Notice that no zoom or center are set; they default to center `[0, 0]` and `zoom`of `0`.
  */
 export const VectorLayer = VectorLayerStory;
+
+/**
+ * Vector layer with inline GeoJSON features.
+ * This demonstrates the convenience of passing GeoJSON features directly in the source definition,
+ * which are automatically parsed and transformed into the map projection.
+ */
+export const VectorLayerInlineGeojson = VectorLayerInlineGeojsonStory;
 
 /**
  * Basic vector layer map rendered using `MVT` tiles

--- a/elements/map/stories/vector-layer-inline-geojson.js
+++ b/elements/map/stories/vector-layer-inline-geojson.js
@@ -1,0 +1,51 @@
+/**
+ * Renders vector layer using inline GeoJSON features
+ *
+ * @returns {Object} The story configuration with arguments for the component.
+ */
+const VectorLayerInlineGeojsonStory = {
+  args: {
+    center: [16.37, 48.2],
+    zoom: 12,
+    layers: [
+      {
+        type: "Tile",
+        properties: {
+          id: "osm",
+        },
+        source: {
+          type: "OSM",
+        },
+      },
+      {
+        type: "Vector",
+        properties: {
+          id: "inlineGeojson",
+        },
+        source: {
+          type: "Vector",
+          features: [
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [16.37, 48.2],
+              },
+              properties: {
+                name: "Vienna",
+              },
+            },
+          ],
+        },
+        style: {
+          "circle-radius": 10,
+          "circle-fill-color": "red",
+          "circle-stroke-color": "white",
+          "circle-stroke-width": 2,
+        },
+      },
+    ],
+  },
+};
+
+export default VectorLayerInlineGeojsonStory;

--- a/elements/map/test/cases/layer-type/index.js
+++ b/elements/map/test/cases/layer-type/index.js
@@ -12,3 +12,4 @@ export { default as flatGeoBufLayerCombined } from "./load-flatgeobuf-layer-comb
 export { default as loadVectorLayer } from "./load-vector-layer";
 export { default as loadClusterLayer } from "./load-cluster-layer";
 export { default as applyGeojsonFormat } from "./apply-geojson-format";
+export { default as loadInlineGeojson } from "./load-inline-geojson";

--- a/elements/map/test/cases/layer-type/load-inline-geojson.js
+++ b/elements/map/test/cases/layer-type/load-inline-geojson.js
@@ -1,0 +1,71 @@
+import { html } from "lit";
+
+/**
+ * Tests to load Vector Layer with inline GeoJSON features
+ */
+const loadInlineGeojson = () => {
+  const inlineLayer = [
+    {
+      type: "Vector",
+      properties: { id: "inlineGeojson" },
+      source: {
+        type: "Vector",
+        features: [
+          {
+            type: "Feature",
+            geometry: {
+              type: "Point",
+              coordinates: [16.37, 48.2],
+            },
+            properties: {
+              name: "Vienna",
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: "Vector",
+      properties: { id: "inlineFeatureCollection" },
+      source: {
+        type: "Vector",
+        features: {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [12.49, 41.9],
+              },
+              properties: {
+                name: "Rome",
+              },
+            },
+          ],
+        },
+      },
+    },
+  ];
+
+  cy.mount(html`<eox-map .layers=${inlineLayer}></eox-map>`).as("eox-map");
+  cy.get("eox-map").and(($el) => {
+    const eoxMap = $el[0];
+    const layers = eoxMap.map.getLayers().getArray();
+    expect(layers).to.have.length(2);
+
+    const layer1 = eoxMap.getLayerById("inlineGeojson");
+    expect(layer1).to.exist;
+    const features1 = layer1.getSource().getFeatures();
+    expect(features1).to.have.length(1);
+    expect(features1[0].get("name")).to.equal("Vienna");
+
+    const layer2 = eoxMap.getLayerById("inlineFeatureCollection");
+    expect(layer2).to.exist;
+    const features2 = layer2.getSource().getFeatures();
+    expect(features2).to.have.length(1);
+    expect(features2[0].get("name")).to.equal("Rome");
+  });
+};
+
+export default loadInlineGeojson;

--- a/elements/map/test/vectorLayer.cy.js
+++ b/elements/map/test/vectorLayer.cy.js
@@ -1,5 +1,9 @@
 import "../src/main";
-import { applyGeojsonFormat, loadVectorLayer } from "./cases/layer-type";
+import {
+  applyGeojsonFormat,
+  loadVectorLayer,
+  loadInlineGeojson,
+} from "./cases/layer-type";
 import {
   updateFlatStyleVectorLayer,
   updateStyleExpressionVectorLayer,
@@ -18,6 +22,11 @@ describe("layers", () => {
    * Test case to apply geojson format options
    */
   it("apply geojson format options", () => applyGeojsonFormat());
+
+  /**
+   * Test case to load inline GeoJSON features
+   */
+  it("loads inline GeoJSON features", () => loadInlineGeojson());
 
   /**
    * Test case to correctly update flat style on Vector Layer


### PR DESCRIPTION
## Implemented changes

This PR introduces convenience support for passing inline GeoJSON features directly inside the `source` configuration of standard Vector layers/sources. Previously, using inline GeoJSON features required converting the payload into a dataURL or using a separate custom loader.

Now, you can define your vector layers with a `features` array or `FeatureCollection` object directly inside the source block. The features are automatically parsed and reprojected to the map's current projection (`EOxMap.OLprojection`).

### Example Usage:
```js
map.layers = [
  {
    type: "Vector",
    properties: { id: "sampleVector" },
    source: {
      type: "Vector",
      features: [ // Inline GeoJSON features
        {
          type: "Feature",
          geometry: {
            type: "Point",
            coordinates: [16.37, 48.20]
          },
          properties: {
            name: "Vienna"
          }
        }
      ]
    }
  }
];
```

## Changes
- **Source parser** (`elements/map/src/helpers/generate.js`): Updated `createOlSourceFromDefinition` to check for and parse inline GeoJSON features using `ol/format/GeoJSON`. Added `EOxMap` parameter to recursively pass projection context.
- **Types** (`elements/map/src/layers.ts`): Updated `EoxSource` type signature to support `features?: any`.
- **Tests** (`elements/map/test/`):
  - Added new Cypress cases verifying automatic reprojection and loading behavior for both arrays of feature objects and full `FeatureCollection` objects.
- **Stories** (`elements/map/stories/`):
  - Added a new functional story `VectorLayerInlineGeojson` to showcase the usage.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
