### PR TITLE
chore: point examples link to an actual narratives catalog

### DIFF
--- a/elements/storytelling/README.md
+++ b/elements/storytelling/README.md
@@ -2,7 +2,7 @@
 
 ## Examples
 
-[Examples](https://eox-a.github.io/EOxElements/elements/storytelling/examples/index.html)
+[Examples of built stories](https://eoxhub-workspaces.github.io/preview-narratives/?preview_url=https://esa-eodashboards.github.io/eodashboard-narratives/)
 
 ## Usage
 


### PR DESCRIPTION
## Implemented changes

Current storytelling examples link gives a 404. The new link points to the eodashboard-narratives via a preview instance, so that we have a showcase of well developed and advanced existing narratives.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [ ] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [ ] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [ ] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
