### PR TITLE
chore(docs): fix storybook 10.4+ rendering

### DIFF
--- a/.storybook/Types.jsx
+++ b/.storybook/Types.jsx
@@ -3,10 +3,22 @@ import { useOf } from "@storybook/addon-docs/blocks";
 import typedocJson from "../types.json";
 
 export const Types = ({ of }) => {
-  const { component } = useOf("component");
+  let component;
+  try {
+    const resolved = useOf("component", ["component"]);
+    component = resolved?.component;
+  } catch (e) {
+    // ignore
+  }
+
+  if (!component) {
+    return null;
+  }
+
   const hasTypes = Object.values(typedocJson.files.entries).find(
     (e) => e.includes(component.replace("eox-", "")) && e.includes(".ts"),
   );
+
   if (hasTypes) {
     return [
       <h3 id="types" key="title">
@@ -24,4 +36,6 @@ export const Types = ({ of }) => {
       ></iframe>,
     ];
   }
+
+  return null;
 };

--- a/.storybook/custom-panels/CodePanel.js
+++ b/.storybook/custom-panels/CodePanel.js
@@ -1,7 +1,10 @@
 import React, { useState } from "react";
 import { useChannel, useGlobals, useStorybookApi } from "storybook/manager-api";
-import { AddonPanel, Tabs } from "storybook/internal/components";
-import { Source } from "@storybook/addon-docs/blocks";
+import {
+  AddonPanel,
+  Tabs,
+  SyntaxHighlighter,
+} from "storybook/internal/components";
 
 export const CodePanel = (props) => {
   const api = useStorybookApi();
@@ -39,10 +42,13 @@ export const CodePanel = (props) => {
         <div id="vue" title="Vue"></div>
         <div id="svelte" title="Svelte"></div>
       </Tabs>
-      <Source
-        code={codeSnippet}
+      <SyntaxHighlighter
         language={selectedCodeLanguage === "react" ? "jsx" : "html"}
-      />
+        copyable
+        bordered
+      >
+        {codeSnippet}
+      </SyntaxHighlighter>
     </AddonPanel>
   );
 };

--- a/.storybook/custom-panels/DescriptionPanel.js
+++ b/.storybook/custom-panels/DescriptionPanel.js
@@ -1,7 +1,13 @@
 import React from "react";
 import { useStorybookApi } from "storybook/manager-api";
 import { AddonPanel } from "storybook/internal/components";
-import { Markdown } from "@storybook/addon-docs/blocks";
+import MarkdownIt from "markdown-it";
+
+const md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  typographer: true,
+});
 
 export const DescriptionPanel = (props) => {
   const api = useStorybookApi();
@@ -9,14 +15,18 @@ export const DescriptionPanel = (props) => {
   const storyData = api.getCurrentStoryData();
 
   if (!props.active || !storyData?.prepared) {
-    return;
+    return null;
   }
+
+  const storyDescription = storyData.parameters?.docs?.description?.story || "";
+  const renderedHtml = md.render(storyDescription);
 
   return (
     <AddonPanel {...props}>
-      <div style={{ padding: "10px 20px" }}>
-        <Markdown>{storyData.parameters?.docs?.description?.story}</Markdown>
-      </div>
+      <div
+        style={{ padding: "10px 20px" }}
+        dangerouslySetInnerHTML={{ __html: renderedHtml }}
+      />
     </AddonPanel>
   );
 };

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -32,6 +32,26 @@ const config = {
   addons: [getAbsolutePath("@storybook/addon-docs")],
   managerEntries: [join(import.meta.dirname, "./custom-panels/manager.js")],
   framework: getAbsolutePath("@storybook/web-components-vite"),
+  async viteFinal(config) {
+    config.build = config.build || {};
+    config.build.rollupOptions = config.build.rollupOptions || {};
+    config.build.rollupOptions.output = config.build.rollupOptions.output || {};
+
+    const manualChunksFn = (id) => {
+      if (id.includes("@mdx-js/react")) {
+        return "mdx-react";
+      }
+    };
+
+    if (Array.isArray(config.build.rollupOptions.output)) {
+      config.build.rollupOptions.output.forEach((opt) => {
+        opt.manualChunks = manualChunksFn;
+      });
+    } else {
+      config.build.rollupOptions.output.manualChunks = manualChunksFn;
+    }
+    return config;
+  },
   docs: {
     toc: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "cypress-lit": "^0.0.8",
         "cypress-network-idle": "^2.0.1",
         "eslint-plugin-storybook": "^10.0.8",
+        "markdown-it": "^14.1.1",
         "nodemon": "^3.0.3",
         "nyc": "^18.0.0",
         "prettier-plugin-svelte": "^3.4.0",
@@ -121,7 +122,7 @@
     },
     "elements/itemfilter": {
       "name": "@eox/itemfilter",
-      "version": "1.17.1",
+      "version": "1.17.3",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
         "@eox/ui": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@storybook/web-components-vite": "^10.0.8",
     "concurrently": "^9.0.0",
     "custom-elements-manifest": "^2.0.0",
+    "markdown-it": "^14.1.1",
     "cypress": "^15.0.0",
     "cypress-fail-on-console-error": "^5.1.1",
     "cypress-file-upload": "^5.0.8",


### PR DESCRIPTION
## Implemented changes

This PR fixes a browser crash (React Error # 130) that started occurring when loading the deployed Storybook 10.4+ in the browser. 

The error had two distinct causes introduced by recent minor package updates (including Vite 6/8 and its Rust-based **Rolldown** bundler transition):
1. **Manager UI Crash (Manager Side)**: Custom dashboard panels (`CodePanel.js` & `DescriptionPanel.js`) imported preview-only block components (`<Source>` and `<Markdown>`) from `@storybook/addon-docs/blocks`. In newer Storybook 10 versions, these dynamic blocks resolve to `undefined` in the Manager environment, throwing React Error # 130.
2. **Docs Tab Crash (Preview/Iframe Side)**: Under Rolldown, `@mdx-js/react` was code-split into the shared preview chunk but not listed in the public exports, causing `{ MDXProvider }` to be destructured as `undefined` at runtime inside `DocsRenderer`.
3. **Docs Types Fallback Crash**: The `<Types>` component in `Types.jsx` returned `undefined` when type definitions were absent (most stories / MDX pages), which is a fatal render crash in React.

<img width="2840" height="1614" alt="image" src="https://github.com/user-attachments/assets/5995fdea-d908-41ac-8966-5084decb1cbb" />


---

## Changes Made
This PR applies the **absolute minimum set of required changes** to resolve both issues:

### 🛠️ Storybook Manager UI
- **`.storybook/custom-panels/CodePanel.js`**: Swapped `<Source>` for the manager-safe `<SyntaxHighlighter>` component exported directly by `storybook/internal/components`.
- **`.storybook/custom-panels/DescriptionPanel.js`**: Swapped `<Markdown>` for lightweight `markdown-it` parsing loaded via `dangerouslySetInnerHTML`.
- **`package.json`**: Added `"markdown-it": "^14.1.1"` as a direct devDependency.

### 📦 Storybook Docs & Bundling (Rolldown Workaround)
- **`.storybook/main.js`**: Added a `viteFinal` customizer with a `manualChunks` function. This explicitly splits `@mdx-js/react` into its own isolated `mdx-react` chunk, guaranteeing that `MDXProvider` is correctly exported and preventing the Rolldown code-splitting export bug.
- **`.storybook/Types.jsx`**: Handled fallback conditions elegantly and added an explicit `return null;` (instead of implicitly returning `undefined`) when types are not resolved.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
