### PR TITLE
fix: EoxLayer type declaration

### DIFF
--- a/.github/workflows/preview_release.yml
+++ b/.github/workflows/preview_release.yml
@@ -41,7 +41,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: Determine changed packages 🔍
+        id: changed
+        run: |
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+          PATHS=$(git diff --name-only FETCH_HEAD HEAD | node -e 'const pkgs=Object.keys(require(process.cwd()+"/release-please-config.json").packages);const files=require("fs").readFileSync(0,"utf8").split("\n").filter(Boolean);process.stdout.write(pkgs.filter((p)=>files.some((f)=>f.startsWith(p+"/"))).join(" "))')
+          echo "paths=$PATHS" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies 👨🏻‍💻
+        if: steps.changed.outputs.paths != ''
         run: npm ci --prefer-offline --no-audit
-      - name: Release preview 🚀
-        run: npx pkg-pr-new publish './elements/*' './utils/' --comment=off
+
+      - name: Release previews 🚀
+        if: steps.changed.outputs.paths != ''
+        run: |
+          ROOT_DIR=$(pwd)
+          for p in ${{ steps.changed.outputs.paths }}; do
+            cd "$ROOT_DIR/$p"
+            npm run types:generate --if-present
+            npx pkg-pr-new publish . --comment=off
+          done

--- a/.github/workflows/preview_release.yml
+++ b/.github/workflows/preview_release.yml
@@ -44,8 +44,12 @@ jobs:
       - name: Determine changed packages 🔍
         id: changed
         run: |
