### PR TITLE
fix: date range filter state initialization

### DIFF
--- a/elements/itemfilter/src/helpers/filter-client.js
+++ b/elements/itemfilter/src/helpers/filter-client.js
@@ -86,7 +86,9 @@ export const filter = async (items, filters, config) => {
     .filter(([, value]) => value.type === "range")
     .reduce((acc, [key, value]) => {
       const parseValue = (input) => {
-        return value.format === "date" ? dayjs(input).valueOf() : parseFloat(input);
+        return value.format === "date"
+          ? dayjs(input).valueOf()
+          : parseFloat(input);
       };
       acc[key] = {
         min: parseValue(value.state.min),
@@ -103,7 +105,9 @@ export const filter = async (items, filters, config) => {
       for (const [key, value] of Object.entries(rangeFilters)) {
         // Function to parse value based on format
         const parseValue = (input) => {
-          return value.format === "date" ? dayjs(input).valueOf() : parseFloat(input);
+          return value.format === "date"
+            ? dayjs(input).valueOf()
+            : parseFloat(input);
         };
         const rangeValue = getValue(key, results[i]);
         if (rangeValue) {

--- a/elements/itemfilter/src/helpers/filter-client.js
+++ b/elements/itemfilter/src/helpers/filter-client.js
@@ -85,9 +85,12 @@ export const filter = async (items, filters, config) => {
   const rangeFilters = Object.entries(filters)
     .filter(([, value]) => value.type === "range")
     .reduce((acc, [key, value]) => {
+      const parseValue = (input) => {
+        return value.format === "date" ? dayjs(input).valueOf() : parseFloat(input);
+      };
       acc[key] = {
-        min: value.state.min,
-        max: value.state.max,
+        min: parseValue(value.state.min),
+        max: parseValue(value.state.max),
         format: value.format,
       };
       return acc; // Return the accumulated range filters
@@ -100,7 +103,7 @@ export const filter = async (items, filters, config) => {
       for (const [key, value] of Object.entries(rangeFilters)) {
         // Function to parse value based on format
         const parseValue = (input) => {
-          return value.format === "date" ? dayjs(input).valueOf() : input;
+          return value.format === "date" ? dayjs(input).valueOf() : parseFloat(input);
         };
         const rangeValue = getValue(key, results[i]);
         if (rangeValue) {

--- a/elements/itemfilter/src/methods/itemfilter/filter-apply.js
+++ b/elements/itemfilter/src/methods/itemfilter/filter-apply.js
@@ -153,6 +153,24 @@ function filterApplyMethod(config, items, EOxItemFilter) {
         existingFilter?.state || {},
         filterProperty.state,
       );
+
+      if (filterProperty.type === "range" && filterProperty.state) {
+        const parseVal = (val) => {
+          return filterProperty.format === "date"
+            ? dayjs(val).valueOf()
+            : parseFloat(val);
+        };
+        if (filterProperty.state.min !== undefined) {
+          EOxItemFilter.filters[filterKey].state.min = parseVal(
+            filterProperty.state.min,
+          );
+        }
+        if (filterProperty.state.max !== undefined) {
+          EOxItemFilter.filters[filterKey].state.max = parseVal(
+            filterProperty.state.max,
+          );
+        }
+      }
     });
   }
 

--- a/elements/itemfilter/test/cases/filters/date-range-filter.js
+++ b/elements/itemfilter/test/cases/filters/date-range-filter.js
@@ -69,6 +69,49 @@ export function dateRangeFilterTest() {
 }
 
 /**
+ * Test case for date range filter initialization with pre-set state as strings
+ */
+export function preSetDateRangeFilterTest() {
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.items = [
+      { title: "Item 1", timestamp: "2021-01-01" },
+      { title: "Item 2", timestamp: "2021-01-10" },
+      { title: "Item 3", timestamp: "2021-01-20" },
+      { title: "Item 4", timestamp: "2021-01-30" },
+    ];
+    eoxItemFilter.filterProperties = [
+      {
+        key: "timestamp",
+        title: "Date Range",
+        type: "range",
+        format: "date",
+        expanded: true,
+        min: "2020-12-31",
+        max: "2021-01-10",
+        state: {
+          min: "2020-12-31",
+          max: "2021-01-10",
+        },
+      },
+    ];
+  });
+
+  // Check results: only first two items should be visible
+  cy.get("eox-itemfilter")
+    .shadow()
+    .find("eox-itemfilter-results")
+    .find("ul#results")
+    .within(() => {
+      cy.get("li").should("have.length", 2);
+      cy.contains("Item 1");
+      cy.contains("Item 2");
+      cy.contains("Item 3").should("not.exist");
+      cy.contains("Item 4").should("not.exist");
+    });
+}
+
+/**
  * Test case for date range filter integration with external search
  */
 export function externalDateRangeFilterTest() {

--- a/elements/itemfilter/test/cases/filters/index.js
+++ b/elements/itemfilter/test/cases/filters/index.js
@@ -3,6 +3,7 @@
 export { default as filterkeysTest } from "./filter-keys";
 export {
   dateRangeFilterTest,
+  preSetDateRangeFilterTest,
   externalDateRangeFilterTest,
 } from "./date-range-filter";
 export { rangeFilterTest } from "./range-filter";

--- a/elements/itemfilter/test/date-range-filter.cy.js
+++ b/elements/itemfilter/test/date-range-filter.cy.js
@@ -1,6 +1,7 @@
 import "../src/main";
 import {
   dateRangeFilterTest,
+  preSetDateRangeFilterTest,
   externalDateRangeFilterTest,
 } from "./cases/filters/";
 
@@ -18,6 +19,9 @@ describe("Item Filter Date Range", () => {
 
   it("should filter items using the date range picker", () =>
     dateRangeFilterTest());
+
+  it("should filter items with pre-set date range state", () =>
+    preSetDateRangeFilterTest());
 
   it("should filter items using the date range picker with external search", () =>
     externalDateRangeFilterTest());


### PR DESCRIPTION
## Problem

Presetting state of date range filter was not possible.

## Implemented changes

- Parse date strings in pre-set filter state to numerical timestamps.
- Prevents initial load failures where item numbers were compared against string boundaries.
- Update filter-client.js to parse bounds before comparison
- Update filter-apply.js to normalize state during bootstrap
- Add test for pre-set date range state

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
