### PR TITLE
fix(style): Increase max-height of expanded filter container to 400px

### DIFF
--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -99,7 +99,7 @@ li label {
   flex-direction: column;
 }
 eox-itemfilter-expandcontainer {
-  max-height: 300px;
+  max-height: 400px;
   width: 100%;
 }
 eox-itemfilter-expandcontainer > [data-type=filter] {


### PR DESCRIPTION
## Implemented changes

Quick fix: to fit 10 items (via "--select-filter-max-items": 10 css var) and avoid overflow:

## Screenshots/Videos
before:
<img width="594" height="1314" alt="image" src="https://github.com/user-attachments/assets/a4d3e6e7-e21c-4af3-857b-5a985ca2148c" />

after:
<img width="594" height="1314" alt="image" src="https://github.com/user-attachments/assets/ae536c38-ed0e-4a6b-89b8-42578a776def" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
