### PR TITLE
fix(style): handle long titles in filter options and search results

### DIFF
--- a/elements/itemfilter/src/components/filters/selector.js
+++ b/elements/itemfilter/src/components/filters/selector.js
@@ -8,6 +8,7 @@ import {
   handleKeyDownSelectorMethod,
   updatedSelectorMethod,
 } from "../../methods/filters";
+import { capitalize } from "../../helpers";
 
 /**
  * EOxSelector is a custom web component that provides a flexible selector interface for filtering items.
@@ -231,7 +232,10 @@ export class EOxSelector extends LitElement {
                 data-identifier="${suggestion.toString().toLowerCase()}"
                 data-title="${suggestion}"
               >
-                <label class="${type} small max">
+                <label
+                  class="${type} small max"
+                  title="${capitalize(suggestion.toString())}"
+                >
                   <input
                     type="${type}"
                     name=${suggestion}
@@ -243,7 +247,12 @@ export class EOxSelector extends LitElement {
                     }}
                     tabindex=${this.tabIndex + 1}
                   />
-                  <span class="title small-line">${suggestion}</span>
+                  <span
+                    class="title small-line"
+                    title="${capitalize(suggestion.toString())}"
+                  >
+                    <span class="title-text">${suggestion}</span>
+                  </span>
                 </label>
               </li>
             `,

--- a/elements/itemfilter/src/methods/results/create.js
+++ b/elements/itemfilter/src/methods/results/create.js
@@ -3,7 +3,7 @@ import { html as staticHtml, unsafeStatic } from "lit/static-html.js";
 import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import { getValue } from "../../helpers";
+import { capitalize, getValue } from "../../helpers";
 
 /**
  * Creates the item details view for the aggregation property in the EOxItemFilterResults component.
@@ -80,9 +80,16 @@ export function createItemListMethod(
       ${repeat(
         items,
         (item) => item.id,
-        (item) => staticHtml`
+        (item) => {
+          const itemTitleRaw =
+            getValue(config.titleProperty, item)?.toString() || "";
+          const itemTitle = item.highlightedText
+            ? itemTitleRaw
+            : capitalize(itemTitleRaw);
+          return staticHtml`
         ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`<eox-layout-item`) : unsafeStatic(`<li`)}
             class="${className(item)}"
+            title="${itemTitle}"
             @click=${() => {
               if (EOxItemFilterResults.selectedResult === item) {
                 EOxItemFilterResults.selectedResult = null;
@@ -173,6 +180,7 @@ export function createItemListMethod(
                       class="title truncate ${item.highlightedText
                         ? "highlight-enabled"
                         : ""}"
+                      title="${itemTitle}"
                       >${unsafeHTML(
                         item.highlightedText ||
                           getValue(config.titleProperty, item).toString(),
@@ -196,6 +204,7 @@ export function createItemListMethod(
                       class="title truncate ${item.highlightedText
                         ? "highlight-enabled"
                         : ""}"
+                      title="${itemTitle}"
                       >${unsafeHTML(
                         item.highlightedText || item[config.titleProperty],
                       )}</span
@@ -227,7 +236,8 @@ export function createItemListMethod(
               )}
             </nav>
           </li>
-        `,
+        `;
+        },
       )}
     ${EOxItemFilterResults.resultType === "cards" ? unsafeStatic(`</eox-layout>`) : unsafeStatic(`</ul>`)}
   `;

--- a/elements/itemfilter/src/style.eox.js
+++ b/elements/itemfilter/src/style.eox.js
@@ -418,6 +418,30 @@ eox-itemfilter-results li {
   display: flex;
   justify-content: space-between;
   min-block-size: 32px !important;
+  height: auto;
+}
+.select li label,
+.multiselect li label {
+  min-width: 0;
+  max-width: 100%;
+}
+.select li label .title,
+.multiselect li label .title {
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
+  overflow: visible;
+}
+.select li label .title .title-text,
+.multiselect li label .title .title-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
 }
 .select li:hover,
 .multiselect li:hover,

--- a/elements/itemfilter/test/cases/filters/index.js
+++ b/elements/itemfilter/test/cases/filters/index.js
@@ -2,6 +2,7 @@
 
 export { default as filterkeysTest } from "./filter-keys";
 export { default as selectorSearchTest } from "./selector-search";
+export { default as selectorLongTitleTest } from "./selector-long-title";
 export {
   dateRangeFilterTest,
   preSetDateRangeFilterTest,

--- a/elements/itemfilter/test/cases/filters/selector-long-title.js
+++ b/elements/itemfilter/test/cases/filters/selector-long-title.js
@@ -1,0 +1,51 @@
+const selectorLongTitleTest = () => {
+  const longTitleRaw =
+    "alpha particles differential directional flux and extended long name";
+  const longTitleCapitalized =
+    "Alpha Particles Differential Directional Flux And Extended Long Name";
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.style.width = "250px";
+    eoxItemFilter.filterProperties = [
+      {
+        key: "themes",
+        type: "multiselect",
+        expanded: true,
+        filterKeys: [longTitleRaw],
+      },
+    ];
+    eoxItemFilter.requestUpdate();
+  });
+
+  cy.get("eox-itemfilter")
+    .shadow()
+    .within(() => {
+      cy.get("eox-itemfilter-select")
+        .should("be.visible")
+        .within(() => {
+          cy.get("ul.multiselect li")
+            .first()
+            .within(() => {
+              cy.get("label").should(
+                "have.attr",
+                "title",
+                longTitleCapitalized,
+              );
+              cy.get("span.title").should(
+                "have.attr",
+                "title",
+                longTitleCapitalized,
+              );
+              cy.get("span.title-text")
+                .should("have.css", "text-overflow", "ellipsis")
+                .should("have.css", "white-space", "nowrap")
+                .should(($span) => {
+                  const el = $span[0];
+                  expect(el.scrollWidth).to.be.greaterThan(el.offsetWidth);
+                });
+            });
+        });
+    });
+};
+
+export default selectorLongTitleTest;

--- a/elements/itemfilter/test/cases/general/index.js
+++ b/elements/itemfilter/test/cases/general/index.js
@@ -16,5 +16,6 @@ export { default as validationTest } from "./validation";
 export { default as slotRenderTest } from "./slots";
 export { default as resultsActionTest } from "./results-action";
 export { default as inlineModeToggleTest } from "./inline-mode-toggle";
+export { default as resultsTitleTest } from "./results-title";
 export { resultSortingTest } from "./result-sorting";
 export { default as resultAggregationTest } from "./results-aggregation";

--- a/elements/itemfilter/test/cases/general/results-title.js
+++ b/elements/itemfilter/test/cases/general/results-title.js
@@ -1,0 +1,34 @@
+const resultsTitleTest = () => {
+  const longTitleRaw =
+    "alpha particles differential directional flux and extended long result name";
+  const longTitleCapitalized =
+    "Alpha Particles Differential Directional Flux And Extended Long Result Name";
+  cy.get("eox-itemfilter").then(($el) => {
+    const eoxItemFilter = $el[0];
+    eoxItemFilter.style.width = "250px";
+    eoxItemFilter.items = [
+      {
+        id: "long-item-1",
+        title: longTitleRaw,
+      },
+    ];
+    eoxItemFilter.titleProperty = "title";
+    eoxItemFilter.requestUpdate();
+  });
+
+  cy.get("eox-itemfilter")
+    .shadow()
+    .within(() => {
+      cy.get("ul#results li")
+        .first()
+        .within(() => {
+          cy.get("span.title").should(
+            "have.attr",
+            "title",
+            longTitleCapitalized,
+          );
+        });
+    });
+};
+
+export default resultsTitleTest;

--- a/elements/itemfilter/test/filters.cy.js
+++ b/elements/itemfilter/test/filters.cy.js
@@ -1,6 +1,10 @@
 import "../src/main";
 import testItems from "./testItems.json";
-import { filterkeysTest, selectorSearchTest } from "./cases/filters/";
+import {
+  filterkeysTest,
+  selectorSearchTest,
+  selectorLongTitleTest,
+} from "./cases/filters/";
 
 describe("Item Filter Config", () => {
   const state = {
@@ -57,4 +61,10 @@ describe("Item Filter Config", () => {
    */
   it("should find long selector options by words at the end", () =>
     selectorSearchTest());
