### PR TITLE
feat: blocks support

### DIFF
--- a/elements/storytelling/src/helpers/blocks-to-markdown.js
+++ b/elements/storytelling/src/helpers/blocks-to-markdown.js
@@ -1,0 +1,163 @@
+/**
+ * Compiles a flat object of properties into a string of HTML comment attributes.
+ *
+ * @param {Object} props - The properties to compile.
+ * @returns {string} The compiled attributes string.
+ */
+function compileAttributes(props) {
+  const parts = [];
+  for (const [key, value] of Object.entries(props)) {
+    if (value === undefined || value === null) continue;
+
+    if (typeof value === "object" || Array.isArray(value)) {
+      // Use single quotes for stringified JSON arrays/objects to prevent breaking HTML comment formatting
+      parts.push(`${key}='${JSON.stringify(value)}'`);
+    } else if (typeof value === "string") {
+      parts.push(`${key}="${value.replace(/"/g, "&quot;")}"`);
+    } else {
+      parts.push(`${key}=${value}`);
+    }
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Translates an array of block-based A2UI JSON structures into a standard storytelling Markdown string.
+ *
+ * @param {Array<Object>} blocks - The array of storytelling blocks.
+ * @returns {string} Compiled Markdown string.
+ */
+export function blocksToMarkdown(blocks) {
+  if (!blocks || !Array.isArray(blocks)) return "";
+
+  return blocks
+    .map((block) => {
+      if (!block || !block.type) return "";
+
+      const props = block.props || {};
+
+      switch (block.type) {
+        case "hero-image":
+        case "hero-video": {
+          const isVideo = block.type === "hero-video";
+          const tagName = isVideo ? "video" : "img";
+          const heroTitle = props.title || "";
+          const heroDesc = props.description || "";
+
+          const attrProps = {
+            as: tagName,
+            mode: "hero",
+            src: props.src,
+            "data-fallback-src":
+              props.fallbackSrc || props["data-fallback-src"],
+            style: props.style,
+            class: props.class,
+          };
+
+          let md = `# ${heroTitle} <!--{ ${compileAttributes(attrProps)} }-->`;
+          if (heroDesc) {
+            md += `\n### ${heroDesc} <!--{ style="font-size:1rem;opacity:0.7;margin-top:1rem;" }-->`;
+          }
+          return md;
+        }
+
+        case "text":
+          return props.markdown || "";
+
+        case "eox-map":
+        case "img": {
+          const isTour = props.mode === "tour";
+          const tagName = block.type;
+          const sectionTitle = props.title || "";
+          const sectionDesc = props.description || "";
+
+          if (isTour) {
+            const generalProps = {
+              as: tagName,
+              mode: "tour",
+              style: props.style,
+              class: props.class,
+            };
+
+            let md = `## ${sectionTitle} <!--{ ${compileAttributes(generalProps)} }-->`;
+            if (sectionDesc) {
+              md += `\n${sectionDesc}`;
+            }
+
+            if (props.steps && Array.isArray(props.steps)) {
+              props.steps.forEach((step) => {
+                const stepProps = {
+                  // eox-map properties
+                  layers: step.layers,
+                  center: step.center,
+                  zoom: step.zoom,
+                  animationOptions: step.animationOptions,
+                  // img properties
+                  src: step.src,
+                  style: step.style,
+                };
+
+                md += `\n\n### <!--{ ${compileAttributes(stepProps)} }-->`;
+                if (step.title) {
+                  md += `\n#### ${step.title}`;
+                }
+                if (step.description) {
+                  md += `\n${step.description}`;
+                }
+              });
+            }
+            return md;
+          } else {
+            // Standard non-tour map or image
+            const attrProps = {
+              as: tagName,
+              style:
+                props.style ||
+                (tagName === "eox-map" ? "width: 100%; height: 500px;" : ""),
+              class: props.class,
+              // Map-specific standard props
+              layers: props.layers,
+              zoom: props.zoom,
+              center: props.center,
+              // Image-specific standard props
+              src: props.src,
+              "data-fallback-src":
+                props.fallbackSrc || props["data-fallback-src"],
+              ...props,
+            };
+            delete attrProps.title;
+            delete attrProps.description;
+
+            return `## ${sectionTitle} <!--{ ${compileAttributes(attrProps)} }-->`;
+          }
+        }
+
+        case "eox-chart": {
+          const chartTitle = props.title || "";
+          const attrProps = {
+            as: "eox-chart",
+            style: props.style || "width: 100%; height: 400px;",
+            class: props.class,
+            spec: props.spec,
+          };
+
+          return `## ${chartTitle} <!--{ ${compileAttributes(attrProps)} }-->`;
+        }
+
+        default: {
+          // Fallback generic custom component translation
+          const genericTitle = props.title || "";
+          const attrProps = {
+            as: block.type,
+            style: props.style,
+            class: props.class,
+            ...props,
+          };
+          delete attrProps.title; // Avoid duplicating the title inside comments if parsed as attribute
+
+          return `## ${genericTitle} <!--{ ${compileAttributes(attrProps)} }-->`;
+        }
+      }
+    })
+    .join("\n\n");
+}

--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -1,5 +1,6 @@
 export { default as loadMarkdownURL } from "./load-markdown-url.js";
 export { renderHtmlString, parseNavWithAddSection } from "./render-html-string";
+export { blocksToMarkdown } from "./blocks-to-markdown";
 export {
   scrollAnchorClickEvent,
   scrollIntoView,

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -13,6 +13,7 @@ import {
   addLightBoxScript,
   addCustomSection,
   initSavedMarkdown,
+  blocksToMarkdown,
 } from "./helpers";
 import DOMPurify from "isomorphic-dompurify";
 import {
@@ -63,6 +64,7 @@ export class EOxStoryTelling extends LitElement {
     return {
       markdown: { attribute: "markdown", type: String },
       markdownURL: { attribute: "markdown-url", type: String },
+      blocks: { attribute: "blocks", type: Array },
       nav: { state: true, attribute: false, type: Array },
       showNav: { attribute: "show-nav", type: Boolean },
       showEditor: { attribute: "show-editor", type: String },
@@ -110,6 +112,11 @@ export class EOxStoryTelling extends LitElement {
      * @type {String} - Markdown Content URL
      */
     this.markdownURL = null;
+
+    /**
+     * @type {Array<Object>} - Story blocks JSON
+     */
+    this.blocks = null;
 
     /**
      * Render the element without additional styles
@@ -217,6 +224,15 @@ export class EOxStoryTelling extends LitElement {
    * @param {Map} changedProperties - A map of changed properties.
    */
   async updated(changedProperties) {
+    // Compile JSON blocks to Markdown if `blocks` property changed
+    if (changedProperties.has("blocks") && this.blocks) {
+      const compiledMarkdown = blocksToMarkdown(this.blocks);
+      if (this.markdown !== compiledMarkdown) {
+        this.markdown = compiledMarkdown;
+        this.requestUpdate();
+      }
+    }
+
     // Attempt to fetch new markdown content from the URL if `markdownURL` changed
     if (changedProperties.has("markdownURL") && this.markdownURL) {
       this.markdown =

--- a/elements/storytelling/stories/blocks-showcase.js
+++ b/elements/storytelling/stories/blocks-showcase.js
@@ -1,0 +1,234 @@
+import { html } from "lit";
+
+export const BlocksShowcase = {
+  argTypes: {
+    blocks: {
+      table: {
+        category: "properties",
+      },
+    },
+  },
+  args: {
+    blocks: [
+      {
+        type: "hero-video",
+        props: {
+          title: "Welcome to Storytelling",
+          src: "https://dlmultimedia.esa.int/download/public/videos/2023/06/010/2306_010_AR_EN.mp4",
+          description:
+            "An introduction on how to write interactive and multimedial stories using structured JSON blocks. Scroll down to get started!",
+        },
+      },
+      {
+        type: "text",
+        props: {
+          markdown: `
+## Why storytelling?
+
+Storytelling is crucial in the realm of science because scientific data, while rich in information, can often be complex and challenging to communicate. By framing data within narratives, storytelling makes scientific concepts accessible, engaging, and memorable to a wider audience. It bridges the gap between the technical details of research and the public's understanding, fostering appreciation, curiosity, and ultimately, a deeper connection to the wonders of science.
+
+Specifically, **scrolly**telling[^1] adds another layer of engagement, which allows the user to interact with the website by simply scrolling through it.
+
+[^1]: Blend of *scroll* + *storytelling*. [Storytelling enriched with multimedial elements triggered while scrolling down a webpage](https://en.wiktionary.org/wiki/scrollytelling).
+`,
+        },
+      },
+      {
+        type: "text",
+        props: {
+          markdown: `
+## Structured Block Composition
+
+This entire storytelling page was generated from a **clean, structured JSON array** (A2UI format) instead of direct raw Markdown compilation.
+
+### Why Structured Blocks?
+- **AI Agent-Friendly:** LLMs are exceptionally good at returning exact structured JSON schemas, eliminating the risk of malformed HTML comments.
+- **Dynamic Content Updates:** The agent can stream updates of specific blocks (like changing coordinates on a map or adding a section) securely.
+- **Standardized Prototyping:** Separates block-level content structures from prose formatting.
+`,
+        },
+      },
+      {
+        type: "text",
+        props: {
+          markdown: `
+## Story structure
+### The hero
+The hero is the initial section of a story. It can be either a full-screen image or a full-screen video, with some overlaying text.
+
+### Story sections
+Each section represents a structured piece of the narrative document, which can easily be managed, re-ordered, or modified dynamically by a co-pilot chat agent.
+`,
+        },
+      },
+      {
+        type: "eox-map",
+        props: {
+          title: "Map section",
+          class: "overlay-br",
+          style: "width: 100%; height: 500px;",
+          config: {
+            controls: {
+              Zoom: {},
+              Attribution: {},
+              FullScreen: {},
+              OverviewMap: {
+                layers: [
+                  {
+                    type: "Tile",
+                    properties: { id: "overviewMap" },
+                    source: { type: "OSM" },
+                  },
+                ],
+              },
+            },
+            layers: [
+              {
+                type: "Tile",
+                properties: { id: "overviewMap" },
+                source: {
+                  type: "TileWMS",
+                  url: "https://ows.mundialis.de/services/service",
+                  params: { LAYERS: "TOPO-WMS" },
+                },
+              },
+            ],
+            view: {
+              center: [15, 48],
+              zoom: 1,
+            },
+          },
+          description:
+            '### Some title for map <!--{ style="color: white; font-size: 1.25rem;" }-->\nLorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->',
+        },
+      },
+      {
+        type: "eox-map",
+        props: {
+          title: "Map Tour section",
+          class: "overlay-br",
+          mode: "tour",
+          description:
+            'Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <!--{ style="opacity: 0.75; font-size: 1rem;" }-->',
+          steps: [
+            {
+              title: "This is a map tour.",
+              description:
+                "It allows you to have different layers, zoom and center settings for each tour 'step'.",
+              center: [12.46, 41.89],
+              zoom: 5,
+              layers: [
+                {
+                  type: "Tile",
+                  properties: { id: "osm" },
+                  source: { type: "OSM" },
+                },
+              ],
+              animationOptions: { duration: 500 },
+            },
+            {
+              title: "Second tour step.",
+              description:
+                "Each tour step is described as an item in the steps array.",
+              center: [12.46, 41.89],
+              zoom: 10,
+              layers: [
+                {
+                  type: "Tile",
+                  properties: { id: "osm" },
+                  source: { type: "OSM" },
+                },
+                {
+                  type: "Tile",
+                  properties: { id: "customId" },
+                  source: {
+                    type: "WMTSCapabilities",
+                    url: "https://tiles.maps.eox.at/wmts/1.0.0/WMTSCapabilities.xml",
+                    layer: "s2cloudless-2017",
+                  },
+                },
+              ],
+            },
+            {
+              title: "Third tour step.",
+              description:
+                "To change individual parameters like zoom or center, or to change the map layers for a step, just set them using the HTML comment syntax. This changes the map setting for the current map.",
+              center: [16.36, 48.2],
+              zoom: 10,
+              layers: [
+                {
+                  type: "Tile",
+                  properties: { id: "osm" },
+                  source: { type: "OSM" },
+                },
+                {
+                  type: "Tile",
+                  properties: { id: "customId" },
+                  source: {
+                    type: "WMTSCapabilities",
+                    url: "https://tiles.maps.eox.at/wmts/1.0.0/WMTSCapabilities.xml",
+                    layer: "s2cloudless-2017",
+                  },
+                },
+              ],
+              animationOptions: { duration: 500 },
+            },
+          ],
+        },
+      },
+      {
+        type: "img",
+        props: {
+          title: "Image Tour section",
+          mode: "tour",
+          steps: [
+            {
+              title: "This is an image tour.",
+              description:
+                "It allows you to have different sources for each tour 'step'.",
+              src: "https://picsum.photos/800/600",
+              style: "background: #fff0c4;",
+            },
+            {
+              title: "Second tour step.",
+              description:
+                "Each tour step is described as an h3 heading behind the scenes.",
+              src: "https://picsum.photos/900/700",
+              style: "background: #ffe7ef;",
+            },
+            {
+              title: "Third tour step.",
+              description:
+                "The tour transitions smoothly as the user scrolls down the page.",
+              src: "https://picsum.photos/900/800",
+              style: "background: #e2fffc;",
+            },
+          ],
+        },
+      },
+      {
+        type: "text",
+        props: {
+          markdown: `
+## Final Words
+Hopefully, this was a good introduction to the story writing possibilities using structured blocks in EOxStorytelling - get started writing your own story!
+More features will be added soon, so feel free to follow progress at the [EOxElements GitHub repository](https://github.com/EOX-A/EOxElements).
+`,
+        },
+      },
+    ],
+    id: "blocks-showcase",
+    showNav: true,
+    showHeroScrollIndicator: true,
+  },
+  render: (args) => html`
+    <eox-storytelling
+      id=${args.id}
+      ?show-nav=${args.showNav}
+      ?show-hero-scroll-indicator=${args.showHeroScrollIndicator}
+      .blocks=${args.blocks}
+    ></eox-storytelling>
+  `,
+};
+
+export default BlocksShowcase;

--- a/elements/storytelling/stories/index.js
+++ b/elements/storytelling/stories/index.js
@@ -9,3 +9,4 @@ export { default as MarkdownMapTourStory } from "./markdown-map-tour"; // StoryT
 export { default as MarkdownImageTourStory } from "./markdown-image-tour"; // StoryTelling with image tour
 export { default as MarkdownShowcaseStory } from "./markdown-showcase"; // StoryTelling with complex markdown and tour
 export { default as MarkdownInitEventStory } from "./markdown-init-event"; // StoryTelling with init event
+export { default as BlocksShowcaseStory } from "./blocks-showcase"; // StoryTelling with block JSON payload

--- a/elements/storytelling/stories/storytelling.stories.js
+++ b/elements/storytelling/stories/storytelling.stories.js
@@ -12,6 +12,7 @@ import {
   MarkdownImageTourStory,
   MarkdownShowcaseStory,
   MarkdownInitEventStory,
+  BlocksShowcaseStory,
 } from "./index";
 import { html } from "lit";
 
@@ -95,3 +96,10 @@ export const MarkdownInitEvent = MarkdownInitEventStory;
  * A comprehensive example combining a hero section, standard markdown with configuration, a map section, a map tour, and an image tour all in one story.
  */
 export const MarkdownShowcase = MarkdownShowcaseStory;
+
+/**
+ * Blocks-based Storytelling Showcase (A2UI).
+ * Demonstrates how to configure and render the storytelling component entirely via a structured JSON array (the `.blocks` property).
+ * This eliminates the need for the LLM or client application to generate HTML comments or raw markdown wrappers.
+ */
+export const BlocksShowcase = BlocksShowcaseStory;

--- a/elements/storytelling/test/cases/index.js
+++ b/elements/storytelling/test/cases/index.js
@@ -13,3 +13,4 @@ export { default as loadMapTourTest } from "./load-map-tour";
 export { default as loadHeroSectionTest } from "./load-hero-section";
 export { default as loadMarkdownLightBoxTest } from "./load-lightbox";
 export { default as loadMarkdownErrorStory } from "./load-error";
+export { default as loadBlocksTest } from "./load-blocks";

--- a/elements/storytelling/test/cases/load-blocks.js
+++ b/elements/storytelling/test/cases/load-blocks.js
@@ -1,0 +1,79 @@
+import { TEST_SELECTORS } from "../../src/enums";
+import "../../../map/src/main";
+
+// Destructure TEST_SELECTORS object
+const { storyTelling } = TEST_SELECTORS;
+
+/**
+ * Ensure the storytelling component successfully loads and compiles blocks
+ */
+const loadBlocksTest = () => {
+  cy.mount(`<eox-storytelling id="blocks-test"></eox-storytelling>`).as(
+    storyTelling,
+  );
+
+  const testBlocks = [
+    {
+      type: "hero-image",
+      props: {
+        title: "Dynamic Hero Title",
+        src: "https://www.gstatic.com/prettyearth/assets/full/14617.jpg",
+        description: "Dynamic Hero Desc",
+      },
+    },
+    {
+      type: "text",
+      props: {
+        markdown:
+          "This is a paragraph with **bold text** generated from JSON blocks.",
+      },
+    },
+    {
+      type: "eox-map",
+      props: {
+        title: "Standard Map Block",
+        zoom: 6,
+        center: [16, 48],
+        layers: [
+          {
+            type: "Tile",
+            properties: { id: "osm" },
+            source: { type: "OSM" },
+          },
+        ],
+      },
+    },
+  ];
+
+  cy.get(storyTelling).then(($el) => {
+    $el[0].blocks = testBlocks;
+  });
+
+  cy.get(storyTelling)
+    .shadow()
+    .within(() => {
+      // 1. Verify hero section is rendered
+      cy.get("h1").should("contain.text", "Dynamic Hero Title");
+      cy.get("h3").should("contain.text", "Dynamic Hero Desc");
+      cy.get("img[mode='hero']").should(
+        "have.attr",
+        "src",
+        "https://www.gstatic.com/prettyearth/assets/full/14617.jpg",
+      );
+
+      // 2. Verify text section with bold text is rendered
+      cy.get("p").should("contain.text", "generated from JSON blocks.");
+      cy.get("strong").should("contain.text", "bold text");
+
+      // 3. Verify eox-map is instantiated with the correct zoom and center properties
+      cy.get("eox-map").should("exist");
+      cy.get("eox-map").then(($eoxMap) => {
+        expect($eoxMap[0].zoom).to.eq(6);
+        const mapCenter = $eoxMap[0].map.getView().getCenter();
+        expect(mapCenter[0]).to.be.closeTo(1781111.85, 100);
+        expect(mapCenter[1]).to.be.closeTo(6106854.83, 100);
+      });
+    });
+};
+
+export default loadBlocksTest;

--- a/elements/storytelling/test/general.cy.js
+++ b/elements/storytelling/test/general.cy.js
@@ -15,6 +15,7 @@ import {
   loadHeroSectionTest,
   loadMarkdownLightBoxTest,
   loadMarkdownErrorStory,
+  loadBlocksTest,
 } from "./cases";
 
 // Test suite for Storytelling
@@ -59,4 +60,7 @@ describe("Storytelling", () => {
 
   // Test case to ensure markdown error loaded
   it("Load markdown error", () => loadMarkdownErrorStory());
+
+  // Test case to ensure blocks configuration is correctly translated and rendered
+  it("loads structured JSON blocks", () => loadBlocksTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR introduces support for a declarative, structured block-based layout property (`blocks`) on the `<eox-storytelling>` component.

By accepting an array of JSON blocks (A2UI-like format), AI agents and conversational interfaces can now seamlessly generate, update, and modify narrative pages without having to deal with complex, fragile HTML comments and raw Markdown formatting.

Under the hood, the blocks array is compiled into the standard Markdown layout and assigned to the `.markdown` property, rendering the layout seamlessly while maintaining full, instant backward compatibility and raw `.md` export capabilities.

### Key Changes

- **New Translator Helper:** Added `elements/storytelling/src/helpers/blocks-to-markdown.js` to serialize JSON blocks (supporting `hero-image`, `hero-video`, `text`, non-tour maps with custom controls, map tours with dynamic steps, image tours, and generic custom components) into standard storytelling Markdown.
- **Component Property Added:** Declared the reactive `blocks` property (`type: Array`) inside `eox-storytelling` (in `src/main.js`).
- **Reactive Synchronization:** Watches for changes on `.blocks` in the `updated` lifecycle hook and recompiles it into `.markdown` safely without infinite loops.
- **Storybook Showcase:** Fully upgraded `stories/blocks-showcase.js` to match the complex `markdown-showcase` story 1-to-1 using structured JSON blocks (including hero sections, standard maps with controls, map tours, and image tours).
- **Component Testing:** Created a Cypress component test case `test/cases/load-blocks.js` asserting correct compilation, rendering, zoom levels, and coordinates.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
