### PR TITLE
feat: map loading indicator

### DIFF
--- a/elements/storytelling/src/main.js
+++ b/elements/storytelling/src/main.js
@@ -71,6 +71,10 @@ export class EOxStoryTelling extends LitElement {
         attribute: "show-hero-scroll-indicator",
         type: Boolean,
       },
+      showMapLoadingIndicator: {
+        attribute: "show-map-loading-indicator",
+        type: Boolean,
+      },
       noShadow: { attribute: "no-shadow", type: Boolean },
       disableAutosave: { attribute: "disable-autosave", type: Boolean },
       unstyled: { type: Boolean },
@@ -157,6 +161,13 @@ export class EOxStoryTelling extends LitElement {
     this.showHeroScrollIndicator = false;
 
     /**
+     * Enable or disable map loading indicator by default
+     *
+     * @type {Boolean}
+     */
+    this.showMapLoadingIndicator = false;
+
+    /**
      * List of items in navigation
      *
      * @type {Array<Object>}
@@ -225,8 +236,11 @@ export class EOxStoryTelling extends LitElement {
       this.requestUpdate();
     }
 
-    // Check if 'markdown' property itself has changed and generate sanitized html
-    if (changedProperties.has("markdown")) {
+    // Check if 'markdown' or 'showMapLoadingIndicator' property itself has changed and generate sanitized html
+    if (
+      changedProperties.has("markdown") ||
+      changedProperties.has("showMapLoadingIndicator")
+    ) {
       if (this.markdown) {
         this.dispatchEvent(
           /**
@@ -238,6 +252,7 @@ export class EOxStoryTelling extends LitElement {
         );
       }
 
+      md.showMapLoadingIndicator = this.showMapLoadingIndicator;
       const unsafeHTML = md.render(this.markdown);
 
       validateMarkdownAttrs(md.attrs.sections, this);

--- a/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
+++ b/elements/storytelling/src/markdown-it-plugin/markdown-it-decorate-improved.js
@@ -110,7 +110,7 @@ function curlyAttrs(state) {
       }
 
       parent = findParent(stack, m[1], m[2]);
-      if (parent && applyToToken(parent, m[3])) {
+      if (parent && applyToToken(parent, m[3], state.md)) {
         omissions.unshift(i);
       }
     }
@@ -125,6 +125,7 @@ function curlyAttrs(state) {
         sectionStartIndex,
         sectionStepsIndex,
         sectionSteps,
+        state.md,
       );
 
     token.level = token.level + 1;
@@ -225,6 +226,7 @@ function parseFallBack(nextInlineToken) {
  * @param {Number} sectionStartIndex
  * @param {Number} sectionStepsIndex
  * @param {Boolean} sectionSteps
+ * @param {import("../types").CustomMarkdownIt} md
  * @return {Array<Object>} finalTokens
  *
  */
@@ -236,6 +238,7 @@ function parseInlineContent(
   sectionStartIndex,
   sectionStepsIndex,
   sectionSteps,
+  md,
 ) {
   /**
    * @type {InstanceType<InstanceType<import("markdown-it").default["core"]["State"]>["Token"]>}
@@ -255,7 +258,7 @@ function parseInlineContent(
     const m = child.content.match(TAGS_EXPR);
     if (m) {
       const parent = findParent(stack, m[1], m[2]);
-      if (parent && applyToToken(parent, m[3])) {
+      if (parent && applyToToken(parent, m[3], md)) {
         omissions.unshift(i);
         if (lastText) trimRight(lastText, "content");
       }
@@ -267,7 +270,7 @@ function parseInlineContent(
   if (stack.last.tag === "h3" && sectionSteps && sectionStepsIndex !== -1) {
     const currentSectionStepToken = finalTokens[sectionStepsIndex];
     currentSectionStepToken.section = finalTokens[sectionStartIndex].id;
-    applyToToken(currentSectionStepToken, stack.last.attrStr);
+    applyToToken(currentSectionStepToken, stack.last.attrStr, md);
   }
 
   // Generate nav value and transform div section to `as` attribute
@@ -310,6 +313,7 @@ function parseInlineContent(
         `${lastText ? `title='${lastText.content}'` : ""}${
           stack.last.attrStr
         } #${id}`,
+        md,
       );
 
       currentSectionToken.mode = mode;
@@ -319,10 +323,11 @@ function parseInlineContent(
       applyToToken(
         currentSectionToken,
         `#${sectionId} .${currentSectionToken.attrs[0][1]} .section-custom`,
+        md,
       );
     }
 
-    applyToToken(currentSectionToken, sectionClass);
+    applyToToken(currentSectionToken, sectionClass, md);
   }
 
   if (token.children) omissions.forEach((idx) => token.children.splice(idx, 1));
@@ -570,8 +575,9 @@ function findParent(stack, tag, depth) {
  *
  * @param {Object} token
  * @param {String} attrs
+ * @param {import("../types").CustomMarkdownIt} md
  */
-function applyToToken(token, attrs = "") {
+function applyToToken(token, attrs = "", md = null) {
   let m;
   token.attrStr = attrs;
 
@@ -624,6 +630,28 @@ function applyToToken(token, attrs = "") {
 
   const asAttr = getAttr(token.attrs, "as");
   const modeAttr = getAttr(token.attrs, "mode");
+
+  const showMapLoadingIndicator = md ? md.showMapLoadingIndicator : false;
+
+  if (asAttr === "eox-map" && showMapLoadingIndicator === true) {
+    const controlsAttr = getAttr(token.attrs, "controls");
+    const configAttr = getAttr(token.attrs, "config");
+
+    if (configAttr) {
+      try {
+        const configObj = JSON.parse(configAttr);
+        if (!configObj.controls) {
+          configObj.controls = { LoadingIndicator: {} };
+          const idx = token.attrIndex("config");
+          token.attrs[idx][1] = JSON.stringify(configObj);
+        }
+      } catch (e) {
+        console.error("Error parsing/merging config for map:", e);
+      }
+    } else if (!controlsAttr) {
+      addAttr(token, "controls", '{"LoadingIndicator":{}}');
+    }
+  }
 
   // Adding default attribute based on mode and as
   DEFAULT_MODE_ATTRS[asAttr]?.[modeAttr]?.forEach((attr) => {

--- a/elements/storytelling/src/types.ts
+++ b/elements/storytelling/src/types.ts
@@ -5,6 +5,7 @@ export interface CustomMarkdownIt extends MarkdownIt {
   config: { version?: number; versionCheck: boolean };
   nav: Array<string>;
   sections: object;
+  showMapLoadingIndicator?: boolean;
 }
 export type CustomMarkdownItState = InstanceType<
   MarkdownIt["core"]["State"]

--- a/elements/storytelling/stories/markdown-showcase.js
+++ b/elements/storytelling/stories/markdown-showcase.js
@@ -137,12 +137,14 @@ More features will be added soon, so feel free to follow progress at the [EOxEle
     id: "markdown-tour",
     showNav: true,
     showHeroScrollIndicator: true,
+    showMapLoadingIndicator: true,
   },
   render: (args) => html`
     <eox-storytelling
       id=${args.id}
       ?show-nav=${args.showNav}
       ?show-hero-scroll-indicator=${args.showHeroScrollIndicator}
+      ?show-map-loading-indicator=${args.showMapLoadingIndicator}
       markdown=${args.markdown}
     ></eox-storytelling>
   `,

--- a/elements/storytelling/test/cases/load-map-section.js
+++ b/elements/storytelling/test/cases/load-map-section.js
@@ -1,8 +1,4 @@
-import { TEST_SELECTORS } from "../../src/enums";
 import "../../../map/src/main";
-
-// Destructure TEST_SELECTORS object
-const { storyTelling } = TEST_SELECTORS;
 
 /**
  * Ensure all the map sections loaded
@@ -13,17 +9,36 @@ const loadMapSectionTest = () => {
 ## EOX Map <!--{as=eox-map zoom=${zoom}}-->
 `;
 
-  cy.mount(`<eox-storytelling markdown='${testText}'></eox-storytelling>`).as(
-    storyTelling,
+  cy.mount(
+    `<eox-storytelling id="map-with-loading" show-map-loading-indicator markdown='${testText}'></eox-storytelling>`,
   );
 
-  cy.get(storyTelling)
+  cy.get("#map-with-loading")
     .shadow()
     .within(() => {
       cy.get("eox-map").should("exist");
       cy.get("eox-map").then(($eoxMap) => {
         const zoom = $eoxMap[0].map.getView().getZoom();
         expect($eoxMap[0].zoom).to.eq(zoom);
+        expect($eoxMap[0].controls).to.have.property("LoadingIndicator");
+      });
+    });
+
+  cy.mount(
+    `<eox-storytelling id="map-without-loading" markdown='${testText}'></eox-storytelling>`,
+  );
+
+  cy.get("#map-without-loading")
+    .shadow()
+    .within(() => {
+      cy.get("eox-map").should("exist");
+      cy.get("eox-map").then(($eoxMap) => {
+        const controls = $eoxMap[0].controls;
+        if (controls) {
+          expect(controls).to.not.have.property("LoadingIndicator");
+        } else {
+          expect(controls).to.be.undefined;
+        }
       });
     });
 };

--- a/elements/storytelling/test/cases/load-map-tour.js
+++ b/elements/storytelling/test/cases/load-map-tour.js
@@ -20,13 +20,16 @@ const loadMapTourTest = () => {
 `;
 
   cy.mount(
-    `<eox-storytelling markdown='${testTextMapTour}'></eox-storytelling>`,
+    `<eox-storytelling show-map-loading-indicator markdown='${testTextMapTour}'></eox-storytelling>`,
   ).as(storyTelling);
 
   cy.get(storyTelling)
     .shadow()
     .within(() => {
       cy.get("eox-map").should("exist");
+      cy.get("eox-map").then(($eoxMap) => {
+        expect($eoxMap[0].controls).to.have.property("LoadingIndicator");
+      });
       heading.forEach((i, key) =>
         cy.get("section-step h4").eq(key).should("have.text", i),
       );


### PR DESCRIPTION
## Implemented changes

This PR adds support for a configurable, default loading indicator control for both map-tour maps and individual maps rendered within the `@eox/storytelling` component.

### Changes
1. **Configurable Property & Attribute**:
   - Introduced `showMapLoadingIndicator` property (mapped to `show-map-loading-indicator` attribute) on `eox-storytelling`.
   - Following the existing `showHeroScrollIndicator` pattern, this property defaults to `false` in the constructor.
   - Declared the JSDoc description and standard Lit property types accordingly.

2. **Automated Loading Indicator Injection**:
   - Propagated `showMapLoadingIndicator` settings from `eox-storytelling` directly into the custom Markdown-it core renderer (`markdown-it-decorate-improved.js`).
   - If `showMapLoadingIndicator` is configured to `true`, the `eox-map` components auto-initialize with `controls='{"LoadingIndicator":{}}'`.
   - Safeguarded against overriding existing custom `controls` configurations or explicit nested `controls` keys specified inside custom `config` objects.

3. **Storybook Showcase Enhancement**:
   - Updated `elements/storytelling/stories/markdown-showcase.js` to enable `showMapLoadingIndicator: true` by default in the Storybook args so the loading spinner functionality is demonstrated inside the showcase.

4. **Robust Automated Testing**:
   - Updated storytelling component tests under `elements/storytelling/test/cases/` to cover:
     - Automatic injection of `LoadingIndicator` onto maps by default when enabled.
     - Complete absence of `LoadingIndicator` when disabled (the default fallback).
   - All tests have been verified and pass perfectly.

## Screenshots/videos

https://github.com/user-attachments/assets/9a00b0dc-413f-4179-88fd-58df5915ae39

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
