### PR TITLE
fix: robust FlatGeoBuf bbox calculation for poles and antimeridian crossings

### DIFF
--- a/elements/map/src/custom/sources/FlatGeoBuf.js
+++ b/elements/map/src/custom/sources/FlatGeoBuf.js
@@ -1,4 +1,5 @@
-import { transformExtent } from "ol/proj";
+import { transformExtent, transform } from "../../helpers/transform";
+import { containsCoordinate } from "ol/extent";
 import { deserialize } from "flatgeobuf/lib/mjs/geojson";
 import Vector from "ol/source/Vector.js";
 import GeoJSON from "ol/format/GeoJSON";
@@ -32,12 +33,63 @@ class FlatGeoBuf extends Vector {
    * @returns
    */
   fgbBoundingBox(extent, projection) {
-    // minx, miny, maxx, maxy
+    const sourceProjectionCode = projection.getCode();
+    const dataProjectionCode =
+      typeof this.dataProjection === "string"
+        ? this.dataProjection
+        : this.dataProjection.getCode();
+
+    // Use OL's transformExtent with densification (stops)
+    // to better handle non-linear transformations (like polar)
     const transformedExtent = transformExtent(
       extent,
-      projection.getCode(),
-      this.dataProjection,
+      sourceProjectionCode,
+      dataProjectionCode,
+      20,
     );
+
+    // If source is not the same as data projection, we perform more robust checks
+    if (sourceProjectionCode !== dataProjectionCode) {
+      // Check if the extent contains the poles in polar projections
+      // Transform pole coordinates to source projection
+      const poleNorth = transform([0, 90], "EPSG:4326", sourceProjectionCode);
+      const poleSouth = transform([0, -90], "EPSG:4326", sourceProjectionCode);
+
+      const containsNorthPole = containsCoordinate(extent, poleNorth);
+      const containsSouthPole = containsCoordinate(extent, poleSouth);
+
+      if (containsNorthPole || containsSouthPole) {
+        // If it contains a pole, the extent in 4326 should cover all longitudes
+        transformedExtent[0] = -180;
+        transformedExtent[2] = 180;
+        if (containsNorthPole) {
+          transformedExtent[3] = 90;
+        }
+        if (containsSouthPole) {
+          transformedExtent[1] = -90;
+        }
+      }
+
+      // Antimeridian check
+      const leftLon = transform(
+        [extent[0], (extent[1] + extent[3]) / 2],
+        sourceProjectionCode,
+        dataProjectionCode,
+      )[0];
+      const rightLon = transform(
+        [extent[2], (extent[1] + extent[3]) / 2],
+        sourceProjectionCode,
+        dataProjectionCode,
+      )[0];
+      if (leftLon > rightLon) {
+        // If the left longitude is greater than the right one,
+        // it means we've crossed the antimeridian (180/-180).
+        // In this case, we expand the extent to cover all longitudes.
+        transformedExtent[0] = -180;
+        transformedExtent[2] = 180;
+      }
+    }
+
     return {
       minX: transformedExtent[0],
       minY: transformedExtent[1],

--- a/elements/map/src/custom/sources/FlatGeoBuf.js
+++ b/elements/map/src/custom/sources/FlatGeoBuf.js
@@ -71,16 +71,21 @@ class FlatGeoBuf extends Vector {
       }
 
       // Antimeridian check
-      const leftLon = transform(
-        [extent[0], (extent[1] + extent[3]) / 2],
-        sourceProjectionCode,
-        dataProjectionCode,
-      )[0];
-      const rightLon = transform(
-        [extent[2], (extent[1] + extent[3]) / 2],
-        sourceProjectionCode,
-        dataProjectionCode,
-      )[0];
+      const normalizeLon = (lon) => ((((lon + 180) % 360) + 360) % 360) - 180;
+      const leftLon = normalizeLon(
+        transform(
+          [extent[0], (extent[1] + extent[3]) / 2],
+          sourceProjectionCode,
+          dataProjectionCode,
+        )[0],
+      );
+      const rightLon = normalizeLon(
+        transform(
+          [extent[2], (extent[1] + extent[3]) / 2],
+          sourceProjectionCode,
+          dataProjectionCode,
+        )[0],
+      );
       if (leftLon > rightLon) {
         // If the left longitude is greater than the right one,
         // it means we've crossed the antimeridian (180/-180).

--- a/elements/map/src/custom/sources/FlatGeoBuf.js
+++ b/elements/map/src/custom/sources/FlatGeoBuf.js
@@ -30,9 +30,9 @@ class FlatGeoBuf extends Vector {
    * transform an ol extent into FlatGeoBuf-format
    * @param {import("ol/extent").Extent} extent
    * @param {import("ol/proj").Projection} projection
-   * @returns
+   * @returns {Array<{minX: number, minY: number, maxX: number, maxY: number}>}
    */
-  fgbBoundingBox(extent, projection) {
+  fgbBoundingBoxes(extent, projection) {
     const sourceProjectionCode = projection.getCode();
     const dataProjectionCode =
       typeof this.dataProjection === "string"
@@ -45,8 +45,15 @@ class FlatGeoBuf extends Vector {
       extent,
       sourceProjectionCode,
       dataProjectionCode,
-      20,
+      50,
     );
+
+    const baseRect = {
+      minX: transformedExtent[0],
+      minY: transformedExtent[1],
+      maxX: transformedExtent[2],
+      maxY: transformedExtent[3],
+    };
 
     // If source is not the same as data projection, we perform more robust checks
     if (sourceProjectionCode !== dataProjectionCode) {
@@ -60,47 +67,79 @@ class FlatGeoBuf extends Vector {
 
       if (containsNorthPole || containsSouthPole) {
         // If it contains a pole, the extent in 4326 should cover all longitudes
-        transformedExtent[0] = -180;
-        transformedExtent[2] = 180;
+        baseRect.minX = -180;
+        baseRect.maxX = 180;
         if (containsNorthPole) {
-          transformedExtent[3] = 90;
+          baseRect.maxY = 90;
         }
         if (containsSouthPole) {
-          transformedExtent[1] = -90;
+          baseRect.minY = -90;
         }
+        return [baseRect];
       }
 
       // Antimeridian check
       const normalizeLon = (lon) => ((((lon + 180) % 360) + 360) % 360) - 180;
-      const leftLon = normalizeLon(
-        transform(
-          [extent[0], (extent[1] + extent[3]) / 2],
-          sourceProjectionCode,
-          dataProjectionCode,
-        )[0],
-      );
-      const rightLon = normalizeLon(
-        transform(
-          [extent[2], (extent[1] + extent[3]) / 2],
-          sourceProjectionCode,
-          dataProjectionCode,
-        )[0],
-      );
-      if (leftLon > rightLon) {
-        // If the left longitude is greater than the right one,
-        // it means we've crossed the antimeridian (180/-180).
-        // In this case, we expand the extent to cover all longitudes.
-        transformedExtent[0] = -180;
-        transformedExtent[2] = 180;
+      const stops = 10;
+      const segments = [
+        [
+          [extent[0], extent[1]],
+          [extent[0], extent[3]],
+        ], // left edge
+        [
+          [extent[2], extent[1]],
+          [extent[2], extent[3]],
+        ], // right edge
+        [
+          [extent[0], extent[1]],
+          [extent[2], extent[1]],
+        ], // bottom edge
+        [
+          [extent[0], extent[3]],
+          [extent[2], extent[3]],
+        ], // top edge
+      ];
+      let crossesAntimeridian = false;
+      let minLonPos = 180;
+      let maxLonNeg = -180;
+      let hasPos = false;
+      let hasNeg = false;
+
+      for (const [start, end] of segments) {
+        let prevLon = null;
+        for (let i = 0; i <= stops; i++) {
+          const coords = [
+            start[0] + (end[0] - start[0]) * (i / stops),
+            start[1] + (end[1] - start[1]) * (i / stops),
+          ];
+          const lon = normalizeLon(
+            transform(coords, sourceProjectionCode, dataProjectionCode)[0],
+          );
+          if (lon >= 0) {
+            minLonPos = Math.min(minLonPos, lon);
+            hasPos = true;
+          } else {
+            maxLonNeg = Math.max(maxLonNeg, lon);
+            hasNeg = true;
+          }
+          if (prevLon !== null && Math.abs(lon - prevLon) > 180) {
+            crossesAntimeridian = true;
+          }
+          prevLon = lon;
+        }
+      }
+
+      if (crossesAntimeridian && hasPos && hasNeg) {
+        // If we've crossed the antimeridian (180/-180),
+        // we return two boxes: one for the positive side and one for the negative side.
+        return [
+          { ...baseRect, minX: minLonPos, maxX: 180 },
+          { ...baseRect, minX: -180, maxX: maxLonNeg },
+        ];
       }
     }
 
-    return {
-      minX: transformedExtent[0],
-      minY: transformedExtent[1],
-      maxX: transformedExtent[2],
-      maxY: transformedExtent[3],
-    };
+    return [baseRect];
   }
 
   /**
@@ -108,46 +147,48 @@ class FlatGeoBuf extends Vector {
    * @this {FlatGeoBuf}
    */
   async loader(extent, _, projection, success, failure) {
-    const rect = this.fgbBoundingBox(extent, projection);
+    const rects = this.fgbBoundingBoxes(extent, projection);
     try {
-      // Use flatgeobuf JavaScript API to iterate features as geojson.
-      // Because we specify a bounding box, flatgeobuf will only fetch the relevant subset of data,
-      // rather than the entire file.
-      if (rect.minX !== -Infinity) {
-        /**
-         * @type {Array<import("ol/Feature").default>}
-         */
-        const features = [];
-        const geoJsonFormat = new GeoJSON({
-          featureProjection: projection,
-          dataProjection: this.dataProjection,
-        });
-        const usedIds = new Set();
-        let fallbackCounter = 0;
-        for (const url of this.resourceURLs) {
+      /**
+       * @type {Array<import("ol/Feature").default>}
+       */
+      const features = [];
+      const usedIds = new Set();
+      let fallbackCounter = 0;
+      const geoJsonFormat = new GeoJSON({
+        featureProjection: projection,
+        dataProjection: this.dataProjection,
+      });
+
+      for (const url of this.resourceURLs) {
+        for (const rect of rects) {
+          if (rect.minX === -Infinity || rect.maxX === Infinity) continue;
           const iter = deserialize(url, rect);
           for await (const feature of iter) {
             const olFeature = geoJsonFormat.readFeature(feature);
             //@ts-expect-error for GeoJSON-Format this should always be a single feature.
-            let id = olFeature.getId();
-            // If no ID exists, or it's already used, generate a new one
-            if (id == null || usedIds.has(id)) {
-              // Generate unique fallback ID
-              do {
-                id = `auto_${fallbackCounter++}`;
-              } while (usedIds.has(id));
-              //@ts-expect-error for GeoJSON-Format this should always be a single feature.
-              olFeature.setId(id);
+            const id = olFeature.getId();
+
+            const actualId =
+              id !== null && id !== undefined ? id : fallbackCounter++;
+            // Create a unique internal ID combining URL and feature ID
+            // to allow deduplication across split boxes but keep features from different URLs
+            const combinedId = `${url}_${actualId}`;
+            if (usedIds.has(combinedId)) {
+              continue;
             }
-            usedIds.add(id);
+            usedIds.add(combinedId);
+
+            //@ts-expect-error for GeoJSON-Format this should always be a single feature.
+            olFeature.setId(combinedId);
             //@ts-expect-error for GeoJSON-Format this should always be a single feature.
             features.push(olFeature);
           }
         }
-        super.clear();
-        super.addFeatures(features);
-        success(features);
       }
+      super.clear();
+      super.addFeatures(features);
+      success(features);
     } catch (_) {
       failure();
     }

--- a/elements/map/src/helpers/transform.js
+++ b/elements/map/src/helpers/transform.js
@@ -24,11 +24,17 @@ export function transform(coordinate, source, destination = undefined) {
  * @param {import('ol/extent').Extent} extent
  * @param {import('ol/proj').ProjectionLike} source
  * @param {import('ol/proj').ProjectionLike=} destination
+ * @param {number=} stops
  * @returns {import('ol/extent').Extent}
  */
-export function transformExtent(extent, source, destination = undefined) {
+export function transformExtent(
+  extent,
+  source,
+  destination = undefined,
+  stops = undefined,
+) {
   if (!destination) {
     destination = "EPSG:4326";
   }
-  return olTransformExtent(extent, source, destination);
+  return olTransformExtent(extent, source, destination, stops);
 }

--- a/elements/map/test/cases/layer-type/index.js
+++ b/elements/map/test/cases/layer-type/index.js
@@ -13,3 +13,4 @@ export { default as loadVectorLayer } from "./load-vector-layer";
 export { default as loadClusterLayer } from "./load-cluster-layer";
 export { default as applyGeojsonFormat } from "./apply-geojson-format";
 export { default as loadInlineGeojson } from "./load-inline-geojson";
+export { default as testFlatGeoBufPolarLogic } from "./test-flatgeobuf-polar-logic";

--- a/elements/map/test/cases/layer-type/test-flatgeobuf-polar-logic.js
+++ b/elements/map/test/cases/layer-type/test-flatgeobuf-polar-logic.js
@@ -1,0 +1,45 @@
+import FlatGeoBuf from "../../../src/custom/sources/FlatGeoBuf";
+import registerProjection from "../../../src/helpers/register-projection";
+import Projection from "ol/proj/Projection";
+
+/**
+ * Tests the logic of FlatGeoBuf bounding box calculation
+ */
+const testFlatGeoBufPolarLogic = () => {
+  // Register EPSG:3413 (North Pole)
+  registerProjection(
+    "EPSG:3413",
+    "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+  );
+
+  const source = new FlatGeoBuf({
+    url: "test.fgb",
+    projection: "EPSG:4326",
+  });
+
+  // 1. Test Pole Crossing
+  // In EPSG:3413, the North Pole is at (0, 0)
+  const poleExtent = [-1000, -1000, 1000, 1000];
+  const poleProjection = new Projection({ code: "EPSG:3413" });
+
+  const poleBbox = source.fgbBoundingBox(poleExtent, poleProjection);
+
+  expect(poleBbox.minX).to.equal(-180, "North pole crossing sets minX to -180");
+  expect(poleBbox.maxX).to.equal(180, "North pole crossing sets maxX to 180");
+  expect(poleBbox.maxY).to.equal(90, "North pole crossing sets maxY to 90");
+
+  // 2. Test Antimeridian Crossing
+  // In EPSG:3857, the antimeridian is around 20037508
+  const antimeridianExtent = [20037000, 0, 20038000, 1000];
+  const webMercator = new Projection({ code: "EPSG:3857" });
+
+  const antiBbox = source.fgbBoundingBox(antimeridianExtent, webMercator);
+
+  expect(antiBbox.minX).to.equal(
+    -180,
+    "Antimeridian crossing sets minX to -180",
+  );
+  expect(antiBbox.maxX).to.equal(180, "Antimeridian crossing sets maxX to 180");
+};
+
+export default testFlatGeoBufPolarLogic;

--- a/elements/map/test/cases/layer-type/test-flatgeobuf-polar-logic.js
+++ b/elements/map/test/cases/layer-type/test-flatgeobuf-polar-logic.js
@@ -22,24 +22,60 @@ const testFlatGeoBufPolarLogic = () => {
   const poleExtent = [-1000, -1000, 1000, 1000];
   const poleProjection = new Projection({ code: "EPSG:3413" });
 
-  const poleBbox = source.fgbBoundingBox(poleExtent, poleProjection);
+  const poleBboxes = source.fgbBoundingBoxes(poleExtent, poleProjection);
 
-  expect(poleBbox.minX).to.equal(-180, "North pole crossing sets minX to -180");
-  expect(poleBbox.maxX).to.equal(180, "North pole crossing sets maxX to 180");
-  expect(poleBbox.maxY).to.equal(90, "North pole crossing sets maxY to 90");
+  expect(poleBboxes[0].minX).to.equal(
+    -180,
+    "North pole crossing sets minX to -180",
+  );
+  expect(poleBboxes[0].maxX).to.equal(
+    180,
+    "North pole crossing sets maxX to 180",
+  );
+  expect(poleBboxes[0].maxY).to.equal(
+    90,
+    "North pole crossing sets maxY to 90",
+  );
 
   // 2. Test Antimeridian Crossing
   // In EPSG:3857, the antimeridian is around 20037508
   const antimeridianExtent = [20037000, 0, 20038000, 1000];
   const webMercator = new Projection({ code: "EPSG:3857" });
 
-  const antiBbox = source.fgbBoundingBox(antimeridianExtent, webMercator);
+  const antiBboxes = source.fgbBoundingBoxes(antimeridianExtent, webMercator);
 
-  expect(antiBbox.minX).to.equal(
-    -180,
-    "Antimeridian crossing sets minX to -180",
+  expect(antiBboxes.length).to.equal(
+    2,
+    "Antimeridian crossing returns 2 boxes",
   );
-  expect(antiBbox.maxX).to.equal(180, "Antimeridian crossing sets maxX to 180");
+  expect(antiBboxes[0].maxX).to.equal(180, "Box A ends at 180");
+  expect(antiBboxes[1].minX).to.equal(-180, "Box B starts at -180");
+
+  // 3. Test Antimeridian Crossing in Polar Projection (without containing the pole)
+  const polarAntimeridianExtent = [-1500, 500, -500, 1500];
+  const polarAntiBboxes = source.fgbBoundingBoxes(
+    polarAntimeridianExtent,
+    poleProjection,
+  );
+
+  expect(polarAntiBboxes.length).to.equal(
+    2,
+    "Polar antimeridian crossing returns 2 boxes",
+  );
+
+  // 4. Negative Test: Normal Extent
+  // Ensure a "normal" extent (Austria) doesn't get expanded
+  const normalExtent = [1000000, 5000000, 2000000, 6000000]; // EPSG:3857
+  const normalBboxes = source.fgbBoundingBoxes(normalExtent, webMercator);
+  expect(normalBboxes.length).to.equal(1, "Normal extent returns 1 box");
+  expect(normalBboxes[0].minX).to.be.greaterThan(
+    -180,
+    "Normal extent does not expand minX to -180",
+  );
+  expect(normalBboxes[0].maxX).to.be.lessThan(
+    180,
+    "Normal extent does not expand maxX to 180",
+  );
 };
 
 export default testFlatGeoBufPolarLogic;

--- a/elements/map/test/flatGeoBuf.cy.js
+++ b/elements/map/test/flatGeoBuf.cy.js
@@ -1,7 +1,10 @@
 import "../src/main";
 import "../src/plugins/advancedLayersAndSources/index";
-import { flatGeoBufLayer } from "./cases/layer-type";
-import { flatGeoBufLayerCombined } from "./cases/layer-type";
+import {
+  flatGeoBufLayer,
+  flatGeoBufLayerCombined,
+  testFlatGeoBufPolarLogic,
+} from "./cases/layer-type";
 
 /**
  * Test suite for the EOX Map to load a layer with a  FlatGeoBuf source
@@ -11,6 +14,12 @@ describe("FlatGeoBuf Source", () => {
    * Test case to load flatgeobuf source
    */
   it("loads a FlatGeoBuf source", () => flatGeoBufLayer());
+
+  /**
+   * Test case to verify polar and antimeridian logic
+   */
+  it("correctly calculates bbox for polar and antimeridian crossings", () =>
+    testFlatGeoBufPolarLogic());
 });
 
 /**


### PR DESCRIPTION
## Implemented changes

This PR improves the data fetching logic for the FlatGeoBuf source rect bbox for global, polar, and wrap-around map views.                                                                                                                                                         
                                                                                                                                                                
Previously, the bounding box for FlatGeoBuf requests was calculated (in our integration) by transforming only the corners of the map current view extent. This often failed to capture the true footprint in EPSG:4326 when crossing the poles or the antimeridian, resulting in data not being requested if the view contained e.g. north pole.
                                                                                                                           
### Key Changes:                                                                                                                                                   
- Densified Extent Transformation: Updated transformExtent helper to support "stops" (sampling points), allowing OpenLayers to accurately calculate the transformed bounding box for non-linear projections. (not sure if really needed but keeping it)
- Polar Crossing Detection: Implemented explicit checks for North/South Pole. If a pole is within the map extent, the request bounding box is expanded to cover the whole crs extent (of that pole)
- Antimeridian Wrap-around Support: Added logic to detect antimeridian crossings by comparing normalized longitudes of the extent edges. When a crossing is detected, the request expands to a full global longitude range (-180 to 180).                                                                                                                     
 - Added a unit test for both methods.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