-          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
-          PATHS=$(git diff --name-only FETCH_HEAD HEAD | node -e 'const pkgs=Object.keys(require(process.cwd()+"/release-please-config.json").packages);const files=require("fs").readFileSync(0,"utf8").split("\n").filter(Boolean);process.stdout.write(pkgs.filter((p)=>files.some((f)=>f.startsWith(p+"/"))).join(" "))')
+          PATHS=$(git diff --name-only -r HEAD^1 HEAD | node -e '
+            const { packages } = require("./release-please-config.json");
+            const files = require("fs").readFileSync(0, "utf8").split("\n");
+            const changed = Object.keys(packages).filter((p) => files.some((f) => f.startsWith(p + "/")));
+            process.stdout.write(changed.join(" "));
+          ')
           echo "paths=$PATHS" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies 👨🏻‍💻

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -91,6 +91,7 @@ export function createLayer(EOxMap, layer, createInteractions = true) {
   const olLayer = new newLayer({
     ...layer,
     ...(layer.type !== "MapboxStyle" &&
+      "source" in layer &&
       layer.source && {
         source: createOlSourceFromDefinition(layer.source, EOxMap),
       }),
@@ -111,11 +112,9 @@ export function createLayer(EOxMap, layer, createInteractions = true) {
     );
   }
 
-  if ("style" in layer) {
+  if ("style" in layer && layer.style) {
     /** @type {VectorOrVectorTileLayer} **/ (olLayer).setStyle(
-      /** @type {import("../layers").EOxLayerType<"Vector","Vector">} **/ (
-        layer
-      ).style,
+      /** @type {import("ol/style/Style").StyleLike} */ (layer.style),
     );
   }
 
@@ -268,6 +267,8 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
   if (
     newLayerDefinition.type !== existingJsonDefinition.type ||
     (newLayerDefinition.type !== "MapboxStyle" &&
+      "source" in newLayerDefinition &&
+      "source" in existingJsonDefinition &&
       newLayerDefinition.source?.type !== existingJsonDefinition.source?.type)
   ) {
     throw new Error(`Layers are not compatible to be updated`);
@@ -279,6 +280,8 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
   // Update source if different
   if (
     newLayerDefinition.type !== "MapboxStyle" &&
+    "source" in newLayerDefinition &&
+    "source" in existingJsonDefinition &&
     serialize(newLayerDefinition.source) !==
       serialize(existingJsonDefinition.source)
   ) {
@@ -312,11 +315,8 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
   // Update style if different
   if (
     ["Vector", "VectorTile", "WebGLTile"].includes(newLayerDefinition.type) &&
-    serialize(
-      /** @type {import("../layers.ts").EOxLayerType<"Vector"|"VectorTile"|"WebGLTile",any>} */ (
-        newLayerDefinition
-      ).style,
-    ) !== serialize(existingJsonDefinition.style)
+    serialize(newLayerDefinition.style) !==
+      serialize(existingJsonDefinition.style)
   ) {
     // @ts-expect-error TODO
     existingLayer.setStyle(

--- a/elements/map/src/helpers/generate.js
+++ b/elements/map/src/helpers/generate.js
@@ -314,7 +314,8 @@ export function updateLayer(EOxMap, newLayerDefinition, existingLayer) {
 
   // Update style if different
   if (
-    ["Vector", "VectorTile", "WebGLTile"].includes(newLayerDefinition.type) &&
+    "style" in newLayerDefinition &&
+    "style" in existingJsonDefinition &&
     serialize(newLayerDefinition.style) !==
       serialize(existingJsonDefinition.style)
   ) {

--- a/elements/map/src/layers.ts
+++ b/elements/map/src/layers.ts
@@ -119,8 +119,14 @@ type OlSourceOption<S extends keyof OLSources> = Omit<
 
 type OlLayerOption<T extends keyof OLLayers> = Omit<
   Omit<ConstructorParameters<OLLayers[T]>[0], "properties">,
-  "source" | "layers" | "map"
+  "source" | "layers" | "map" | "style"
 >;
+
+type EOxLayerStyle<T extends keyof OLLayers> = T extends "Vector" | "VectorTile"
+  ? import("ol/style/Style").StyleLike | import("ol/style/flat").FlatStyleLike
+  : T extends "WebGLTile"
+    ? import("ol/layer/WebGLTile").Style
+    : never;
 
 export type EoxSource<S extends keyof OLSources> = (S extends "WMTS"
   ? OlSourceOption<S>
@@ -151,6 +157,7 @@ export type EOxLayerType<
   zIndex?: number;
   visible?: boolean;
   opacity?: number;
+  style?: EOxLayerStyle<T>;
   properties?: {
     id: string;
     [key: string]: any;
@@ -158,17 +165,14 @@ export type EOxLayerType<
   interactions?: T extends "Vector" | "VectorTile"
     ? Array<import("./types").EOxInteraction>
     : never;
-} & (S extends keyof OLSources ? SourceProperties<S> : {});
+} & ([S] extends [never] ? {} : SourceProperties<S>);
 
-export type EOxLayerTypeGroup = Omit<
-  EOxLayerType<"Group", keyof OLSources>,
-  "layers"
-> & {
+export type EOxLayerTypeGroup = Omit<EOxLayerType<"Group">, "layers"> & {
   layers: EoxLayer[];
 };
 
 export type EOxLayerTypeMapboxStyle = Omit<
-  EOxLayerType<"MapboxStyle", keyof OLSources>,
+  EOxLayerType<"MapboxStyle">,
   "source" | "sources"
 >;
 

--- a/elements/map/src/layers.ts
+++ b/elements/map/src/layers.ts
@@ -91,7 +91,7 @@ export type EOxFormatType<F extends keyof OLFormats> =
   | F
   | ({
       type: F;
-    } & ConstructorParameters<OLFormats[F]>[0]);
+    } & NonNullable<ConstructorParameters<OLFormats[F]>[0]>);
 
 export type EOxFormat =
   | EOxFormatType<"EsriJSON">
@@ -113,20 +113,14 @@ export type EOxFormat =
   | EOxFormatType<"WKB">;
 
 type OlSourceOption<S extends keyof OLSources> = Omit<
-  ConstructorParameters<OLSources[S]>[0],
+  NonNullable<ConstructorParameters<OLSources[S]>[0]>,
   "map" | "layer"
 >;
 
 type OlLayerOption<T extends keyof OLLayers> = Omit<
-  Omit<ConstructorParameters<OLLayers[T]>[0], "properties">,
-  "source" | "layers" | "map" | "style"
+  Omit<NonNullable<ConstructorParameters<OLLayers[T]>[0]>, "properties">,
+  "source" | "layers" | "map"
 >;
-
-type EOxLayerStyle<T extends keyof OLLayers> = T extends "Vector" | "VectorTile"
-  ? import("ol/style/Style").StyleLike | import("ol/style/flat").FlatStyleLike
-  : T extends "WebGLTile"
-    ? import("ol/layer/WebGLTile").Style
-    : never;
 
 export type EoxSource<S extends keyof OLSources> = (S extends "WMTS"
   ? OlSourceOption<S>
@@ -157,7 +151,6 @@ export type EOxLayerType<
   zIndex?: number;
   visible?: boolean;
   opacity?: number;
-  style?: EOxLayerStyle<T>;
   properties?: {
     id: string;
     [key: string]: any;
@@ -180,6 +173,11 @@ export type EoxLayer =
   | EOxLayerType<"Vector", "Vector">
   | EOxLayerType<"Vector", "FlatGeoBuf">
   | EOxLayerType<"Vector", "Cluster">
+  | EOxLayerType<"VectorImage", "Vector">
+  | EOxLayerType<"Heatmap", "Vector">
+  | EOxLayerType<"WebGLVector", "Vector">
+  | EOxLayerType<"WebGLPoints", "Vector">
+  | EOxLayerType<"Graticule">
   | EOxLayerType<"VectorTile", "VectorTile">
   | EOxLayerType<"WebGLTile", "GeoTIFF">
   | EOxLayerType<"WebGLTile", "GeoZarr">


### PR DESCRIPTION
## Implemented changes

`EoxLayer` type had become inconsistent: some layers (notably STAC) fell out of the type entirely, and source and style values weren't typed correctly across all layer kinds. This PR restores full coverage so every layer is recognized, adds proper per type styling, and fixes how sourceless layers are handled. 


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] ~I have added a test related to this feature/fix~
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
