### PR TITLE
fix: layerConfig removeProperties behaviour

### DIFF
--- a/elements/layercontrol/src/methods/layer-config/data-change.js
+++ b/elements/layercontrol/src/methods/layer-config/data-change.js
@@ -20,12 +20,14 @@ const dataChangeMethod = (data, tileUrlFunc, EOxLayerControlLayerConfig) => {
     /** @type {import("ol/source").Source & { getTileUrlFunction: Function, setTileUrlFunction: Function, setKey: Function, updateParams: Function, _updatedUrl: string, getUrls: Function }} */ (
       EOxLayerControlLayerConfig.layer.getSource()
     );
+    
+  const removeProperties =
+    EOxLayerControlLayerConfig.layerConfig.schema?.options?.removeProperties ??
+    [];
+  const updatedData = { ...data };
+  removeProperties.forEach((prop) => delete updatedData[prop]);
+
   if (source.updateParams) {
-    const updatedData = { ...data };
-    const removeProperties =
-      EOxLayerControlLayerConfig.layerConfig.schema?.options
-        ?.removeProperties ?? [];
-    removeProperties.forEach((prop) => delete updatedData[prop]);
     source.updateParams(updatedData);
   } else if (source.getTileUrlFunction && source.getTileUrlFunction()) {
     if (!newTileUrlFunc) {
@@ -43,10 +45,6 @@ const dataChangeMethod = (data, tileUrlFunc, EOxLayerControlLayerConfig) => {
     // Setting a new tile URL function for the layer's source by applying updated data to the existing function.
     source.setTileUrlFunction((...args) => {
       const url = new URL(newTileUrlFunc(...args));
-      const removeProperties =
-        EOxLayerControlLayerConfig.layerConfig.schema?.options
-          ?.removeProperties ?? [];
-
       // Remove unwanted properties from query parameters
       removeProperties.forEach((prop) => url.searchParams.delete(prop));
       return updateUrl(url.href, data);

--- a/elements/layercontrol/src/methods/layer-config/data-change.js
+++ b/elements/layercontrol/src/methods/layer-config/data-change.js
@@ -32,6 +32,14 @@ const dataChangeMethod = (data, tileUrlFunc, EOxLayerControlLayerConfig) => {
       newTileUrlFunc = source.getTileUrlFunction();
     }
 
+    // Store the updated URL synchronously so switching to the globe reflects the change
+    if (source instanceof XYZ_ol) {
+      source._updatedUrl = updateUrl(
+        /** @type {XYZ_ol} */ (source).getUrls()[0],
+        data,
+      );
+    }
+
     // Setting a new tile URL function for the layer's source by applying updated data to the existing function.
     source.setTileUrlFunction((...args) => {
       const url = new URL(newTileUrlFunc(...args));
@@ -39,19 +47,9 @@ const dataChangeMethod = (data, tileUrlFunc, EOxLayerControlLayerConfig) => {
         EOxLayerControlLayerConfig.layerConfig.schema?.options
           ?.removeProperties ?? [];
 
-      const updatedData = { ...data };
-      removeProperties.forEach((prop) => delete updatedData[prop]);
-
-      // Store the updated URL on the source for other components (like the globe) to use
-      if (source instanceof XYZ_ol) {
-        source._updatedUrl = updateUrl(
-          /** @type {XYZ_ol} */ (source).getUrls()[0],
-          updatedData,
-        );
-      }
       // Remove unwanted properties from query parameters
       removeProperties.forEach((prop) => url.searchParams.delete(prop));
-      return updateUrl(url.href, updatedData);
+      return updateUrl(url.href, data);
     });
 
     // TODO: It's not advisable to access protected methods directly.
@@ -65,17 +63,11 @@ const dataChangeMethod = (data, tileUrlFunc, EOxLayerControlLayerConfig) => {
   if (map) {
     const globe = map.globe;
     if (globe) {
-      const updatedData = { ...data };
-      const removeProperties =
-        EOxLayerControlLayerConfig.layerConfig.schema?.options
-          ?.removeProperties ?? [];
-      removeProperties.forEach((prop) => delete updatedData[prop]);
-
       const globusLayer = globe.planet.layers.filter(
         (l) => l.name == EOxLayerControlLayerConfig.layer.get("id"),
       )[0];
       if (globusLayer) {
-        globusLayer.setUrl(updateUrl(globusLayer.url, updatedData));
+        globusLayer.setUrl(updateUrl(globusLayer.url, data));
       }
       window.eoxMapGlobe.refresh();
     }

--- a/elements/layercontrol/src/methods/layer-config/data-change.js
+++ b/elements/layercontrol/src/methods/layer-config/data-change.js
@@ -20,7 +20,7 @@ const dataChangeMethod = (data, tileUrlFunc, EOxLayerControlLayerConfig) => {
     /** @type {import("ol/source").Source & { getTileUrlFunction: Function, setTileUrlFunction: Function, setKey: Function, updateParams: Function, _updatedUrl: string, getUrls: Function }} */ (
       EOxLayerControlLayerConfig.layer.getSource()
     );
-    
+
   const removeProperties =
     EOxLayerControlLayerConfig.layerConfig.schema?.options?.removeProperties ??
     [];

--- a/elements/layercontrol/stories/layercontrol.stories.js
+++ b/elements/layercontrol/stories/layercontrol.stories.js
@@ -63,6 +63,7 @@ export const Tools = ToolsStory;
 
 /**
  * Shows the config tool in action. The "config" tool reads settings from the `layerConfig` property and renders a form based on a provided JSON schema, allowing users to update source URL parameters and other settings. Requires the `@eox/jsonform` package for form rendering.
+ * This example demonstrates `layerConfig.type: "tileUrl"` , with a top level special option `removeProperties` in the schema that describes a list of parameter keys whose initial tile URL values are dropped, so they are not carried over as start values into the form updates.
  */
 export const LayerConfig = LayerConfigStory;
 

--- a/elements/layercontrol/test/layerConfig.cy.js
+++ b/elements/layercontrol/test/layerConfig.cy.js
@@ -73,13 +73,13 @@ describe("LayerControl: LayerConfig", () => {
     });
   });
 
-  it("updates XYZ tileUrlFunction and respects removeProperties", () => {
+  it("updates XYZ tileUrlFunction, clearing removeProperties from the existing URL while applying the full update", () => {
     const setTileUrlFunctionSpy = cy.spy().as("setTileUrlFunctionSpy");
     const setKeySpy = cy.spy().as("setKeySpy");
 
     const mockSource = {
       getTileUrlFunction: () => () =>
-        `https://tiles.com/z/y/x?foo=bar&removeMe=old`,
+        `https://tiles.com/z/y/x?style=old&cmap=speed&stale=1`,
       setTileUrlFunction: setTileUrlFunctionSpy,
       setKey: setKeySpy,
       getUrls: () => ["https://tiles.com/z/y/x"],
@@ -99,11 +99,11 @@ describe("LayerControl: LayerConfig", () => {
       schema: {
         type: "object",
         properties: {
-          foo: { type: "string" },
-          removeMe: { type: "string" },
+          style: { type: "string" },
+          cmap: { type: "string" },
         },
         options: {
-          removeProperties: ["removeMe"],
+          removeProperties: ["cmap", "stale"],
         },
       },
     };
@@ -122,8 +122,8 @@ describe("LayerControl: LayerConfig", () => {
         $jsonform[0].dispatchEvent(
           new CustomEvent("change", {
             detail: {
-              foo: "new_bar",
-              removeMe: "should_be_stripped",
+              style: "new",
+              cmap: "thermal",
             },
           }),
         );
@@ -133,12 +133,16 @@ describe("LayerControl: LayerConfig", () => {
     cy.get("@setTileUrlFunctionSpy").should("have.been.called");
     cy.get("@setKeySpy").should("have.been.called");
 
-    // Verify the new tile function correctly filters the URL
     cy.get("@setTileUrlFunctionSpy").then((spy) => {
       const newTileFunc = spy.getCall(0).args[0];
       const resultUrl = newTileFunc([0, 0, 0]);
-      expect(resultUrl).to.contain("foo=new_bar");
-      expect(resultUrl).to.not.contain("removeMe=should_be_stripped");
+      // The full form update is applied, including a removeProperties key
+      expect(resultUrl).to.contain("style=new");
+      expect(resultUrl).to.contain("cmap=thermal");
+      // Stale/initial values from the existing URL are cleared
+      expect(resultUrl).to.not.contain("style=old");
+      expect(resultUrl).to.not.contain("cmap=speed");
+      expect(resultUrl).to.not.contain("stale=1");
     });
   });
 });


### PR DESCRIPTION
## Implemented changes

This reverts the layerConfig's `removeProperties` behaviour to drop the values of the tile URL initially only instead of on every update.

An example use case for this would be if the tile server exposes 2 params (`variables` and `expressions`) and the initial URL includes `variables` and the `layerConfig` updates `expressions` but the server gives `variables` precedence and do not render `expressions` unless `variables` is not present.
In that case the schema options can hold `removeProperties: ["variables"]` so that `expressions` would be passed on initial load of the form.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
