### PR TITLE
fix: allow selector search to match end of long option names

### DIFF
--- a/elements/itemfilter/src/methods/filters/selector.js
+++ b/elements/itemfilter/src/methods/filters/selector.js
@@ -162,6 +162,7 @@ function updateSuggestions(EOxItemFilterSelector) {
   if (EOxItemFilterSelector.query) {
     const fuse = new Fuse(items, {
       threshold: 0.4,
+      ignoreLocation: true,
     });
     filteredSuggestion = fuse
       .search(EOxItemFilterSelector.query)

--- a/elements/itemfilter/test/cases/filters/index.js
+++ b/elements/itemfilter/test/cases/filters/index.js
@@ -1,6 +1,7 @@
 // Exported test methods
 
 export { default as filterkeysTest } from "./filter-keys";
+export { default as selectorSearchTest } from "./selector-search";
 export {
   dateRangeFilterTest,
   preSetDateRangeFilterTest,

--- a/elements/itemfilter/test/cases/filters/selector-search.js
+++ b/elements/itemfilter/test/cases/filters/selector-search.js
@@ -1,0 +1,46 @@
+const selectorSearchTest = () => {
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.filterProperties = [
+      {
+        key: "themes",
+        type: "multiselect",
+        expanded: true,
+        filterKeys: [
+          "optionA",
+          "optionB",
+          "optionC",
+          "optionD",
+          "optionE",
+          "optionF",
+          "optionG",
+          "optionH",
+          "optionI",
+          "This is an extremely long option name that has many words and finally ends with a search term like banana",
+        ],
+      },
+    ];
+    eoxItemFilter.requestUpdate();
+  });
+
+  cy.get("eox-itemfilter")
+    .shadow()
+    .within(() => {
+      cy.get("eox-itemfilter-select")
+        .should("be.visible")
+        .within(() => {
+          // Check that there are 10 suggestions initially
+          cy.get("ul.multiselect li").should("have.length", 10);
+
+          // Type "banana" (at the end of the long string) into the input
+          cy.get(".autocomplete-input").type("banana");
+
+          // Check that only 1 suggestion remains (the long one)
+          cy.get("ul.multiselect li")
+            .should("have.length", 1)
+            .and("contain", "banana");
+        });
+    });
+};
+
+export default selectorSearchTest;

--- a/elements/itemfilter/test/filters.cy.js
+++ b/elements/itemfilter/test/filters.cy.js
@@ -1,6 +1,6 @@
 import "../src/main";
 import testItems from "./testItems.json";
-import { filterkeysTest } from "./cases/filters/";
+import { filterkeysTest, selectorSearchTest } from "./cases/filters/";
 
 describe("Item Filter Config", () => {
   const state = {
@@ -51,4 +51,10 @@ describe("Item Filter Config", () => {
    * Test case for filterKeys
    */
   it("should support setting filterKeys", () => filterkeysTest(filterKeys));
+
+  /**
+   * Test case for selector autocomplete search
+   */
+  it("should find long selector options by words at the end", () =>
+    selectorSearchTest());
 });


### PR DESCRIPTION
## Implemented changes

This PR addresses an issue in the item filter's multiselect autocomplete/selector component where options with long names could not be found if the search term matched towards the end of the option name.

### Cause
By default, Fuse.js penalizes matches that are far from the starting `location` (`0`). For long option names, terms matching near the end (e.g. index > 80) accumulate a large distance penalty, pushing their score past the `threshold` limit (set to `0.4`), which excludes them from search results.

### Solution
Configured Fuse.js with `ignoreLocation: true` in the selector search method. This tells Fuse.js to match substrings anywhere in the string without applying a location/distance-based score penalty, making it reliable for searching inside long names.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
