### PR TITLE
Fix: jsonform round based on step for minmaxslider

### DIFF
--- a/elements/jsonform/src/custom-inputs/minmax.js
+++ b/elements/jsonform/src/custom-inputs/minmax.js
@@ -14,6 +14,34 @@ function setAttributes(element, attributes) {
   });
 }
 
+/**
+ * Return the number of decimal places required to represent a numeric step.
+ * Supports both ordinary decimals and scientific notation.
+ *
+ * @param {number|string|undefined} value
+ * @returns {number|undefined}
+ */
+function getDecimalPlaces(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return undefined;
+  }
+
+  const [coefficient, exponentString = "0"] = numericValue
+    .toString()
+    .toLowerCase()
+    .split("e");
+
+  const fractionLength = coefficient.split(".")[1]?.length ?? 0;
+  const exponent = Number(exponentString);
+
+  return Math.max(0, fractionLength - exponent);
+}
+
 // Define a custom editor class extending AbstractEditor
 export class MinMaxEditor extends AbstractEditor {
   register() {
@@ -55,18 +83,22 @@ export class MinMaxEditor extends AbstractEditor {
     const minKey = Object.keys(properties).find((k) => k.includes("min"));
     const maxKey = Object.keys(properties).find((k) => k.includes("max"));
 
+    const step = properties[minKey].step ?? properties[maxKey].step;
+    const round = getDecimalPlaces(step);
+
     // Define attributes for the range slider
     const attributes = {
       min: properties[minKey].minimum,
       max: properties[maxKey].maximum,
       // only positive integer supported
-      step: properties[minKey].step || properties[maxKey].step,
-      value1: startVals?.[minKey] || properties[minKey].default,
-      value2: startVals?.[maxKey] || properties[maxKey].default,
+      step,
+      value1: startVals?.[minKey] ?? properties[minKey].default,
+      value2: startVals?.[maxKey] ?? properties[maxKey].default,
       "generate-labels": "true",
       "generate-labels-text-color": "currentColor",
       "slider-width": "100%",
       "range-dragging": "false",
+      ...(round !== undefined && { round }),
     };
     setAttributes(range, attributes);
 

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -28,3 +28,4 @@ export {
   loadStepsEditorCascadingResetTest,
   loadStepsEditorConditionalTest,
 } from "./load-steps-editor";
+export { default as loadMinMaxEditorTest } from "./load-minmax-editor";

--- a/elements/jsonform/test/cases/load-minmax-editor.js
+++ b/elements/jsonform/test/cases/load-minmax-editor.js
@@ -1,0 +1,50 @@
+import { html } from "lit";
+
+/**
+ * Test to ensure the minmax editor correctly handles the step and round attributes
+ */
+const loadMinMaxEditorTest = () => {
+  const schema = {
+    type: "object",
+    properties: {
+      vminmax: {
+        type: "object",
+        format: "minmax",
+        properties: {
+          vmin: {
+            type: "number",
+            minimum: 0,
+            default: 0,
+            step: 0.001,
+            format: "range",
+          },
+          vmax: {
+            type: "number",
+            maximum: 0.0075,
+            default: 0.005,
+            step: 0.001,
+            format: "range",
+          },
+        },
+      },
+    },
+  };
+
+  cy.mount(html`<eox-jsonform .schema=${schema}></eox-jsonform>`);
+
+  cy.get("eox-jsonform").should(([$el]) => {
+    expect($el.editor).to.not.be.undefined;
+  });
+
+  cy.get("eox-jsonform")
+    .shadow()
+    .within(() => {
+      cy.get("tc-range-slider")
+        .should("have.attr", "step", "0.001")
+        .and("have.attr", "round", "3")
+        .and("have.attr", "value1", "0")
+        .and("have.attr", "value2", "0.005");
+    });
+};
+
+export default loadMinMaxEditorTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -29,6 +29,7 @@ import {
   loadStepsEditorInteractionTest,
   loadStepsEditorCascadingResetTest,
   loadStepsEditorConditionalTest,
+  loadMinMaxEditorTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -66,4 +67,6 @@ describe("Jsonform", () => {
     loadStepsEditorCascadingResetTest());
   it("handles steps editor conditional if/then", () =>
     loadStepsEditorConditionalTest());
+  it("loads the minmax editor with correct precision", () =>
+    loadMinMaxEditorTest());
 });

--- a/elements/layercontrol/src/enums/stories/index.js
+++ b/elements/layercontrol/src/enums/stories/index.js
@@ -340,6 +340,7 @@ const LAYERCONFIG_LAYER_SEE = {
             maximum: 5,
             format: "range",
             default: 2,
+            step: 0.001,
           },
           vmax: {
             type: "number",


### PR DESCRIPTION
## Implemented changes

Enhances the minmax custom editor in eox-jsonform by automatically calculating the decimal precision for the range slider based on the provided step attribute.

 Previously, the underlying slider used a default rounding of 2 decimal places, which caused higher-precision values (e.g., 0.005) to be rounded incorrectly.

### Changes:
- Added getDecimalPlaces helper to determine precision from step (supporting decimals and scientific notation).
- Replaced || with ?? when handling numeric properties to correctly support 0 as a valid value.
- Added a test

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
