### PR TITLE
fix: Clear duplicate select (click & hover) highlights

### DIFF
--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -80,9 +80,7 @@ export class EOxSelectInteraction {
     const pointerLeaveListener = () => {
       if (options.condition !== "pointermove") return;
       overlay?.setPosition(undefined);
-      // Clear the hover highlight when the pointer leaves the map, otherwise it
-      // stays stuck (and stacks with other highlights) once the pointer moves
-      // off the map.
+      // Clear the hover highlight, otherwise it stays stuck
       if (this.selectedFids?.length) {
         this.selectedFids = [];
         this.selectStyleLayer?.changed();
@@ -533,8 +531,7 @@ export class EOxSelectInteraction {
       this.selectLayer instanceof VectorTile
     ) {
       this.selectStyleLayer.setMap(null);
-      // Without this, the orphaned listener re-attaches this dead style layer
-      // (and its stale highlight) whenever a layer with the same id reappears.
+      // Drop the listener so the dead style layer doesnt re-attach.
       this.eoxMap.map.getLayerGroup().un("change", this.changeLayerListener);
       delete this.eoxMap.selectInteractions[this.options.id];
       this.selectLayer.un("change:source", this.changeSourceListener);

--- a/elements/map/src/helpers/select.js
+++ b/elements/map/src/helpers/select.js
@@ -78,8 +78,14 @@ export class EOxSelectInteraction {
     }
     // Set up event listeners to handle pointer leave events
     const pointerLeaveListener = () => {
-      if (overlay && options.condition === "pointermove") {
-        overlay.setPosition(undefined);
+      if (options.condition !== "pointermove") return;
+      overlay?.setPosition(undefined);
+      // Clear the hover highlight when the pointer leaves the map, otherwise it
+      // stays stuck (and stacks with other highlights) once the pointer moves
+      // off the map.
+      if (this.selectedFids?.length) {
+        this.selectedFids = [];
+        this.selectStyleLayer?.changed();
       }
     };
     eoxMap.map.on("change:target", (e) => {
@@ -282,7 +288,7 @@ export class EOxSelectInteraction {
       this.selectLayer.on("change:source", this.changeSourceListener);
 
       // Set up the map event listener for the specified condition (e.g., click, pointermove)
-      const changeLayerListener = () => {
+      this.changeLayerListener = () => {
         if (eoxMap.getLayerById(anyLayer.get("id"))) {
           // If a select layer exists, keep it in current activation state
           // (active/inactive) and assign it (and the overlay) to the map
@@ -295,7 +301,7 @@ export class EOxSelectInteraction {
           overlay?.setMap(null);
         }
       };
-      eoxMap.map.getLayerGroup().on("change", changeLayerListener);
+      eoxMap.map.getLayerGroup().on("change", this.changeLayerListener);
 
       /**
        * Adds a listener on pointermove
@@ -527,6 +533,9 @@ export class EOxSelectInteraction {
       this.selectLayer instanceof VectorTile
     ) {
       this.selectStyleLayer.setMap(null);
+      // Without this, the orphaned listener re-attaches this dead style layer
+      // (and its stale highlight) whenever a layer with the same id reappears.
+      this.eoxMap.map.getLayerGroup().un("change", this.changeLayerListener);
       delete this.eoxMap.selectInteractions[this.options.id];
       this.selectLayer.un("change:source", this.changeSourceListener);
       this.eoxMap.map.un("pointermove", this.pointerMoveListener);

--- a/elements/map/test/cases/hover/clear-hover-highlight-on-pointer-leave.js
+++ b/elements/map/test/cases/hover/clear-hover-highlight-on-pointer-leave.js
@@ -3,9 +3,8 @@ import ecoRegionsFixture from "../../fixtures/ecoregions.json";
 import vectorLayerJson from "../../fixtures/vectorLayer.json";
 
 /**
- * A pointermove (hover) select interaction must clear its highlight when the
- * pointer leaves the map, otherwise the highlight stays stuck (and stacks with
- * other highlights) once the pointer moves off the map.
+ * A hover (pointermove) interaction must clear its highlight when the pointer
+ * leaves the map.
  */
 const clearHoverHighlightOnPointerLeave = () => {
   cy.intercept("https://openlayers.org/data/vector/ecoregions.json", (req) => {
@@ -33,11 +32,9 @@ const clearHoverHighlightOnPointerLeave = () => {
     const interaction = eoxMap.selectInteractions.hoverInteraction;
     expect(interaction, "hover interaction created").to.exist;
 
-    // Simulate a hover highlight.
     interaction.highlightById(["someFeatureId"]);
     expect(interaction.selectedFids, "highlight set").to.have.length(1);
 
-    // Pointer leaves the map -> highlight must be cleared.
     eoxMap.map
       .getTargetElement()
       .dispatchEvent(new PointerEvent("pointerleave"));

--- a/elements/map/test/cases/hover/index.js
+++ b/elements/map/test/cases/hover/index.js
@@ -2,6 +2,7 @@
 
 export { default as addSelectInteraction } from "./add-select-interaction";
 export { default as selectAfterReArrangingLayers } from "./select-after-re-arranging-layers";
+export { default as clearHoverHighlightOnPointerLeave } from "./clear-hover-highlight-on-pointer-leave";
 export { default as displayTooltip } from "./display-tooltip";
 export { default as displayCustomTooltip } from "./display-custom-tooltip";
 export { default as disableTooltip } from "./disable-tooltip";

--- a/elements/map/test/cases/select/clear-hover-highlight-on-pointer-leave.js
+++ b/elements/map/test/cases/select/clear-hover-highlight-on-pointer-leave.js
@@ -24,9 +24,9 @@ const clearHoverHighlightOnPointerLeave = () => {
     },
   ];
 
-  cy.mount(
-    html`<eox-map .center=${[0, 0]} .layers=${styleJson}></eox-map>`,
-  ).as("eox-map");
+  cy.mount(html`<eox-map .center=${[0, 0]} .layers=${styleJson}></eox-map>`).as(
+    "eox-map",
+  );
 
   cy.get("eox-map").and(($el) => {
     const eoxMap = $el[0];

--- a/elements/map/test/cases/select/clear-hover-highlight-on-pointer-leave.js
+++ b/elements/map/test/cases/select/clear-hover-highlight-on-pointer-leave.js
@@ -1,0 +1,51 @@
+import { html } from "lit";
+import ecoRegionsFixture from "../../fixtures/ecoregions.json";
+import vectorLayerJson from "../../fixtures/vectorLayer.json";
+
+/**
+ * A pointermove (hover) select interaction must clear its highlight when the
+ * pointer leaves the map, otherwise the highlight stays stuck (and stacks with
+ * other highlights) once the pointer moves off the map.
+ */
+const clearHoverHighlightOnPointerLeave = () => {
+  cy.intercept("https://openlayers.org/data/vector/ecoregions.json", (req) => {
+    req.reply(ecoRegionsFixture);
+  });
+
+  const styleJson = JSON.parse(JSON.stringify(vectorLayerJson));
+  styleJson[0].interactions = [
+    {
+      type: "select",
+      options: {
+        id: "hoverInteraction",
+        condition: "pointermove",
+        style: { "stroke-color": "white", "stroke-width": 3 },
+      },
+    },
+  ];
+
+  cy.mount(
+    html`<eox-map .center=${[0, 0]} .layers=${styleJson}></eox-map>`,
+  ).as("eox-map");
+
+  cy.get("eox-map").and(($el) => {
+    const eoxMap = $el[0];
+    const interaction = eoxMap.selectInteractions.hoverInteraction;
+    expect(interaction, "hover interaction created").to.exist;
+
+    // Simulate a hover highlight.
+    interaction.highlightById(["someFeatureId"]);
+    expect(interaction.selectedFids, "highlight set").to.have.length(1);
+
+    // Pointer leaves the map -> highlight must be cleared.
+    eoxMap.map
+      .getTargetElement()
+      .dispatchEvent(new PointerEvent("pointerleave"));
+    expect(
+      interaction.selectedFids,
+      "highlight cleared on pointer leave",
+    ).to.have.length(0);
+  });
+};
+
+export default clearHoverHighlightOnPointerLeave;

--- a/elements/map/test/cases/select/index.js
+++ b/elements/map/test/cases/select/index.js
@@ -8,5 +8,4 @@ export { default as highlightByIdVectorTileLayer } from "./highlight-by-id-vecto
 export { default as removeSelectInteraction } from "./remove-select-interaction";
 export { default as removeSelectInteractionLayer } from "./remove-select-interaction-layer";
 export { default as removeSelectInteractionCleansUp } from "./remove-select-interaction-cleanup";
-export { default as clearHoverHighlightOnPointerLeave } from "./clear-hover-highlight-on-pointer-leave";
 export { default as noDuplicateVectorLoad } from "./no-duplicate-vector-load";

--- a/elements/map/test/cases/select/index.js
+++ b/elements/map/test/cases/select/index.js
@@ -7,4 +7,6 @@ export { default as highlightByIdVectorLayer } from "./highlight-by-id-vector-la
 export { default as highlightByIdVectorTileLayer } from "./highlight-by-id-vector-tile-layer";
 export { default as removeSelectInteraction } from "./remove-select-interaction";
 export { default as removeSelectInteractionLayer } from "./remove-select-interaction-layer";
+export { default as removeSelectInteractionCleansUp } from "./remove-select-interaction-cleanup";
+export { default as clearHoverHighlightOnPointerLeave } from "./clear-hover-highlight-on-pointer-leave";
 export { default as noDuplicateVectorLoad } from "./no-duplicate-vector-load";

--- a/elements/map/test/cases/select/remove-select-interaction-cleanup.js
+++ b/elements/map/test/cases/select/remove-select-interaction-cleanup.js
@@ -3,9 +3,8 @@ import ecoRegionsFixture from "../../fixtures/ecoregions.json";
 import vectorLayerJson from "../../fixtures/vectorLayer.json";
 
 /**
- * Removing a select interaction (by removing its layer) must tear down its
- * layer-group "change" listener. Otherwise, re-adding a layer with the same id
- * re-attaches the dead selection style layer, leaving stale/duplicate highlights.
+ * Removing a select layer must not leave a listener that re-attaches its dead style layer
+ * when a same-id layer is re-added (stale/duplicate highlights).
  */
 const removeSelectInteractionCleansUp = () => {
   cy.intercept("https://openlayers.org/data/vector/ecoregions.json", (req) => {
@@ -36,18 +35,15 @@ const removeSelectInteractionCleansUp = () => {
     const interaction = eoxMap.selectInteractions.selectInteraction;
     expect(interaction, "select interaction created").to.exist;
 
-    // Spy on the (soon to be dead) selection style layer's re-attach.
     const setMapSpy = cy.spy(interaction.selectStyleLayer, "setMap");
 
-    // Remove the select layer -> tears down the interaction.
+    // Remove the select layer, then re-add one with the same id.
     eoxMap.layers = otherLayer;
     expect(
       eoxMap.selectInteractions.selectInteraction,
       "interaction removed with its layer",
     ).to.not.exist;
 
-    // Re-add a layer with the same id; a leaked listener would re-attach the
-    // dead style layer to the map here.
     eoxMap.layers = withSelect;
 
     const reAttached = setMapSpy

--- a/elements/map/test/cases/select/remove-select-interaction-cleanup.js
+++ b/elements/map/test/cases/select/remove-select-interaction-cleanup.js
@@ -1,0 +1,63 @@
+import { html } from "lit";
+import ecoRegionsFixture from "../../fixtures/ecoregions.json";
+import vectorLayerJson from "../../fixtures/vectorLayer.json";
+
+/**
+ * Removing a select interaction (by removing its layer) must tear down its
+ * layer-group "change" listener. Otherwise, re-adding a layer with the same id
+ * re-attaches the dead selection style layer, leaving stale/duplicate highlights.
+ */
+const removeSelectInteractionCleansUp = () => {
+  cy.intercept("https://openlayers.org/data/vector/ecoregions.json", (req) => {
+    req.reply(ecoRegionsFixture);
+  });
+
+  const withSelect = JSON.parse(JSON.stringify(vectorLayerJson));
+  withSelect[0].interactions = [
+    {
+      type: "select",
+      options: {
+        id: "selectInteraction",
+        condition: "click",
+        style: { "stroke-color": "white", "stroke-width": 3 },
+      },
+    },
+  ];
+
+  const otherLayer = JSON.parse(JSON.stringify(vectorLayerJson));
+  otherLayer[0].properties.id = "otherLayer";
+
+  cy.mount(
+    html`<eox-map .center=${[0, 0]} .layers=${withSelect}></eox-map>`,
+  ).as("eox-map");
+
+  cy.get("eox-map").and(($el) => {
+    const eoxMap = $el[0];
+    const interaction = eoxMap.selectInteractions.selectInteraction;
+    expect(interaction, "select interaction created").to.exist;
+
+    // Spy on the (soon to be dead) selection style layer's re-attach.
+    const setMapSpy = cy.spy(interaction.selectStyleLayer, "setMap");
+
+    // Remove the select layer -> tears down the interaction.
+    eoxMap.layers = otherLayer;
+    expect(
+      eoxMap.selectInteractions.selectInteraction,
+      "interaction removed with its layer",
+    ).to.not.exist;
+
+    // Re-add a layer with the same id; a leaked listener would re-attach the
+    // dead style layer to the map here.
+    eoxMap.layers = withSelect;
+
+    const reAttached = setMapSpy
+      .getCalls()
+      .some((call) => call.args[0] === eoxMap.map);
+    expect(
+      reAttached,
+      "dead select style layer is not re-attached after re-adding the layer",
+    ).to.equal(false);
+  });
+};
+
+export default removeSelectInteractionCleansUp;

--- a/elements/map/test/hoverInteraction.cy.js
+++ b/elements/map/test/hoverInteraction.cy.js
@@ -2,6 +2,7 @@ import "../src/main";
 import {
   addSelectInteraction,
   selectAfterReArrangingLayers,
+  clearHoverHighlightOnPointerLeave,
 } from "./cases/hover/index.js";
 
 /**
@@ -18,4 +19,10 @@ describe("select interaction with hover", () => {
    */
   it("working selection after re-arranging layers", () =>
     selectAfterReArrangingLayers());
+
+  /**
+   * Test case that the hover highlight clears when the pointer leaves the map
+   */
+  it("clears the hover highlight when the pointer leaves the map", () =>
+    clearHoverHighlightOnPointerLeave());
 });

--- a/elements/map/test/selectInteraction.cy.js
+++ b/elements/map/test/selectInteraction.cy.js
@@ -8,7 +8,6 @@ import {
   removeSelectInteractionLayer,
   removeSelectInteraction,
   removeSelectInteractionCleansUp,
-  clearHoverHighlightOnPointerLeave,
   noDuplicateVectorLoad,
 } from "./cases/select/index.js";
 
@@ -85,13 +84,6 @@ describe("select interaction on click", () => {
    */
   it("cleans up listeners so a re-added layer does not restore a stale highlight", () =>
     removeSelectInteractionCleansUp());
-
-  /**
-   * A hover (pointermove) interaction must clear its highlight when the pointer
-   * leaves the map
-   */
-  it("clears the hover highlight when the pointer leaves the map", () =>
-    clearHoverHighlightOnPointerLeave());
 
   /**
    * Adding a select interaction must not duplicate the vector source XHR

--- a/elements/map/test/selectInteraction.cy.js
+++ b/elements/map/test/selectInteraction.cy.js
@@ -7,6 +7,8 @@ import {
   highlightByIdVectorTileLayer,
   removeSelectInteractionLayer,
   removeSelectInteraction,
+  removeSelectInteractionCleansUp,
+  clearHoverHighlightOnPointerLeave,
   noDuplicateVectorLoad,
 } from "./cases/select/index.js";
 
@@ -76,6 +78,20 @@ describe("select interaction on click", () => {
    * Test case to remove interaction
    */
   it("remove interaction", () => removeSelectInteraction());
+
+  /**
+   * Removing the layer must tear down the interaction's layer-group listener so
+   * re-adding a same-id layer does not re-attach the dead select style layer
+   */
+  it("cleans up listeners so a re-added layer does not restore a stale highlight", () =>
+    removeSelectInteractionCleansUp());
+
+  /**
+   * A hover (pointermove) interaction must clear its highlight when the pointer
+   * leaves the map
+   */
+  it("clears the hover highlight when the pointer leaves the map", () =>
+    clearHoverHighlightOnPointerLeave());
 
   /**
    * Adding a select interaction must not duplicate the vector source XHR


### PR DESCRIPTION
## Implemented changes
This PR addresses 2 issues:
1. Hover (pointermove) highlight stayed stuck when the pointer left the map, `pointerLeaveListener` only hid the tooltip. It now also clears `selectedFids`, so the highlight no longer lingers (and stacks with other highlights) once the pointer moves off the map.
2. `remove()` leaked the layer-group "change" listener, so re-adding a layer with the same id re-attached the dead selection style layer (and its stale highlight). The listener is now stored and torn down in remove().

Two Tests has been added:
- hoverInteraction.cy.js: hover highlight clears on pointer-leave.
- selectInteraction.cy.js: re-adding a same-id layer doesn't restore a stale highlight.

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