+
+  /**
+   * Test case for long selector option title display
+   */
+  it("should display full title for long selector option on hover/focus and set title attribute", () =>
+    selectorLongTitleTest());
 });

--- a/elements/itemfilter/test/general.cy.js
+++ b/elements/itemfilter/test/general.cy.js
@@ -20,6 +20,7 @@ import {
   resultSortingTest,
   resultAggregationTest,
   inlineModeToggleTest,
+  resultsTitleTest,
 } from "./cases/general/";
 
 /**
@@ -162,4 +163,10 @@ describe("Item Filter Config", () => {
    */
   it("should preserve active filters when toggling inlineMode back and forth", () =>
     inlineModeToggleTest());
+
+  /**
+   * Test case to verify result title attribute and capitalized formatting.
+   */
+  it("should display capitalized title attribute for result items", () =>
+    resultsTitleTest());
 });


### PR DESCRIPTION
## Implemented changes

In constrained width layouts, long filter option titles and search result titles were previously cut off without ellipsis or native tooltip previews, forcing horizontal scrolling or hiding full item names.

This PR improves UX by ensuring long titles in `@eox/itemfilter` truncate with `...` and present full capitalized hover tooltips without causing layout shifts.

## Screenshots/Videos

<img width="209" height="241" alt="image" src="https://github.com/user-attachments/assets/a4c09dff-dafe-4668-aa26-e28239e22986" />
<img width="411" height="131" alt="image" src="https://github.com/user-attachments/assets/3522d4c1-c296-43d2-bc32-da54de88b4eb" />


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
