### PR TITLE
fix: minmax slider precision rounding and branch defaults

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,6 @@
 import { defineConfig } from "cypress";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
 const pathsChanged = process.env.CI_PATHS_CHANGED;
 
 // by default all component tests are run

--- a/elements/jsonform/src/custom-inputs/minmax.js
+++ b/elements/jsonform/src/custom-inputs/minmax.js
@@ -138,15 +138,21 @@ export class MinMaxEditor extends AbstractEditor {
     }
 
     // Add event listener for change events on the range slider
-    this.input.addEventListener("change", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.value = {
-        [minKey]: range.value1 ?? e.detail.value1,
-        [maxKey]: range.value2 ?? e.detail.value2,
-      };
-      this.onChange(true);
-    });
+    this.input.addEventListener(
+      "change",
+      /** @type {EventListener} */ (
+        (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const customEvent = /** @type {CustomEvent} */ (e);
+          this.value = {
+            [minKey]: range.value1 ?? customEvent.detail?.value1,
+            [maxKey]: range.value2 ?? customEvent.detail?.value2,
+          };
+          this.onChange(true);
+        }
+      ),
+    );
 
     this.container.appendChild(this.control);
 

--- a/elements/jsonform/src/custom-inputs/minmax.js
+++ b/elements/jsonform/src/custom-inputs/minmax.js
@@ -3,62 +3,92 @@ import "toolcool-range-slider/dist/plugins/tcrs-generated-labels.min.js";
 import "toolcool-range-slider";
 
 /**
- * Set multiple attributes to an element
+ * Return decimal places for step (supports scientific notation).
  *
- * @param {Element} element - The DOM element to set attributes on
- * @param {{[key: string]: any}} attributes - The attributes to set on the element
- */
-function setAttributes(element, attributes) {
-  Object.keys(attributes).forEach((attr) => {
-    element.setAttribute(attr, attributes[attr]);
-  });
-}
-
-/**
- * Return the number of decimal places required to represent a numeric step.
- * Supports both ordinary decimals and scientific notation.
- *
- * @param {number|string|undefined} value
+ * @param {number|string|undefined} val
  * @returns {number|undefined}
  */
