### PR TITLE
fix: seed `layerConfig` start values for anyOf/oneOf/allOf schemas

### DIFF
--- a/elements/layercontrol/src/helpers/get-start-vals.js
+++ b/elements/layercontrol/src/helpers/get-start-vals.js
@@ -1,4 +1,29 @@
 /**
+ * Collects a schema's field definitions, from `properties` and from any `anyOf`/`oneOf`/`allOf`
+ * branches.
+ *
+ * json-editor uses those combinators for "pick one variant" forms, where the fields live in the
+ * branches and the schema's own `properties` is empty — so reading `properties` alone finds
+ * nothing.
+ *
+ * @param {{[key: string]: any}} schema - The schema object to collect fields from.
+ * @returns {{[key: string]: any}} - Field definitions keyed by property name.
+ */
+function collectFieldSchemas(schema) {
+  if (!schema || typeof schema !== "object") return {};
+
+  const fields = { ...schema.properties };
+  for (const key of ["anyOf", "oneOf", "allOf"]) {
+    if (Array.isArray(schema[key])) {
+      for (const branch of schema[key]) {
+        Object.assign(fields, collectFieldSchemas(branch));
+      }
+    }
+  }
+  return fields;
+}
+
+/**
  * Recursively traverses the schema object to extract startVals based on values of nested properties.
  *
  * @param {{[key: string]: any}} schema - The schema object to traverse.
@@ -12,16 +37,19 @@ export function getNestedStartVals(schema, nestedValues) {
     const type = schema[key].type;
     // Extract startVal based on type
     if (type && type !== "object" && nestedValues[key] !== undefined) {
-      startVals[key] =
+      const value =
         type === "number" ? Number(nestedValues[key]) : nestedValues[key];
-    } else if (typeof schema[key] === "object" && schema[key]?.properties) {
+      // A value the URL carries but the schema can't hold (e.g. "auto" as a number) would
+      // otherwise seed the form with NaN.
+      startVals[key] = Number.isNaN(value) ? nestedValues[key] : value;
+    } else {
       // Recursively traverse nested properties
-      const nestedStartVals = getNestedStartVals(
-        schema[key].properties,
-        nestedValues,
-      );
-      if (Object.keys(nestedStartVals).length > 0) {
-        startVals[key] = nestedStartVals;
+      const nestedFields = collectFieldSchemas(schema[key]);
+      if (Object.keys(nestedFields).length) {
+        const nestedStartVals = getNestedStartVals(nestedFields, nestedValues);
+        if (Object.keys(nestedStartVals).length > 0) {
+          startVals[key] = nestedStartVals;
+        }
       }
     }
   }
@@ -76,8 +104,10 @@ export function getStartVals(layer, layerConfig) {
     }
   } else return null;
 
+  // Fall back to the schema itself for schemas passed as a bare map of property definitions.
+  const fieldSchemas = collectFieldSchemas(layerConfig.schema);
   const startVals = getNestedStartVals(
-    layerConfig.schema?.properties || layerConfig.schema,
+    Object.keys(fieldSchemas).length ? fieldSchemas : layerConfig.schema,
     nestedValues,
   );
 

--- a/elements/layercontrol/src/helpers/get-start-vals.js
+++ b/elements/layercontrol/src/helpers/get-start-vals.js
@@ -12,7 +12,7 @@
 function collectFieldSchemas(schema) {
   if (!schema || typeof schema !== "object") return {};
 
-  const fields = { ...schema.properties };
+  const fields = {};
   for (const key of ["anyOf", "oneOf", "allOf"]) {
     if (Array.isArray(schema[key])) {
       for (const branch of schema[key]) {
@@ -20,7 +20,9 @@ function collectFieldSchemas(schema) {
       }
     }
   }
-  return fields;
+  // The schema's own `properties` overlays last: branches only extend it, so a
+  // constraint-only branch entry (e.g. `{const: "a"}`) can't shadow a real field definition.
+  return Object.assign(fields, schema.properties);
 }
 
 /**
@@ -44,12 +46,12 @@ export function getNestedStartVals(schema, nestedValues) {
       startVals[key] = Number.isNaN(value) ? nestedValues[key] : value;
     } else {
       // Recursively traverse nested properties
-      const nestedFields = collectFieldSchemas(schema[key]);
-      if (Object.keys(nestedFields).length) {
-        const nestedStartVals = getNestedStartVals(nestedFields, nestedValues);
-        if (Object.keys(nestedStartVals).length > 0) {
-          startVals[key] = nestedStartVals;
-        }
+      const nestedStartVals = getNestedStartVals(
+        collectFieldSchemas(schema[key]),
+        nestedValues,
+      );
+      if (Object.keys(nestedStartVals).length > 0) {
+        startVals[key] = nestedStartVals;
       }
     }
   }

--- a/elements/layercontrol/src/helpers/get-start-vals.js
+++ b/elements/layercontrol/src/helpers/get-start-vals.js
@@ -1,64 +1,4 @@
 /**
- * Collects a schema's field definitions, from `properties` and from any `anyOf`/`oneOf`/`allOf`
- * branches.
- *
- * json-editor uses those combinators for "pick one variant" forms, where the fields live in the
- * branches and the schema's own `properties` is empty — so reading `properties` alone finds
- * nothing.
- *
- * @param {{[key: string]: any}} schema - The schema object to collect fields from.
- * @returns {{[key: string]: any}} - Field definitions keyed by property name.
- */
-function collectFieldSchemas(schema) {
-  if (!schema || typeof schema !== "object") return {};
-
-  const fields = {};
-  for (const key of ["anyOf", "oneOf", "allOf"]) {
-    if (Array.isArray(schema[key])) {
-      for (const branch of schema[key]) {
-        Object.assign(fields, collectFieldSchemas(branch));
-      }
-    }
-  }
-  // The schema's own `properties` overlays last: branches only extend it, so a
-  // constraint-only branch entry (e.g. `{const: "a"}`) can't shadow a real field definition.
-  return Object.assign(fields, schema.properties);
-}
-
-/**
- * Recursively traverses the schema object to extract startVals based on values of nested properties.
- *
- * @param {{[key: string]: any}} schema - The schema object to traverse.
- * @param {{[key: string]: any}} nestedValues - values of nested properties to extract startVals.
- * @returns {object} - Object containing the startVals.
- */
-export function getNestedStartVals(schema, nestedValues) {
-  let startVals = {};
-
-  for (const key in schema) {
-    const type = schema[key].type;
-    // Extract startVal based on type
-    if (type && type !== "object" && nestedValues[key] !== undefined) {
-      const value =
-        type === "number" ? Number(nestedValues[key]) : nestedValues[key];
-      // A value the URL carries but the schema can't hold (e.g. "auto" as a number) would
-      // otherwise seed the form with NaN.
-      startVals[key] = Number.isNaN(value) ? nestedValues[key] : value;
-    } else {
-      // Recursively traverse nested properties
-      const nestedStartVals = getNestedStartVals(
-        collectFieldSchemas(schema[key]),
-        nestedValues,
-      );
-      if (Object.keys(nestedStartVals).length > 0) {
-        startVals[key] = nestedStartVals;
-      }
-    }
-  }
-  return startVals;
-}
-
-/**
  * Retrieves startVals from Query Params or style variables based on layer configuration.
  *
  * @param {import("ol/layer").Layer} layer - The layer object.
@@ -106,12 +46,109 @@ export function getStartVals(layer, layerConfig) {
     }
   } else return null;
 
-  // Fall back to the schema itself for schemas passed as a bare map of property definitions.
+  // fall back for schemas passed as a bare map of field definitions
   const fieldSchemas = collectFieldSchemas(layerConfig.schema);
   const startVals = getNestedStartVals(
     Object.keys(fieldSchemas).length ? fieldSchemas : layerConfig.schema,
     nestedValues,
+    layerConfig.schema,
   );
 
   return Object.keys(startVals).length ? startVals : null;
+}
+
+/**
+ * Collects a schema's field definitions from `properties` and from `anyOf`/`oneOf`/`allOf`
+ * branches, resolving `$ref` branches against the root schema. json-editor uses those
+ * combinators for "pick one variant" forms, where `properties` alone is empty.
+ *
+ * @param {{[key: string]: any}} schema - The schema object to collect fields from.
+ * @param {{[key: string]: any}} [rootSchema] - The root schema `$ref`s resolve against.
+ * @param {Set<string>} [seenRefs] - Already-resolved refs, guards against circular `$ref`s.
+ * @returns {{[key: string]: any}} - Field definitions keyed by property name.
+ */
+function collectFieldSchemas(
+  schema,
+  rootSchema = schema,
+  seenRefs = new Set(),
+) {
+  if (!schema || typeof schema !== "object") return {};
+
+  const fields = {};
+  if (typeof schema.$ref === "string" && !seenRefs.has(schema.$ref)) {
+    seenRefs.add(schema.$ref);
+    Object.assign(
+      fields,
+      collectFieldSchemas(
+        resolveLocalRef(schema.$ref, rootSchema),
+        rootSchema,
+        seenRefs,
+      ),
+    );
+  }
+  for (const key of ["anyOf", "oneOf", "allOf"]) {
+    if (Array.isArray(schema[key])) {
+      for (const branch of schema[key]) {
+        Object.assign(
+          fields,
+          collectFieldSchemas(branch, rootSchema, seenRefs),
+        );
+      }
+    }
+  }
+  // `properties` overlays last so constraint-only branch entries can't shadow real fields
+  return Object.assign(fields, schema.properties);
+}
+
+/**
+ * Recursively traverses the schema object to extract startVals based on values of nested properties.
+ *
+ * @param {{[key: string]: any}} schema - The schema object to traverse.
+ * @param {{[key: string]: any}} nestedValues - values of nested properties to extract startVals.
+ * @param {{[key: string]: any}} [rootSchema] - The root schema `$ref`s resolve against.
+ * @returns {object} - Object containing the startVals.
+ */
+export function getNestedStartVals(schema, nestedValues, rootSchema = schema) {
+  let startVals = {};
+
+  for (const key in schema) {
+    const type = schema[key]?.type;
+    // Extract startVal based on type
+    if (type && type !== "object" && nestedValues[key] !== undefined) {
+      const value = ["number", "integer"].includes(type)
+        ? Number(nestedValues[key])
+        : nestedValues[key];
+      // keep the raw URL value instead of NaN (e.g. "auto" on a number field)
+      startVals[key] = Number.isNaN(value) ? nestedValues[key] : value;
+    } else {
+      // Recursively traverse nested properties
+      const nestedStartVals = getNestedStartVals(
+        collectFieldSchemas(schema[key], rootSchema),
+        nestedValues,
+        rootSchema,
+      );
+      if (Object.keys(nestedStartVals).length > 0) {
+        startVals[key] = nestedStartVals;
+      }
+    }
+  }
+  return startVals;
+}
+
+/**
+ * Resolves a local `$ref` pointer (e.g. `#/definitions/foo`) against the root schema.
+ *
+ * @param {string} ref - The `$ref` value.
+ * @param {{[key: string]: any}} rootSchema - The schema holding `definitions`/`$defs`.
+ * @returns {{[key: string]: any} | undefined} - The referenced schema, or undefined for external/unresolvable refs.
+ */
+function resolveLocalRef(ref, rootSchema) {
+  if (!ref.startsWith("#/")) return undefined;
+  return ref
+    .slice(2)
+    .split("/")
+    .reduce(
+      (node, part) => node?.[part.replace(/~1/g, "/").replace(/~0/g, "~")],
+      rootSchema,
+    );
 }

