### PR TITLE
fix: bypass DOMPurify for code/markdown fields

### DIFF
--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -83,6 +83,26 @@ export const createEditor = (element) => {
     (schema) => schema.options?.resolver && schema.options.resolver,
   );
 
+  // Bypass purification for editors containing raw code/markdown/html (like Ace Editor)
+  // to prevent DOMPurify from stripping valid HTML/markdown/code tags
+  const originalPurify = JSONEditor.AbstractEditor.prototype.purify;
+  JSONEditor.AbstractEditor.prototype.purify = function (val) {
+    const isCodeFormat = [
+      "html",
+      "markdown",
+      "javascript",
+      "json",
+      "css",
+      "yaml",
+      "xml",
+    ].includes(this.input_type || this.format);
+
+    if (this.ace_editor_instance || isCodeFormat) {
+      return val;
+    }
+    return originalPurify.call(this, val);
+  };
+
   // Custom theme modifications for EOxUI for grid layout
   JSONEditor.defaults.themes.html.prototype.setGridColumnSize = (
     el,

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -87,6 +87,7 @@ export const createEditor = (element) => {
   // to prevent DOMPurify from stripping valid HTML/markdown/code tags
   const originalPurify = JSONEditor.AbstractEditor.prototype.purify;
   JSONEditor.AbstractEditor.prototype.purify = function (val) {
+    const format = this.input_type || this.format || this.schema?.format;
     const isCodeFormat = [
       "html",
       "markdown",
@@ -95,7 +96,7 @@ export const createEditor = (element) => {
       "css",
       "yaml",
       "xml",
-    ].includes(this.input_type || this.format);
+    ].includes(format);
 
     if (this.ace_editor_instance || isCodeFormat) {
       return val;

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -8,6 +8,7 @@ export { default as loadReRenderFormOnChangeTest } from "./re-render-form-on-cha
 export { default as loadMarkdownTest } from "./load-markdown";
 export { default as loadCodeMarkdownToolbarTest } from "./load-code-markdown-toolbar";
 export { default as loadCodeTest } from "./load-code";
+export { default as loadCodeHTMLTest } from "./load-code-html";
 export { default as triggerChangeEventTest } from "./trigger-change-event";
 export { default as loadValuesTest } from "./load-values";
 export { default as loadMisMatchingValuesTest } from "./load-mismatching-values";

--- a/elements/jsonform/test/cases/load-code-html.js
+++ b/elements/jsonform/test/cases/load-code-html.js
@@ -1,0 +1,47 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+const testVals = {
+  key: "foo",
+  value: "<div><span class='test'>test</span></div>",
+};
+
+/**
+ * Test to verify if HTML code inside the code/ace editor is preserved.
+ */
+const loadCodeHTMLTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "html",
+            options: {
+              resolver: "ace",
+            },
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: testVals.value,
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  // Find the jsonForm element and access its shadow DOM
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      // Check if Ace editor has loaded
+      cy.get(".ace_editor").should("exist");
+      // Check if raw HTML markup was rendered correctly and NOT stripped by DOMPurify
+      cy.get(".ace_content").invoke("text").should("contain", testVals.value);
+    });
+};
+
+export default loadCodeHTMLTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -16,6 +16,7 @@ import {
   loadCustomEditorInterfaceTest,
   loadSubmitButtonTest,
   loadCodeTest,
+  loadCodeHTMLTest,
   loadShowOptInPropertiesTest,
   loadButtonsEditorTest,
   loadSpatialValuesTest,
@@ -43,6 +44,7 @@ describe("Jsonform", () => {
   it("loads the code markdown toolbar", () => loadCodeMarkdownToolbarTest());
   it("loads the markdown editor", () => loadMarkdownTest());
   it("loads the code editor", () => loadCodeTest());
+  it("preserves HTML markup inside code editor", () => loadCodeHTMLTest());
   it("triggers a change event when typing", () => triggerChangeEventTest());
   it("loads values", () => loadValuesTest());
   it("loads mismatching values", () => loadMisMatchingValuesTest());


### PR DESCRIPTION
## Implemented changes

When attempting to set HTML/markdown values in an Ace editor (or other code/markdown fields) inside `eox-jsonform`, the HTML is stripped out.

This occurs because importing `isomorphic-dompurify` registers `window.DOMPurify` globally. Under the hood, JSONEditor's base `AbstractEditor.prototype.purify` detects `window.DOMPurify` and automatically sanitizes the raw string value of **all** string-type inputs, treating them as active HTML and stripping valid tags, styles, or scripts from custom-input code sessions.

### Fix

This PR overrides `JSONEditor.AbstractEditor.prototype.purify` inside `elements/jsonform/src/helpers/editor.js` to bypass sanitization specifically when:

1. An active `ace_editor_instance` is being used.
2. The schema/editor format matches standard markup or programming languages (`html`, `markdown`, `javascript`, `json`, `css`, `yaml`, `xml`).

This ensures safe defense-in-depth sanitization continues for standard string elements, while leaving raw user code intact.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
