### PR TITLE
feat: A2UI virtual components

### DIFF
--- a/a2ui/scripts/build-catalog.js
+++ b/a2ui/scripts/build-catalog.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { A2UI_SPEC_VERSION } from "../src/constants.js";
+import { virtualComponents } from "../src/transformers/virtual-components.js";
 
 // Locate package.json to read current version
 const packageJsonPath = path.resolve(process.cwd(), "package.json");
@@ -202,6 +203,107 @@ for (const el of elements) {
       {
         type: "object",
         properties: componentProps,
+        required: ["component"],
+      },
+    ],
+    unevaluatedProperties: false,
+  };
+}
+
+for (const vc of virtualComponents) {
+  const componentProps = {
+    component: { const: vc.name },
+  };
+
+  let properties = {};
+  if (vc.name === "EOxStorytellingHero") {
+    properties = {
+      title: { type: "string", description: "Main title of the hero section" },
+      as: {
+        type: "string",
+        enum: ["img", "video"],
+        description: "Render hero background as an image or a video",
+      },
+      background: {
+        type: "string",
+        description: "URL of the hero background image/video source",
+      },
+      description: {
+        type: "string",
+        description: "Sub-description text to overlay on the hero section",
+      },
+    };
+  } else if (vc.name === "EOxStorytellingText") {
+    properties = {
+      title: {
+        type: "string",
+        description: "Title of the text narrative section",
+      },
+      markdown: {
+        type: "string",
+        description: "Markdown-formatted text narrative content",
+      },
+    };
+  } else if (vc.name === "EOxStorytellingTour") {
+    properties = {
+      title: { type: "string", description: "Title of the tour section" },
+      tourTitle: { type: "string", description: "Alternative tour title" },
+      as: {
+        type: "string",
+        description:
+          "Target element type to render under the tour, e.g. 'eox-map' or 'img'",
+      },
+      tourAs: {
+        type: "string",
+        description: "Alternative target element type",
+      },
+      position: {
+        type: "string",
+        enum: ["left", "right"],
+        description:
+          "Position of the text narrative overlay relative to the media",
+      },
+      tourPosition: {
+        type: "string",
+        enum: ["left", "right"],
+        description: "Alternative position override",
+      },
+      children: {
+        type: "array",
+        items: { type: "string" },
+        description: "Array of tour step component IDs",
+      },
+    };
+  } else if (vc.name === "EOxStorytellingTourStep") {
+    properties = {
+      title: { type: "string", description: "Title of the tour step" },
+      stepTitle: { type: "string", description: "Alternative tour step title" },
+      description: {
+        type: "string",
+        description: "Description narrative content of the tour step",
+      },
+      stepDescription: {
+        type: "string",
+        description: "Alternative tour step description narrative content",
+      },
+      config: {
+        type: "object",
+        description:
+          "Configuration object or string containing layers/zoom/center settings for the step",
+      },
+    };
+  }
+
+  eoxCatalogJson.components[vc.name] = {
+    type: "object",
+    allOf: [
+      { $ref: "common_types.json#/$defs/ComponentCommon" },
+      {
+        type: "object",
+        properties: {
+          ...componentProps,
+          ...properties,
+        },
         required: ["component"],
       },
     ],

--- a/a2ui/src/eox-a2ui-element.js
+++ b/a2ui/src/eox-a2ui-element.js
@@ -3,6 +3,7 @@ import { html, unsafeStatic } from "lit/static-html.js";
 import { createRef, ref } from "lit/directives/ref.js";
 import { A2uiLitElement, A2uiController } from "@a2ui/lit/v0_9";
 import { eoxCatalog } from "./eox-catalog.js";
+import { componentTransformers } from "./transformers/index.js";
 
 export class EOxA2uiElement extends A2uiLitElement {
   constructor() {
@@ -29,8 +30,128 @@ export class EOxA2uiElement extends A2uiLitElement {
     super.updated(changedProperties);
     const element = this._elementRef.value;
     if (element && this.controller?.props) {
+      const type = this.context.componentModel.type;
+      const transformer = componentTransformers[type];
+      let transformedProps = {};
+
+      if (transformer) {
+        const children = Array.isArray(this.controller.props.children)
+          ? this.controller.props.children
+          : [];
+        const resolvedChildren = children
+          .map((child) => {
+            const isReference =
+              typeof child === "object" &&
+              child !== null &&
+              child.id &&
+              !child.component &&
+              !child.type;
+            const isInline =
+              typeof child === "object" &&
+              child !== null &&
+              (child.component || child.type);
+
+            if (isInline) {
+              const typeName = child.type || child.component;
+              let nestedChildren = [];
+              if (Array.isArray(child.children)) {
+                nestedChildren = child.children
+                  .map((nestedChild) => {
+                    const isNestedInline =
+                      typeof nestedChild === "object" &&
+                      nestedChild !== null &&
+                      (nestedChild.component || nestedChild.type);
+                    if (isNestedInline) {
+                      return {
+                        id: nestedChild.id,
+                        type: nestedChild.type || nestedChild.component,
+                        ...nestedChild,
+                      };
+                    }
+                    const nestedChildId =
+                      typeof nestedChild === "object" && nestedChild !== null
+                        ? nestedChild.id
+                        : nestedChild;
+                    const nestedChildModel =
+                      this.context.surfaceComponents.get(nestedChildId);
+                    if (nestedChildModel) {
+                      return {
+                        id: nestedChildModel.id,
+                        type: nestedChildModel.type,
+                        ...nestedChildModel.properties,
+                      };
+                    }
+                    return null;
+                  })
+                  .filter(Boolean);
+              }
+              return {
+                id: child.id,
+                type: typeName,
+                ...child,
+                children:
+                  nestedChildren.length > 0
+                    ? nestedChildren
+                    : child.children || [],
+              };
+            }
+
+            const childId =
+              typeof child === "object" && child !== null ? child.id : child;
+            const childModel = this.context.surfaceComponents.get(childId);
+            if (childModel) {
+              let nestedChildren = [];
+              if (Array.isArray(childModel.properties?.children)) {
+                nestedChildren = childModel.properties.children
+                  .map((nestedChild) => {
+                    const isNestedInline =
+                      typeof nestedChild === "object" &&
+                      nestedChild !== null &&
+                      (nestedChild.component || nestedChild.type);
+                    if (isNestedInline) {
+                      return {
+                        id: nestedChild.id,
+                        type: nestedChild.type || nestedChild.component,
+                        ...nestedChild,
+                      };
+                    }
+                    const nestedChildId =
+                      typeof nestedChild === "object" && nestedChild !== null
+                        ? nestedChild.id
+                        : nestedChild;
+                    const nestedChildModel =
+                      this.context.surfaceComponents.get(nestedChildId);
+                    if (nestedChildModel) {
+                      return {
+                        id: nestedChildModel.id,
+                        type: nestedChildModel.type,
+                        ...nestedChildModel.properties,
+                      };
+                    }
+                    return null;
+                  })
+                  .filter(Boolean);
+              }
+              return {
+                id: childModel.id,
+                type: childModel.type,
+                ...childModel.properties,
+                children:
+                  nestedChildren.length > 0
+                    ? nestedChildren
+                    : childModel.properties?.children || [],
+              };
+            }
+            return null;
+          })
+          .filter(Boolean);
+
+        transformedProps = transformer(resolvedChildren, this.controller.props);
+      }
+
       // Pass all properties to the EOxElement
-      for (const [key, value] of Object.entries(this.controller.props)) {
+      const mergedProps = { ...this.controller.props, ...transformedProps };
+      for (const [key, value] of Object.entries(mergedProps)) {
         if (key === "children") {
           continue;
         }
@@ -49,15 +170,15 @@ export class EOxA2uiElement extends A2uiLitElement {
     }
 
     const targetTag = unsafeStatic(api.targetTagName);
+    const hasTransformer = !!componentTransformers[type];
     const children = Array.isArray(this.controller?.props?.children)
       ? this.controller.props.children
       : [];
 
-    return html`
-      <${targetTag} id=${this.context.componentModel.id} ${ref(this._elementRef)}>
-        ${children.map((child) => this.renderNode(child))}
-      </${targetTag}>
-    `;
+    return html`<${targetTag}
+      id=${this.context.componentModel.id}
+      ${ref(this._elementRef)}
+    >${hasTransformer ? nothing : children.map((child) => this.renderNode(child))}</${targetTag}>`;
   }
 }
 

--- a/a2ui/src/eox-catalog.js
+++ b/a2ui/src/eox-catalog.js
@@ -1,10 +1,11 @@
 import { Catalog } from "@a2ui/web_core/v0_9";
 import { eoxComponents, version } from "./generated-catalog.js";
 import { A2UI_SPEC_VERSION } from "./constants.js";
+import { virtualComponents } from "./transformers/virtual-components.js";
 
 export const urlVersion = A2UI_SPEC_VERSION;
 
 export const eoxCatalog = new Catalog(
   `https://eox-a.github.io/EOxElements/a2ui/${urlVersion}/eox_catalog.json`,
-  eoxComponents,
+  [...eoxComponents, ...virtualComponents],
 );

--- a/a2ui/src/index.js
+++ b/a2ui/src/index.js
@@ -2,4 +2,5 @@ export { EOxA2uiElement } from "./eox-a2ui-element.js";
 export { EOxA2uiWrapper } from "./eox-a2ui-wrapper.js";
 export { eoxCatalog } from "./eox-catalog.js";
 export { combinedCatalog, mergeCatalogs } from "./eox-catalog-helper.js";
+export * from "./transformers/index.js";
 export * from "./generated-catalog.js";

--- a/a2ui/src/transformers/eox-storytelling-virtual-components.js
+++ b/a2ui/src/transformers/eox-storytelling-virtual-components.js
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+export const storytellingVirtualComponents = [
+  {
+    name: "EOxStorytellingHero",
+    schema: z.object({
+      title: z.string().optional().describe("Main title of the hero section"),
+      as: z
+        .enum(["img", "video"])
+        .optional()
+        .describe("Render hero background as an image or a video"),
+      background: z
+        .string()
+        .optional()
+        .describe("URL of the hero background image/video source"),
+      description: z
+        .string()
+        .optional()
+        .describe("Sub-description text to overlay on the hero section"),
+    }),
+  },
+  {
+    name: "EOxStorytellingText",
+    schema: z.object({
+      title: z
+        .string()
+        .optional()
+        .describe("Title of the text narrative section"),
+      markdown: z
+        .string()
+        .optional()
+        .describe("Markdown-formatted text narrative content"),
+    }),
+  },
+  {
+    name: "EOxStorytellingTour",
+    schema: z.object({
+      title: z.string().optional().describe("Title of the tour section"),
+      tourTitle: z.string().optional().describe("Alternative tour title"),
+      as: z
+        .string()
+        .optional()
+        .describe(
+          "Target element type to render under the tour, e.g. 'eox-map' or 'img'",
+        ),
+      tourAs: z.string().optional().describe("Alternative target element type"),
+      position: z
+        .enum(["left", "right"])
+        .optional()
+        .describe(
+          "Position of the text narrative overlay relative to the media",
+        ),
+      tourPosition: z
+        .enum(["left", "right"])
+        .optional()
+        .describe("Alternative position override"),
+      children: z
+        .array(z.string())
+        .optional()
+        .describe("Array of tour step component IDs"),
+    }),
+  },
+  {
+    name: "EOxStorytellingTourStep",
+    schema: z.object({
+      title: z.string().optional().describe("Title of the tour step"),
+      stepTitle: z.string().optional().describe("Alternative tour step title"),
+      description: z
+        .string()
+        .optional()
+        .describe("Description narrative content of the tour step"),
+      stepDescription: z
+        .string()
+        .optional()
+        .describe("Alternative tour step description narrative content"),
+      config: z
+        .any()
+        .optional()
+        .describe(
+          "Configuration object or string containing layers/zoom/center settings for the step",
+        ),
+    }),
+  },
+];

--- a/a2ui/src/transformers/eox-storytelling.js
+++ b/a2ui/src/transformers/eox-storytelling.js
@@ -109,7 +109,14 @@ export function transformEOxStorytelling(children, parentProps) {
 
       let tourMarkdown = `## ${tourTitle} <!--{ as="${tourAs}" mode="tour" position="${tourPosition}" }-->`;
 
-      const steps = Array.isArray(child.children) ? child.children : [];
+      const steps = Array.isArray(child.children)
+        ? child.children.map((step) => {
+            if (typeof step === "string") {
+              return children.find((c) => c && c.id === step) || step;
+            }
+            return step;
+          })
+        : [];
       for (const step of steps) {
         if (!step) continue;
         const stepConfig = step.config || "";
@@ -120,6 +127,12 @@ export function transformEOxStorytelling(children, parentProps) {
         tourMarkdown += `\n\n### <!--{ ${stepConfigJson} }-->\n#### ${stepTitle}\n${stepDescription}`;
       }
       markdownParts.push(tourMarkdown);
+    } else if (
+      type === "EOxStorytellingTourStep" ||
+      type === "EOxStorytellingMaptourStep"
+    ) {
+      // Tour steps are rendered nested inside their parent EOxStorytellingTour component
+      continue;
     } else {
       // Fallback for Unknown Elements
       const tagName = getTagName(type);

--- a/a2ui/src/transformers/eox-storytelling.js
+++ b/a2ui/src/transformers/eox-storytelling.js
@@ -1,0 +1,138 @@
+import { eoxCatalog } from "../eox-catalog.js";
+
+function toKebabCase(str) {
+  if (!str) return "";
+  return str
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .toLowerCase();
+}
+
+function getTagName(childType) {
+  const comp = eoxCatalog?.components?.get(childType);
+  if (comp && comp.targetTagName) {
+    return comp.targetTagName;
+  }
+  return toKebabCase(childType);
+}
+
+function serializeConfig(config) {
+  if (typeof config === "string") {
+    return config;
+  }
+  if (typeof config === "object" && config !== null) {
+    return Object.entries(config)
+      .map(([k, v]) => {
+        if (Array.isArray(v)) {
+          if (
+            v.every(
+              (item) => typeof item === "number" || typeof item === "string",
+            )
+          ) {
+            return `${k}=[${v.join(",")}]`;
+          }
+          return `${k}='${JSON.stringify(v)}'`;
+        }
+        if (typeof v === "object") {
+          return `${k}='${JSON.stringify(v)}'`;
+        }
+        if (typeof v === "string") {
+          return `${k}="${v.replace(/"/g, "&quot;")}"`;
+        }
+        return `${k}=${v}`;
+      })
+      .join(" ");
+  }
+  return "";
+}
+
+function serializeProps(child) {
+  const ignoredKeys = [
+    "id",
+    "type",
+    "children",
+    "title",
+    "description",
+    "as",
+    "mode",
+    "background",
+    "tourTitle",
+    "tourAs",
+    "tourPosition",
+    "markdown",
+  ];
+  return Object.entries(child)
+    .filter(([k]) => !ignoredKeys.includes(k))
+    .map(([k, v]) => {
+      if (typeof v === "object" && v !== null) {
+        return `${k}='${JSON.stringify(v)}'`;
+      }
+      if (typeof v === "string") {
+        return `${k}="${v.replace(/"/g, "&quot;")}"`;
+      }
+      return `${k}=${v}`;
+    })
+    .join(" ");
+}
+
+/**
+ * Transforms A2UI virtual storytelling children into a EOxStorytelling-compatible markdown string.
+ *
+ * @param {Array} children - Resolved virtual children nodes of the EOxStorytelling component.
+ * @param {Object} parentProps - Current properties of the parent EOxStorytelling component.
+ * @returns {Object} `{ markdown: string }`
+ */
+export function transformEOxStorytelling(children, parentProps) {
+  const markdownParts = [];
+
+  for (const child of children) {
+    if (!child) continue;
+
+    const type = child.type;
+
+    if (type === "EOxStorytellingHero") {
+      const title = child.title || "";
+      const as = child.as || "img";
+      const background = child.background || "";
+      const description = child.description || "";
+      markdownParts.push(
+        `# ${title} <!--{ as="${as}" mode="hero" src="${background}" }-->\n#### ${description}`,
+      );
+    } else if (type === "EOxStorytellingText") {
+      const title = child.title || "";
+      const bodyMd = child.markdown || "";
+      markdownParts.push(`## ${title}\n${bodyMd}`);
+    } else if (type === "EOxStorytellingTour") {
+      const tourTitle = child.title || child.tourTitle || "";
+      const tourAs = child.as || child.tourAs || "eox-map";
+      const tourPosition = child.position || child.tourPosition || "left";
+
+      let tourMarkdown = `## ${tourTitle} <!--{ as="${tourAs}" mode="tour" position="${tourPosition}" }-->`;
+
+      const steps = Array.isArray(child.children) ? child.children : [];
+      for (const step of steps) {
+        if (!step) continue;
+        const stepConfig = step.config || "";
+        const stepTitle = step.title || step.stepTitle || "";
+        const stepDescription = step.description || step.stepDescription || "";
+        const stepConfigJson = serializeConfig(stepConfig);
+
+        tourMarkdown += `\n\n### <!--{ ${stepConfigJson} }-->\n#### ${stepTitle}\n${stepDescription}`;
+      }
+      markdownParts.push(tourMarkdown);
+    } else {
+      // Fallback for Unknown Elements
+      const tagName = getTagName(type);
+      const title = child.title || "";
+      const extraProps = serializeProps(child);
+      const propsString = extraProps ? ` ${extraProps}` : "";
+      markdownParts.push(
+        `## ${title} <!--{ as="${tagName}"${propsString} }-->`,
+      );
+    }
+  }
+
+  return {
+    markdown: markdownParts.join("\n\n"),
+  };
+}

--- a/a2ui/src/transformers/index.js
+++ b/a2ui/src/transformers/index.js
@@ -1,0 +1,5 @@
+import { transformEOxStorytelling } from "./eox-storytelling.js";
+
+export const componentTransformers = {
+  EOxStorytelling: transformEOxStorytelling,
+};

--- a/a2ui/src/transformers/virtual-components.js
+++ b/a2ui/src/transformers/virtual-components.js
@@ -1,0 +1,9 @@
+import { storytellingVirtualComponents } from "./eox-storytelling-virtual-components.js";
+
+// Central registry to export and combine virtual component definitions for all elements
+export const virtualComponents = [
+  ...storytellingVirtualComponents,
+  // Add other virtual components here in the future:
+  // ...mapVirtualComponents,
+  // ...jsonformVirtualComponents,
+];


### PR DESCRIPTION
## Implemented changes

This PR adds the concept of "virtual components" for the A2UI support (see https://github.com/EOX-A/EOxElements/pull/2395). This allows to virtually use sub-components/children inside the JSON (e.g. eox-storytelling sections such as Hero, Text, Tour, Tour step) in order to facilitate the model reliability and streamability. 

This is less invasive than actually creating sub-components for everything, and also allows to add actual sub-components in the future and just remove the virtual wrapper/transformer.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