--- a/elements/layercontrol/test/layerConfig.cy.js
+++ b/elements/layercontrol/test/layerConfig.cy.js
@@ -144,18 +144,16 @@ describe("LayerControl: LayerConfig", () => {
     });
   });
 
-  it("seeds start values from the tile URL when the schema nests fields under anyOf", () => {
-    // json-editor's "pick one variant" shape: the fields live in the anyOf branches and the
-    // schema's own `properties` is empty. The layer's URL asks for one variant, the schema
-    // defaults to another — without seeding, json-editor applies the default and layer-config
-    // writes it straight back into the tile URL, re-rendering the layer with parameters it
-    // never asked for.
+  /**
+   * Mounts a layerconfig for a mock tile layer whose URL carries the given query string,
+   * and yields the value the component seeds into eox-jsonform.
+   */
+  const seededValueFor = (tileUrl, schema) => {
     const mockSource = {
-      getTileUrlFunction: () => () =>
-        "https://tiles.com/0/0/0.png?expression=%2Fdescending%3Avv&bidx=2",
+      getTileUrlFunction: () => () => tileUrl,
       setTileUrlFunction: () => {},
       setKey: () => {},
-      getUrls: () => ["https://tiles.com/0/0/0.png"],
+      getUrls: () => [tileUrl.split("?")[0]],
       on: () => {},
       un: () => {},
       getState: () => "ready",
@@ -163,13 +161,34 @@ describe("LayerControl: LayerConfig", () => {
 
     const mockLayer = {
       getSource: () => mockSource,
-      get: (prop) => (prop === "id" ? "test-anyof" : null),
+      get: (prop) => (prop === "id" ? "test-seed" : null),
       on: () => {},
       un: () => {},
     };
 
-    const layerConfig = {
-      schema: {
+    cy.mount(html`
+      <eox-layercontrol-layerconfig
+        .layer=${mockLayer}
+        .layerConfig=${{ schema }}
+      ></eox-layercontrol-layerconfig>
+    `);
+
+    return cy
+      .get("eox-layercontrol-layerconfig")
+      .shadow()
+      .find("eox-jsonform", { timeout: 10000 })
+      .then(($jsonform) => $jsonform[0].seededValue);
+  };
+
+  it("seeds start values from the tile URL when the schema nests fields under anyOf", () => {
+    // json-editor's "pick one variant" shape: the fields live in the anyOf branches and the
+    // schema's own `properties` is empty. The layer's URL asks for one variant, the schema
+    // defaults to another — without seeding, json-editor applies the default and layer-config
+    // writes it straight back into the tile URL, re-rendering the layer with parameters it
+    // never asked for.
+    seededValueFor(
+      "https://tiles.com/0/0/0.png?expression=%2Fdescending%3Avv&bidx=2",
+      {
         type: "object",
         properties: {},
         anyOf: [
@@ -183,23 +202,36 @@ describe("LayerControl: LayerConfig", () => {
           },
         ],
       },
-    };
+    ).should("deep.include", {
+      expression: "/descending:vv",
+      bidx: 2,
+    });
+  });
 
-    cy.mount(html`
-      <eox-layercontrol-layerconfig
-        .layer=${mockLayer}
-        .layerConfig=${layerConfig}
-      ></eox-layercontrol-layerconfig>
-    `);
+  it("keeps seeding top-level properties when anyOf branches carry constraint-only entries", () => {
+    // The conditional-validation idiom: real fields live in `properties`, and anyOf branches
+    // repeat some of them as constraints (e.g. `{const: "a"}` plus a `required` list). Those
+    // constraint entries must not shadow the real definitions, or the field stops seeding.
+    seededValueFor("https://tiles.com/0/0/0.png?mode=a&other=y", {
+      type: "object",
+      properties: {
+        mode: { type: "string" },
+        other: { type: "string" },
+      },
+      anyOf: [
+        { properties: { mode: { const: "a" } }, required: ["other"] },
+        { properties: { mode: { const: "b" } } },
+      ],
+    }).should("deep.include", { mode: "a", other: "y" });
+  });
 
-    cy.get("eox-layercontrol-layerconfig")
-      .shadow()
-      .find("eox-jsonform", { timeout: 10000 })
-      .then(($jsonform) => {
-        expect($jsonform[0].seededValue).to.deep.include({
-          expression: "/descending:vv",
-          bidx: 2,
-        });
-      });
+  it("seeds the raw URL value instead of NaN when a number field carries a non-numeric value", () => {
+    seededValueFor("https://tiles.com/0/0/0.png?rescale=auto&bidx=2", {
+      type: "object",
+      properties: {
+        rescale: { type: "number" },
+        bidx: { type: "number" },
+      },
+    }).should("deep.include", { rescale: "auto", bidx: 2 });
   });
 });

--- a/elements/layercontrol/test/layerConfig.cy.js
+++ b/elements/layercontrol/test/layerConfig.cy.js
@@ -8,7 +8,9 @@ describe("LayerControl: LayerConfig", () => {
         "eox-jsonform",
         class extends HTMLElement {
           set schema(val) {}
-          set value(val) {}
+          set value(val) {
+            this.seededValue = val;
+          }
           set options(val) {}
         },
       );
@@ -140,5 +142,64 @@ describe("LayerControl: LayerConfig", () => {
       expect(resultUrl).to.contain("foo=new_bar");
       expect(resultUrl).to.not.contain("removeMe=should_be_stripped");
     });
+  });
+
+  it("seeds start values from the tile URL when the schema nests fields under anyOf", () => {
+    // json-editor's "pick one variant" shape: the fields live in the anyOf branches and the
+    // schema's own `properties` is empty. The layer's URL asks for one variant, the schema
+    // defaults to another — without seeding, json-editor applies the default and layer-config
+    // writes it straight back into the tile URL, re-rendering the layer with parameters it
+    // never asked for.
+    const mockSource = {
+      getTileUrlFunction: () => () =>
+        "https://tiles.com/0/0/0.png?expression=%2Fdescending%3Avv&bidx=2",
+      setTileUrlFunction: () => {},
+      setKey: () => {},
+      getUrls: () => ["https://tiles.com/0/0/0.png"],
+      on: () => {},
+      un: () => {},
+      getState: () => "ready",
+    };
+
+    const mockLayer = {
+      getSource: () => mockSource,
+      get: (prop) => (prop === "id" ? "test-anyof" : null),
+      on: () => {},
+      un: () => {},
+    };
+
+    const layerConfig = {
+      schema: {
+        type: "object",
+        properties: {},
+        anyOf: [
+          {
+            type: "object",
+            title: "Composite",
+            properties: {
+              expression: { type: "string", default: "/ascending:vv" },
+              bidx: { type: "number", default: 1 },
+            },
+          },
+        ],
+      },
+    };
+
+    cy.mount(html`
+      <eox-layercontrol-layerconfig
+        .layer=${mockLayer}
+        .layerConfig=${layerConfig}
+      ></eox-layercontrol-layerconfig>
+    `);
+
+    cy.get("eox-layercontrol-layerconfig")
+      .shadow()
+      .find("eox-jsonform", { timeout: 10000 })
+      .then(($jsonform) => {
+        expect($jsonform[0].seededValue).to.deep.include({
+          expression: "/descending:vv",
+          bidx: 2,
+        });
+      });
   });
 });

--- a/elements/layercontrol/test/layerConfig.cy.js
+++ b/elements/layercontrol/test/layerConfig.cy.js
@@ -145,8 +145,7 @@ describe("LayerControl: LayerConfig", () => {
   });
 
   /**
-   * Mounts a layerconfig for a mock tile layer whose URL carries the given query string,
-   * and yields the value the component seeds into eox-jsonform.
+   * Mounts a layerconfig for a mock tile layer and yields the value seeded into eox-jsonform.
    */
   const seededValueFor = (tileUrl, schema) => {
     const mockSource = {
@@ -181,11 +180,8 @@ describe("LayerControl: LayerConfig", () => {
   };
 
   it("seeds start values from the tile URL when the schema nests fields under anyOf", () => {
-    // json-editor's "pick one variant" shape: the fields live in the anyOf branches and the
-    // schema's own `properties` is empty. The layer's URL asks for one variant, the schema
-    // defaults to another — without seeding, json-editor applies the default and layer-config
-    // writes it straight back into the tile URL, re-rendering the layer with parameters it
-    // never asked for.
+    // fields live in the anyOf branches, `properties` is empty; without seeding,
+    // json-editor's defaults get written back into the tile URL
     seededValueFor(
       "https://tiles.com/0/0/0.png?expression=%2Fdescending%3Avv&bidx=2",
       {
@@ -208,10 +204,32 @@ describe("LayerControl: LayerConfig", () => {
     });
   });
 
+  it("seeds start values when anyOf branches are $refs into definitions", () => {
+    seededValueFor(
+      "https://tiles.com/0/0/0.png?expression=%2Fdescending%3Avv&bidx=2",
+      {
+        type: "object",
+        properties: {},
+        anyOf: [{ $ref: "#/definitions/composite" }],
+        definitions: {
+          composite: {
+            type: "object",
+            title: "Composite",
+            properties: {
+              expression: { type: "string", default: "/ascending:vv" },
+              bidx: { type: "number", default: 1 },
+            },
+          },
+        },
+      },
+    ).should("deep.include", {
+      expression: "/descending:vv",
+      bidx: 2,
+    });
+  });
+
   it("keeps seeding top-level properties when anyOf branches carry constraint-only entries", () => {
-    // The conditional-validation idiom: real fields live in `properties`, and anyOf branches
-    // repeat some of them as constraints (e.g. `{const: "a"}` plus a `required` list). Those
-    // constraint entries must not shadow the real definitions, or the field stops seeding.
+    // constraint entries like `{const: "a"}` must not shadow the real definitions in `properties`
     seededValueFor("https://tiles.com/0/0/0.png?mode=a&other=y", {
       type: "object",
       properties: {
@@ -226,12 +244,13 @@ describe("LayerControl: LayerConfig", () => {
   });
 
   it("seeds the raw URL value instead of NaN when a number field carries a non-numeric value", () => {
-    seededValueFor("https://tiles.com/0/0/0.png?rescale=auto&bidx=2", {
+    seededValueFor("https://tiles.com/0/0/0.png?rescale=auto&bidx=2&zoom=3", {
       type: "object",
       properties: {
         rescale: { type: "number" },
         bidx: { type: "number" },
+        zoom: { type: "integer" },
       },
-    }).should("deep.include", { rescale: "auto", bidx: 2 });
+    }).should("deep.include", { rescale: "auto", bidx: 2, zoom: 3 });
   });
 });


### PR DESCRIPTION
Opening the layer config panel can silently change what a layer shows. When the form schema keeps its fields inside `anyOf`/`oneOf`/`allOf` groups (the "pick one variant" style) instead of plain `properties`, `getStartVals` finds nothing, so the form falls back to the schema's defaults,  and those defaults get written back into the layer's tile URL. 

We hit this downstream (EOPF-Explorer/data-pipeline#348): opening the panel on an *ascending* Sentinel-1 layer flipped it to the form's *descending* default. This PR makes `getStartVals` also look inside those groups, so the form opens showing what the layer is actually rendering.

## For reviewers

I'm not a maintainer and not a JavaScript specialist, so please check the behaviour decisions rather than assume them:

- `anyOf`/`oneOf`/`allOf` forms now receive start values where they previously got none — a real change if anything relied on schema defaults winning; happy to gate it.
- A schema's own `properties` always beat same-named entries from the branches (regression-tested).
- A number field whose URL value isn't numeric (e.g. `rescale=auto`) now seeds the raw string instead of `NaN` — this also affects plain `properties` forms.
- `$ref`-based branches are still not handled (unchanged from before).

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude): the investigation, fix and tests were AI-written, then checked by a second AI review pass. I verified the claims myself: each new test fails without its fix and passes with it, the full `layercontrol` suite is green (32 passing), and the ascending/descending flip above is real output from a live layer — not an illustration.

---


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] ~For new features: I have created a story showcasing this new feature~
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)