### PR TITLE
fix: type checks for step layers and ignore empty slot change

### DIFF
--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -94,7 +94,7 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
       const idCounters = new Map(); // Key: OriginalID, Value: Counter
 
       section.steps.forEach((step) => {
-        if (step.layers) {
+        if (Array.isArray(step.layers)) {
           step.layers.forEach((layer) => {
             if (layer.properties && layer.properties.id) {
               const originalId = layer.properties.id;
@@ -130,7 +130,7 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
       // Collect all unique layers from all steps to enable preloading
       const layerMap = new Map();
       section.steps.forEach((step) => {
-        if (step.layers) {
+        if (Array.isArray(step.layers)) {
           step.layers.forEach((layer) => {
             if (layer.properties && layer.properties.id) {
               layerMap.set(layer.properties.id, layer);

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -302,12 +302,15 @@ export class EOxStoryTelling extends LitElement {
       const slottedContent = slot.assignedNodes({ flatten: true });
 
       // Map each node to its text content, filtering out any non-text nodes, and join into a single string
-      this.markdown = slottedContent
+      const slottedText = slottedContent
         .map((node) => (node.textContent ? node.textContent : ""))
         .join("");
 
-      // Request an update to re-render the component with the new content
-      this.requestUpdate();
+      if (slottedText.trim()) {
+        this.markdown = slottedText;
+        // Request an update to re-render the component with the new content
+        this.requestUpdate();
+      }
     }
   }
 


### PR DESCRIPTION
## Implemented changes

This PR contains two fixes for the `<eox-storytelling>` component to prevent runtime crashes and unnecessary state resets:

1. **Step Layers Type Safety (`render-html-string.js`)**:
   - Replaced simple truthiness checks (`if (step.layers)`) with explicit array checks (`if (Array.isArray(step.layers))`) before invoking `.forEach()` on `step.layers`.
   - This protects against potential runtime errors (e.g., `TypeError: step.layers.forEach is not a function`) if a story step contains non-array layer definitions.

2. **Handle Whitespace-Only Slot Changes (`main.js`)**:
   - Updated the slot change handler to filter out whitespace-only slotted content.
   - Now, `this.markdown` is updated and `this.requestUpdate()` is called only when the slotted text contains actual non-whitespace content (`slottedText.trim()`). This prevents empty line-break nodes in HTML layouts from overwriting or wiping out existing story markdown data.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
