### PR TITLE
fix: Hide attribution control when empty

### DIFF
--- a/elements/map/src/controls/controls.css
+++ b/elements/map/src/controls/controls.css
@@ -276,6 +276,10 @@
   display: flex !important;
   align-items: center;
 }
+/* Hide the empty box when there are no attributions. */
+.ol-attribution:not(:has(li)) {
+  display: none !important;
+}
 .ol-attribution button {
   margin: 0;
 }

--- a/elements/map/test/cases/controls/index.js
+++ b/elements/map/test/cases/controls/index.js
@@ -6,3 +6,4 @@ export { default as setDefaultLoadingIndicator } from "./set-default-loading-ind
 export { default as setCustomFullScreenLoadingIndicator } from "./set-custom-fullscreen-loading-indicator";
 export { default as setLayoutControls } from "./set-layout-controls";
 export { default as setSlottedControls } from "./set-slotted-controls";
+export { default as setAttributionVisibility } from "./set-attribution-visibility";

--- a/elements/map/test/cases/controls/set-attribution-visibility.js
+++ b/elements/map/test/cases/controls/set-attribution-visibility.js
@@ -1,0 +1,53 @@
+import { html } from "lit";
+
+/**
+ * Tests that the attribution control is hidden when there are no attributions
+ * and shown once a layer provides one.
+ */
+const setAttributionVisibility = () => {
+  cy.mount(
+    html`<eox-map
+      .layers=${[
+        {
+          type: "Tile",
+          properties: { id: "noAttribution" },
+          source: { type: "XYZ", url: "https://example.com/{z}/{x}/{y}.png" },
+        },
+      ]}
+      .controls=${{ Attribution: {} }}
+    ></eox-map>`,
+  ).as("eox-map");
+
+  cy.get("eox-map").should(($el) => {
+    const attribution = $el[0].shadowRoot.querySelector(".ol-attribution");
+    expect(attribution, "attribution control exists").to.exist;
+    expect(
+      getComputedStyle(attribution).display,
+      "hidden when there are no attributions",
+    ).to.equal("none");
+  });
+
+  cy.get("eox-map").then(($el) => {
+    $el[0].layers = [
+      {
+        type: "Tile",
+        properties: { id: "with-attribution" },
+        source: {
+          type: "XYZ",
+          url: "https://example.com/{z}/{x}/{y}.png",
+          attributions: "Test Attribution",
+        },
+      },
+    ];
+  });
+
+  cy.get("eox-map").should(($el) => {
+    const attribution = $el[0].shadowRoot.querySelector(".ol-attribution");
+    expect(
+      getComputedStyle(attribution).display,
+      "visible once a layer provides an attribution",
+    ).to.equal("flex");
+  });
+};
+
+export default setAttributionVisibility;

--- a/elements/map/test/controls.cy.js
+++ b/elements/map/test/controls.cy.js
@@ -1,5 +1,6 @@
 import "../src/main";
 import {
+  setAttributionVisibility,
   setBasicControls,
   setCustomFullScreenLoadingIndicator,
   setDefaultLoadingIndicator,
@@ -42,4 +43,9 @@ describe("webcomponent property parsing", () => {
    */
   it("Custom Full Screen Loading Indicator Control", () =>
     setCustomFullScreenLoadingIndicator());
+
+  /**
+   * Test case that the attribution control hides when there are no attributions
+   */
+  it("Attribution visibility when empty", () => setAttributionVisibility());
 });


### PR DESCRIPTION
## Implemented changes

`.ol-attribution { display: flex !important }` overrode OpenLayers' inline `display:none`  that OL sets when there are no attributions, leaving a stray empty control box. This Adds .ol-attribution:not(:has(li)) to hide it when its list is empty (collapsed-with-content and real attributions unaffected).

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
