### PR TITLE
feat: introduce DOM morphing & improve resource management

### DIFF
--- a/elements/storytelling/src/helpers/index.js
+++ b/elements/storytelling/src/helpers/index.js
@@ -1,5 +1,6 @@
 export { default as loadMarkdownURL } from "./load-markdown-url.js";
 export { renderHtmlString, parseNavWithAddSection } from "./render-html-string";
+export { morphDOM, reconcileChildren } from "./morph";
 export {
   scrollAnchorClickEvent,
   scrollIntoView,

--- a/elements/storytelling/src/helpers/morph.js
+++ b/elements/storytelling/src/helpers/morph.js
@@ -1,0 +1,146 @@
+/**
+ * Recursively morphs/patches an existing DOM node to match a target node in-place.
+ *
+ * @param {Node} existingNode - The live DOM node to update.
+ * @param {Node} targetNode - The newly parsed virtual node containing the updates.
+ */
+export function morphDOM(existingNode, targetNode) {
+  if (existingNode.nodeType !== targetNode.nodeType) {
+    /** @type {ChildNode} */ (existingNode).replaceWith(targetNode);
+    return;
+  }
+
+  // Update text or comment nodes
+  if (
+    existingNode.nodeType === Node.TEXT_NODE ||
+    existingNode.nodeType === Node.COMMENT_NODE
+  ) {
+    if (existingNode.nodeValue !== targetNode.nodeValue) {
+      existingNode.nodeValue = targetNode.nodeValue;
+    }
+    return;
+  }
+
+  // Update elements
+  if (existingNode.nodeType === Node.ELEMENT_NODE) {
+    const existingEl = /** @type {HTMLElement} */ (existingNode);
+    const targetEl = /** @type {HTMLElement} */ (targetNode);
+
+    if (existingEl.tagName !== targetEl.tagName) {
+      existingEl.replaceWith(targetEl);
+      return;
+    }
+
+    // 1. Sync attributes
+    const existingAttrs = existingEl.attributes;
+    const targetAttrs = targetEl.attributes;
+
+    // Remove attributes that are not in target
+    for (let i = existingAttrs.length - 1; i >= 0; i--) {
+      const attrName = existingAttrs[i].name;
+      if (!targetEl.hasAttribute(attrName)) {
+        existingEl.removeAttribute(attrName);
+      }
+    }
+
+    // Add or update attributes
+    for (let i = 0; i < targetAttrs.length; i++) {
+      const attrName = targetAttrs[i].name;
+      const attrVal = targetAttrs[i].value;
+      if (existingEl.getAttribute(attrName) !== attrVal) {
+        existingEl.setAttribute(attrName, attrVal);
+      }
+    }
+
+    // 2. Sync Web Component / Custom Element properties
+    if (existingEl.tagName.includes("-")) {
+      for (const key of Object.keys(targetEl)) {
+        if (targetEl[key] !== undefined && existingEl[key] !== targetEl[key]) {
+          existingEl[key] = targetEl[key];
+        }
+      }
+    }
+
+    // 3. Reconcile child nodes recursively
+    const existingChildren = Array.from(existingEl.childNodes);
+    const targetChildren = Array.from(targetEl.childNodes);
+
+    let eIdx = 0;
+    let tIdx = 0;
+
+    while (eIdx < existingChildren.length || tIdx < targetChildren.length) {
+      const existingChild = existingChildren[eIdx];
+      const targetChild = targetChildren[tIdx];
+
+      if (!existingChild && targetChild) {
+        // Target has more children, append them
+        existingEl.appendChild(targetChild);
+        tIdx++;
+      } else if (existingChild && !targetChild) {
+        // Target has fewer children, remove extra
+        existingChild.remove();
+        eIdx++;
+      } else {
+        const existingChildEl = /** @type {Element} */ (existingChild);
+        const targetChildEl = /** @type {Element} */ (targetChild);
+
+        // Both exist, reconcile them if they are compatible
+        if (
+          existingChild.nodeType === targetChild.nodeType &&
+          existingChildEl.tagName === targetChildEl.tagName
+        ) {
+          morphDOM(existingChild, targetChild);
+          eIdx++;
+          tIdx++;
+        } else {
+          // Mismatch: replace in-place
+          /** @type {ChildNode} */ (existingChild).replaceWith(targetChild);
+          eIdx++;
+          tIdx++;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Reconciles the children of a container element to match a list of target elements.
+ *
+ * @param {HTMLElement} parent - The live parent element.
+ * @param {HTMLElement[]} newElements - The array of newly parsed elements.
+ */
+export function reconcileChildren(parent, newElements) {
+  const existingChildren = Array.from(parent.childNodes);
+
+  let eIdx = 0;
+  let tIdx = 0;
+
+  while (eIdx < existingChildren.length || tIdx < newElements.length) {
+    const existingChild = existingChildren[eIdx];
+    const targetChild = newElements[tIdx];
+
+    if (!existingChild && targetChild) {
+      parent.appendChild(targetChild);
+      tIdx++;
+    } else if (existingChild && !targetChild) {
+      existingChild.remove();
+      eIdx++;
+    } else {
+      const existingChildEl = /** @type {Element} */ (existingChild);
+      const targetChildEl = /** @type {Element} */ (targetChild);
+
+      if (
+        existingChild.nodeType === targetChild.nodeType &&
+        existingChildEl.tagName === targetChildEl.tagName
+      ) {
+        morphDOM(existingChild, targetChild);
+        eIdx++;
+        tIdx++;
+      } else {
+        /** @type {ChildNode} */ (existingChild).replaceWith(targetChild);
+        eIdx++;
+        tIdx++;
+      }
+    }
+  }
+}

--- a/elements/storytelling/src/helpers/render-html-string.js
+++ b/elements/storytelling/src/helpers/render-html-string.js
@@ -10,6 +10,7 @@ let sectionObservers = [];
 let sectionNavObservers = [];
 let stepSectionObservers = [];
 let sectionOverlayObservers = [];
+let sectionTimeouts = [];
 
 /**
  * Converts an HTML string into DOM nodes and processes each node.
@@ -27,6 +28,10 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
   const parent = /** @type {HTMLElement} */ (that.shadowRoot || that);
 
   const isNavigation = !!(that.showNav && that.nav.length);
+
+  // Clear all pending timeouts
+  sectionTimeouts.forEach((t) => clearTimeout(t));
+  sectionTimeouts = [];
 
   // Open all links inside story in a new tab
   const anchorTagsArr = doc.querySelectorAll("a");
@@ -70,13 +75,14 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
         { rootMargin: "-50% 0px" },
       );
 
-      setTimeout(() => {
+      const navTimeout = setTimeout(() => {
         const sectionDom = parent.querySelector(`#${section.id}`);
         if (sectionDom) {
           sectionNavObserver.observe(sectionDom);
           sectionNavObservers.push(sectionNavObserver);
         }
       }, 200);
+      sectionTimeouts.push(navTimeout);
     });
   }
 
@@ -191,7 +197,7 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
       });
 
       // Create scroll Step Section Observer with a small delay
-      setTimeout(() => {
+      const stepObserverTimeout = setTimeout(() => {
         const contentParent = parent.querySelector(`#${sectionId}`);
         if (!contentParent) return;
 
@@ -216,7 +222,7 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
 
         // Deferred load of remaining hidden layers
         // This ensures the initial view loads fast, then we inject the rest for caching/preloading
-        setTimeout(() => {
+        const deferredTimeout = setTimeout(() => {
           if (!layersLoaded) {
             layersLoaded = true;
             assignNewAttrValue(
@@ -228,21 +234,23 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
             );
           }
         }, 2500);
+        sectionTimeouts.push(deferredTimeout);
 
         sectionObserver.observe(contentParent);
         sectionObservers.push(sectionObserver);
       }, 500);
+      sectionTimeouts.push(stepObserverTimeout);
 
       // Explicit Preloader: Forces loading of tiles for future steps (different zoom/center)
       // This complements the "Hidden Layer" strategy which only handles the current view.
-      setTimeout(() => {
+      const preloadTimeout = setTimeout(() => {
         const eoxMap = /** @type {any} */ (
           parent.querySelector(elementSelector)
         );
         if (eoxMap && eoxMap.preloadTiles) {
           section.steps.forEach((step, stepIndex) => {
             // Stagger requests to prevent freezing the main thread & network congestion
-            setTimeout(() => {
+            const staggerTimeout = setTimeout(() => {
               const stepLayers = step.layers || [];
               // Collect IDs - these are already deduplicated in the previous block
               const layerIds = stepLayers
@@ -257,9 +265,11 @@ export function renderHtmlString(htmlString, sections, initDispatchFunc, that) {
                 eoxMap.preloadTiles(layerIds, zoom, center, 0.5);
               }
             }, stepIndex * 1000); // 1-second delay between preloading each step
+            sectionTimeouts.push(staggerTimeout);
           });
         }
       }, 3000); // Start preloading 3s after init
+      sectionTimeouts.push(preloadTimeout);
     }
   });
 
@@ -331,9 +341,11 @@ function assignNewAttrValue(
   allLayers = [],
 ) {
   const element = /** @type {any} */ (parent.querySelector(elementSelector));
+  if (!element) return;
   const attrs = section.steps[index];
 
   Object.keys(attrs).forEach((attr) => {
+    if (attr === "id") return;
     if (attr === "layers" && allLayers.length && Array.isArray(attrs[attr])) {
       const stepLayers = attrs[attr];
       const mergedLayers = allLayers.map((layer) => {
@@ -464,7 +476,8 @@ function processNode(node, initDispatchFunc, that) {
             )),
         );
       }
-      setTimeout(() => initDispatchFunc(element), 100);
+      const dispatchTimeout = setTimeout(() => initDispatchFunc(element), 100);
+      sectionTimeouts.push(dispatchTimeout);
     });
   }
 

--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -13,6 +13,7 @@ import {
   addLightBoxScript,
   addCustomSection,
   initSavedMarkdown,
+  reconcileChildren,
 } from "./helpers";
 import DOMPurify from "isomorphic-dompurify";
 import {
@@ -266,6 +267,13 @@ export class EOxStoryTelling extends LitElement {
         this,
       );
 
+      const storyContent = /** @type {HTMLElement} */ (
+        (this.shadowRoot || this).querySelector("#story-content")
+      );
+      if (storyContent) {
+        reconcileChildren(storyContent, this.#html);
+      }
+
       if (this.showEditor !== undefined) {
         const parent = this.shadowRoot || this;
         /**
@@ -367,7 +375,7 @@ export class EOxStoryTelling extends LitElement {
       </style>
 
       <div class="story-telling ${editorClass} ${navClass}">
-        <div>${when(this.#html, () => html`${this.#html}`)}</div>
+        <div id="story-content"></div>
         ${when(
           this.showEditor !== undefined,
           () => html`


### PR DESCRIPTION
## Implemented changes

This pull request introduces in-place DOM morphing/reconciliation and improves lifecycle management of asynchronous timeouts for the `<eox-storytelling>` element. Instead of tearing down and recreating the entire DOM tree whenever the story markdown updates, we now perform a recursive patching (morphing) of the existing DOM nodes. This preserves local element state, prevents unnecessary map re-renders/flashes, and retains active IntersectionObservers.

---

## Changes

### 1. **DOM Morphing Engine (`elements/storytelling/src/helpers/morph.js` & `index.js`)**
- Added `morphDOM(existingNode, targetNode)` to recursively update an existing node to match a target virtual/parsed node.
  - Safely syncs element types, text/comment values, and attributes.
  - Synchronizes custom property values specifically on Web Components (custom elements containing `-` in their tag name).
  - Handles children matching and dynamic patching.
- Added `reconcileChildren(parent, newElements)` to align a container's child elements with a list of updated parsed elements.
- Exported the new helpers in `src/helpers/index.js`.

### 2. **Component Lifecycle & Reconciliation (`elements/storytelling/src/main.js`)**
- Swapped full DOM replacement (`<div>${this.#html}</div>`) with a stable `<div id="story-content"></div>` container.
- Integrated `reconcileChildren` in the update loop to morph children under `#story-content` in-place using `this.#html`, preserving existing instances and states of nested components (like maps or editors).

### 3. **Timeout Clearing & Attribute Processing (`elements/storytelling/src/helpers/render-html-string.js`)**
- **Memory/Execution Cleanup**: Added a module-level `sectionTimeouts` array to store all `setTimeout` IDs created during section observation/preloading. Automatically clears all pending timeouts at the beginning of `renderHtmlString` to prevent memory leaks and competing async triggers.
- **Robustness Checks**:
  - Added safe guard `if (!element) return;` in `assignNewAttrValue`.
  - Prevented overriding the element's `id` property (`if (attr === "id") return;`) to avoid altering established DOM identifiers during step updates.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