-function getDecimalPlaces(value) {
-  if (value === undefined || value === null || value === "") {
-    return undefined;
-  }
-
-  const numericValue = Number(value);
-  if (!Number.isFinite(numericValue) || numericValue <= 0) {
-    return undefined;
-  }
-
-  const [coefficient, exponentString = "0"] = numericValue
-    .toString()
-    .toLowerCase()
-    .split("e");
-
-  const fractionLength = coefficient.split(".")[1]?.length ?? 0;
-  const exponent = Number(exponentString);
-
-  return Math.max(0, fractionLength - exponent);
+function getDecimalPlaces(val) {
+  const num = Number(val);
+  if (!Number.isFinite(num) || num <= 0) return undefined;
+  const [coeff, exp = 0] = num.toString().toLowerCase().split("e");
+  return Math.max(0, (coeff.split(".")[1]?.length ?? 0) - Number(exp));
 }
 
 // Define a custom editor class extending AbstractEditor
 export class MinMaxEditor extends AbstractEditor {
-  register() {
-    super.register();
+  _getConfig() {
+    const props = this.schema?.properties || {};
+    const minKey = Object.keys(props).find((k) => k.includes("min")) || "min";
+    const maxKey = Object.keys(props).find((k) => k.includes("max")) || "max";
+    const minProp = props[minKey] || {};
+    const maxProp = props[maxKey] || {};
+    const step = minProp.step ?? maxProp.step;
+    return {
+      minKey,
+      maxKey,
+      minProp,
+      maxProp,
+      step,
+      round: getDecimalPlaces(step),
+    };
   }
 
-  unregister() {
-    super.unregister();
+  getDefault() {
+    const { minKey, maxKey, minProp, maxProp } = this._getConfig();
+    return { [minKey]: minProp.default, [maxKey]: maxProp.default };
+  }
+
+  getValue() {
+    if (!this.dependenciesFulfilled) return undefined;
+    const { minKey, maxKey, minProp, maxProp } = this._getConfig();
+    return {
+      [minKey]: this.input?.value1 ?? this.value?.[minKey] ?? minProp.default,
+      [maxKey]: this.input?.value2 ?? this.value?.[maxKey] ?? maxProp.default,
+    };
+  }
+
+  setValue(value) {
+    const { minKey, maxKey, minProp, maxProp, round } = this._getConfig();
+    let vMin =
+      typeof value?.[minKey] === "number" && Number.isFinite(value[minKey])
+        ? value[minKey]
+        : minProp.default;
+    let vMax =
+      typeof value?.[maxKey] === "number" && Number.isFinite(value[maxKey])
+        ? value[maxKey]
+        : maxProp.default;
+
+    if (minProp.minimum !== undefined && vMin < minProp.minimum)
+      vMin = minProp.default;
+    if (maxProp.maximum !== undefined && vMax > maxProp.maximum)
+      vMax = maxProp.default;
+
+    this.value = { [minKey]: vMin, [maxKey]: vMax };
+
+    if (this.input) {
+      if (round !== undefined) {
+        this.input.round = round;
+        this.input.setAttribute("round", String(round));
+      }
+      if (vMin !== undefined) {
+        this.input.value1 = vMin;
+        this.input.setAttribute("value1", String(vMin));
+      }
+      if (vMax !== undefined) {
+        this.input.value2 = vMax;
+        this.input.setAttribute("value2", String(vMax));
+      }
+    }
+
+    this.onChange(true);
   }
 
   // Build the editor UI
   build() {
-    const properties = this.schema.properties;
-    const options = this.options;
-    const description = this.schema.description;
-    const theme = this.theme;
-    const startVals = this.defaults.startVals[this.key];
+    const { minKey, maxKey, minProp, maxProp, step, round } = this._getConfig();
+    const { options = {}, schema = {}, theme } = this;
+    const startVals = options.startval ?? this.defaults?.startVals?.[this.key];
 
     // Create label and description elements if not in compact mode
     if (!options.compact)
@@ -66,9 +96,9 @@ export class MinMaxEditor extends AbstractEditor {
         this.getTitle(),
         this.isRequired(),
       );
-    if (description)
+    if (schema.description)
       this.description = theme.getFormInputDescription(
-        this.translateProperty(description),
+        this.translateProperty(schema.description),
       );
     if (options.infoText)
       this.infoButton = theme.getInfoButton(
@@ -76,31 +106,22 @@ export class MinMaxEditor extends AbstractEditor {
       );
 
     // Create the range slider element
-    const range = /** @type {HTMLInputElement}*/ (
-      document.createElement("tc-range-slider")
-    );
-    // TODO - better logic to find min & max properties?
-    const minKey = Object.keys(properties).find((k) => k.includes("min"));
-    const maxKey = Object.keys(properties).find((k) => k.includes("max"));
+    const range =
+      /** @type {HTMLInputElement & { round?: number, value1?: number, value2?: number }} */ (
+        document.createElement("tc-range-slider")
+      );
 
-    const step = properties[minKey].step ?? properties[maxKey].step;
-    const round = getDecimalPlaces(step);
-
-    // Define attributes for the range slider
-    const attributes = {
-      min: properties[minKey].minimum,
-      max: properties[maxKey].maximum,
-      // only positive integer supported
-      step,
-      value1: startVals?.[minKey] ?? properties[minKey].default,
-      value2: startVals?.[maxKey] ?? properties[maxKey].default,
+    const attrs = {
+      ...(round !== undefined && { round }),
+      ...(minProp.minimum !== undefined && { min: minProp.minimum }),
+      ...(maxProp.maximum !== undefined && { max: maxProp.maximum }),
+      ...(step !== undefined && { step }),
       "generate-labels": "true",
       "generate-labels-text-color": "currentColor",
       "slider-width": "100%",
       "range-dragging": "false",
-      ...(round !== undefined && { round }),
     };
-    setAttributes(range, attributes);
+    Object.entries(attrs).forEach(([k, v]) => range.setAttribute(k, String(v)));
 
     this.input = range;
     this.input.id = this.formname;
@@ -111,41 +132,38 @@ export class MinMaxEditor extends AbstractEditor {
       this.infoButton,
     );
 
-    if (this.schema.readOnly || this.schema.readonly) {
+    if (schema.readOnly || schema.readonly) {
       this.disable(true);
       this.input.disabled = true;
     }
 
     // Add event listener for change events on the range slider
-    this.input.addEventListener(
-      "change",
-      /** @type {EventListener} */ (
-        /**
-         * @param {CustomEvent} e
-         */
-        (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          this.value = {
-            [minKey]: e.detail.value1,
-            [maxKey]: e.detail.value2,
-          };
-          this.onChange(true);
-        }
-      ),
-    );
+    this.input.addEventListener("change", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.value = {
+        [minKey]: range.value1 ?? e.detail.value1,
+        [maxKey]: range.value2 ?? e.detail.value2,
+      };
+      this.onChange(true);
+    });
 
     this.container.appendChild(this.control);
+
+    // Initialize values and precision
+    this.setValue(
+      startVals ?? {
+        [minKey]: minProp.default,
+        [maxKey]: maxProp.default,
+      },
+    );
   }
 
   // Destroy the editor and remove all associated elements
   destroy() {
-    if (this.label && this.label.parentNode)
-      this.label.parentNode.removeChild(this.label);
-    if (this.description && this.description.parentNode)
-      this.description.parentNode.removeChild(this.description);
-    if (this.input && this.input.parentNode)
-      this.input.parentNode.removeChild(this.input);
+    this.label?.parentNode?.removeChild(this.label);
+    this.description?.parentNode?.removeChild(this.description);
+    this.input?.parentNode?.removeChild(this.input);
     super.destroy();
   }
 }

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -29,3 +29,4 @@ export {
   loadStepsEditorConditionalTest,
 } from "./load-steps-editor";
 export { default as loadMinMaxEditorTest } from "./load-minmax-editor";
+export { default as loadMinMaxBranchSwitchTest } from "./load-minmax-branch-switch";

--- a/elements/jsonform/test/cases/load-minmax-branch-switch.js
+++ b/elements/jsonform/test/cases/load-minmax-branch-switch.js
@@ -1,0 +1,97 @@
+import { html } from "lit";
+import schemaFixture from "../fixtures/rasterformBranchingSchema.json";
+
+/**
+ * Updates URL parameters with given form values
+ *
+ * @param {string} url
+ * @param {Record<string, any>} values
+ * @returns {string}
+ */
+function updateUrl(url, values) {
+  const parsedUrl = new URL(url);
+  Object.entries(values).forEach(([key, value]) => {
+    if (typeof value === "object" && !Array.isArray(value) && value !== null) {
+      Object.keys(value).forEach((k) => {
+        parsedUrl.searchParams.set(k, value[k]);
+      });
+    } else if (Array.isArray(value)) {
+      parsedUrl.searchParams.delete(key);
+      value.forEach((v) => {
+        parsedUrl.searchParams.append(key, v);
+      });
+    } else {
+      parsedUrl.searchParams.set(key, value);
+    }
+  });
+  return parsedUrl.href;
+}
+
+/**
+ * Test switching between anyOf branches with minmax sliders and checking default values and source URL
+ */
+const loadMinMaxBranchSwitchTest = () => {
+  cy.intercept("**/mock-rasterform-schema.json", (req) => {
+    req.reply(schemaFixture);
+  });
+
+  const baseUrl =
+    "https://example.com/stac/collections/RCM_NERSC/tiles/UPSArcticWGS84Quad/{z}/{x}/{y}?assets=HH&rescale=0,0.05&colormap_name=gray";
+  let currentSourceUrl = baseUrl;
+
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${"/mock-rasterform-schema.json"}
+      @change=${(/** @type {CustomEvent<Record<string, any>>} */ e) => {
+        currentSourceUrl = updateUrl(baseUrl, e.detail);
+      }}
+    ></eox-jsonform>`,
+  );
+
+  cy.get("eox-jsonform").should(([$el]) => {
+    expect($el.editor).to.not.be.undefined;
+  });
+
+  // Verify initial branch (HH)
+  cy.get("eox-jsonform")
+    .shadow()
+    .within(() => {
+      cy.get("tc-range-slider")
+        .should("have.attr", "step", "0.005")
+        .and("have.attr", "round", "3")
+        .and("have.attr", "value1", "0")
+        .and("have.attr", "value2", "0.05");
+    });
+
+  // Switch to HV branch in anyOf selector
+  cy.get("eox-jsonform")
+    .shadow()
+    .within(() => {
+      cy.get("select").first().select("HV");
+    });
+
+  // Verify switched branch (HV) slider attributes
+  cy.get("eox-jsonform")
+    .shadow()
+    .within(() => {
+      cy.get("tc-range-slider:visible")
+        .should("have.attr", "step", "0.0005")
+        .and("have.attr", "round", "4")
+        .and("have.attr", "value1", "0")
+        .and("have.attr", "value2", "0.005");
+    });
+
+  // Verify form values and updated source URL
+  cy.get("eox-jsonform").should(([$el]) => {
+    expect($el.value.assets).to.eq("HV");
+    expect($el.value.vminmax.vmin).to.eq(0);
+    expect($el.value.vminmax.vmax).to.eq(0.005);
+    expect($el.value.rescale).to.eq("0,0.005");
+
+    const decodedUrl = decodeURIComponent(currentSourceUrl);
+    expect(decodedUrl).to.include("assets=HV");
+    expect(decodedUrl).to.include("rescale=0,0.005");
+  });
+};
+
+export default loadMinMaxBranchSwitchTest;

--- a/elements/jsonform/test/cases/load-minmax-branch-switch.js
+++ b/elements/jsonform/test/cases/load-minmax-branch-switch.js
@@ -36,7 +36,7 @@ const loadMinMaxBranchSwitchTest = () => {
   });
 
   const baseUrl =
-    "https://example.com/stac/collections/RCM_NERSC/tiles/UPSArcticWGS84Quad/{z}/{x}/{y}?assets=HH&rescale=0,0.05&colormap_name=gray";
+    "https://example.com/{z}/{x}/{y}?assets=HH&rescale=0,0.05&colormap_name=gray";
   let currentSourceUrl = baseUrl;
 
   cy.mount(

--- a/elements/jsonform/test/fixtures/rasterformBranchingSchema.json
+++ b/elements/jsonform/test/fixtures/rasterformBranchingSchema.json
@@ -43,8 +43,7 @@
           },
           "options": {
             "hidden": true
-          },
-          "default": "0,0.05"
+          }
         },
         "colormap_name": {
           "type": "string",
@@ -93,8 +92,7 @@
           },
           "options": {
             "hidden": true
-          },
-          "default": "0,0.005"
+          }
         },
         "colormap_name": {
           "type": "string",

--- a/elements/jsonform/test/fixtures/rasterformBranchingSchema.json
+++ b/elements/jsonform/test/fixtures/rasterformBranchingSchema.json
@@ -1,0 +1,109 @@
+{
+  "type": "object",
+  "title": "Asset",
+  "options": {
+    "no_additional_properties": true
+  },
+  "anyOf": [
+    {
+      "title": "HH",
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "string",
+          "enum": ["HH"],
+          "default": "HH",
+          "options": { "hidden": true }
+        },
+        "vminmax": {
+          "type": "object",
+          "title": "Value Range",
+          "properties": {
+            "vmin": {
+              "type": "number",
+              "default": 0,
+              "format": "range",
+              "minimum": 0,
+              "step": 0.005
+            },
+            "vmax": {
+              "type": "number",
+              "default": 0.05,
+              "format": "range",
+              "maximum": 0.075
+            }
+          },
+          "format": "minmax"
+        },
+        "rescale": {
+          "type": "string",
+          "template": "{{vminmax.vmin}},{{vminmax.vmax}}",
+          "watch": {
+            "vminmax": "vminmax"
+          },
+          "options": {
+            "hidden": true
+          },
+          "default": "0,0.05"
+        },
+        "colormap_name": {
+          "type": "string",
+          "title": "Colormap",
+          "default": "gray",
+          "enum": ["gray", "viridis"]
+        }
+      },
+      "required": ["vminmax", "assets"]
+    },
+    {
+      "title": "HV",
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "string",
+          "enum": ["HV"],
+          "default": "HV",
+          "options": { "hidden": true }
+        },
+        "vminmax": {
+          "type": "object",
+          "title": "Value Range",
+          "properties": {
+            "vmin": {
+              "type": "number",
+              "default": 0,
+              "format": "range",
+              "minimum": 0,
+              "step": 0.0005
+            },
+            "vmax": {
+              "type": "number",
+              "default": 0.005,
+              "format": "range",
+              "maximum": 0.0075
+            }
+          },
+          "format": "minmax"
+        },
+        "rescale": {
+          "type": "string",
+          "template": "{{vminmax.vmin}},{{vminmax.vmax}}",
+          "watch": {
+            "vminmax": "vminmax"
+          },
+          "options": {
+            "hidden": true
+          },
+          "default": "0,0.005"
+        },
+        "colormap_name": {
+          "type": "string",
+          "title": "Colormap",
+          "default": "gray",
+          "enum": ["gray", "viridis"]
+        }
+      },
+      "required": ["vminmax", "assets"]
+    }
+  ]
+}

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -30,6 +30,7 @@ import {
   loadStepsEditorCascadingResetTest,
   loadStepsEditorConditionalTest,
   loadMinMaxEditorTest,
+  loadMinMaxBranchSwitchTest,
 } from "./cases";
 
 // Test suite for Jsonform
@@ -69,4 +70,6 @@ describe("Jsonform", () => {
     loadStepsEditorConditionalTest());
   it("loads the minmax editor with correct precision", () =>
     loadMinMaxEditorTest());
+  it("applies branch defaults when switching anyOf branches with minmax slider", () =>
+    loadMinMaxBranchSwitchTest());
 });


### PR DESCRIPTION
## Implemented changes                                                                                                                                       
- **MinMax Slider Precision & Initialization**:                                                                                                              
     - Prevented rounding to default 2 decimals caused by `tc-range-slider` evaluating values before setting `round` during element construction. (I also submitted an upstream [PR](https://github.com/mzusin/toolcool-range-slider/pull/25) for this).
     - Initialized `round`, `step`, `min`, `max` attributes prior to DOM attachment, then assigned initial values through `setValue()`.
   - **Value Lifecycle & Branch Switching**:
     - Implemented `getDefault()`, `getValue()`, and `setValue()` on `MinMaxEditor` with schema bounds validation and fallback to property defaults when  switching across `anyOf` branches.
     - Restructured and simplified the whole minmax slider and removed a few in my opinion unnecessary parts. Tests still pass and integration in eodash works as well.
   - **Testing & Tooling**:
     - Added test verifying branch switching and parameter precision in `eox-jsonform`.
     - Added `createRequire` in `cypress.config.js` to ensure Node ESM compatibility when invoking CJS task plugins.

close https://github.com/EOX-A/EOxElements/issues/2491
close https://github.com/EOX-A/EOxElements/issues/2382 (actually is fixed too but not intended)
close https://github.com/eodash/eodash/issues/345

## Checklist before requesting a review
   - [x] I have performed a self-review of my code
   - [x] I have added a test related to this feature/fix
   - [ ] For new features: I have created a story showcasing this new feature
   - [x] All checks have passed
   - [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch,breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
   - [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)