### PR TITLE
fix: make agents more aware about jsonform and some of relevant options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,8 @@ customElements.define("eox-example", EOxExample);
 
 ### Key Rules for Implementation
 
+- **Monorepo Commands**: Always run `lint:fix`, `typecheck`, and `format` from the **root** of the repository. Do not run them inside element sub-directories as they might lack the necessary scripts or configuration.
+- **JSDoc Event Listeners**: In custom inputs/editors, cast custom event listener callbacks with `/** @type {EventListener} */` and events with `/** @type {CustomEvent} */` when accessing `e.detail` to prevent `tsc` typecheck errors.
 - **No TypeScript Code**: Use JSDoc for types. Do NOT use TypeScript decorators (`@property`, `@state`) or `.ts` files for logic. TypeScript is used only for type definitions (`types.ts`, `@typedef`).
 - **Reactive Properties**: Always use `static get properties()` or `static properties = {}`. Lit decorators are NOT used anywhere in the codebase. Use `attribute: false` for complex Object/Array types.
 - **Method Delegation (Most Important Pattern)**: Extract business logic to standalone functions in `src/methods/<domain>/` directories.
@@ -131,6 +133,9 @@ customElements.define("eox-example", EOxExample);
   - Re-export methods via barrel `index.js` files.
 - **Enums & Constants**: Do NOT use TypeScript enums. Constants live in `src/enums/` as frozen JavaScript objects with `SCREAMING_SNAKE_CASE` naming.
 - **Projections**: For vector sources with a specific projection (e.g., GeoJSON in EPSG:3035), ensure the projection is registered globally. Prefer using `registerProjection` with a direct proj4 definition string for stability in stories, or `registerProjectionFromCode` for dynamic environments. In the layer definition, use the `format` object to specify `dataProjection`.
+  - **Normalization**: When comparing projections, always normalize to string codes (e.g., `typeof p === 'string' ? p : p.getCode()`).
+  - **Coordinates & Longitude**: For wrap-around or antimeridian logic, always normalize longitudes to the `[-180, 180]` range before magnitude comparison.
+  - **Extent Transformation**: Use `transformExtent` with `stops` (densification) for non-linear or polar transformations to ensure accurate bounding box calculations.
 - **Inter-Component Communication**: Components depending on `<eox-map>` use a standardized `for` property (a CSS selector defaulting to `"eox-map"`). In `firstUpdated()`, call `getElement(this.for)` from `@eox/elements-utils` to resolve the reference, even across shadow boundaries. Address re-resolution on property change in `updated()`.
 - **Styling**:
   - **EOxUI First**: This repository uses [EOxUI](https://github.com/EOX-A/EOxUI). Prefer using proper HTML structure and EOxUI classes over writing custom CSS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ We use `release-please`. Formatting errors here will break the release pipeline.
 - [ ] Functional story added to `stories/` with a code example.
 - [ ] `npm run lint:fix`, `typecheck`, and `format` passed.
 - [ ] PR title/commit message follows `type(scope): message` format.
+- [ ] PR description follows the repository template (`.github/pull_request_template.md`).
 - [ ] I have verified that `addCommonStylesheet()` is used for common styles.
 
 ---

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -14,10 +14,28 @@ import _DOMPurify from "isomorphic-dompurify"; // required for allowing HTML in 
 /**
  * `eox-jsonform` is a flexible and extensible web component for rendering dynamic forms based on JSON schema definitions.
  * It is based on [JSON Editor](https://github.com/json-editor/json-editor) and extends its functionality to support various advanced features.
- * Also check out the [JSON Editor documentation](https://github.com/json-editor/json-editor?tab=readme-ov-file#options) for more details on the available options and configurations.
+ * Also check out the [JSON Editor Documentation](https://raw.githubusercontent.com/json-editor/json-editor/refs/heads/master/README.md) for full details on schema syntax, options, and built-in editors.
+ *
+ * Core JSON-Editor Features & Options Reference:
+ * - **Branching (`anyOf` / `oneOf`)**:
+ *   - Use `"keep_oneof_values": false` in `options` when variants define different defaults, types (e.g., string vs array), or numeric ranges/steps. By default, JSON-Editor carries over values (`keep_oneof_values: true`), corrupting branch defaults and slider ranges.
+ *   - Example: `"options": { "no_additional_properties": true, "keep_oneof_values": false }`
+ * - **Dynamic Field Dependencies & Templates**:
+ *   - `watch`: Watch other form fields (e.g. `"watch": { "vminmax": "vminmax" }`).
+ *   - `template`: Interpolate watched values into string templates (e.g. `"template": "{{vminmax.vmin}},{{vminmax.vmax}}"`).
+ * - **Custom & Advanced Inputs**:
+ *   - `format: "minmax"`: Dual-handle range slider (via `tc-range-slider`) for selecting min/max bounds with automatic precision detection based on `step`.
+ *   - `format: "range"`: Single range slider with `minimum`, `maximum`, and `step`.
+ *   - `format: "markdown"` / `format: "ace"`: Markdown and Ace code editor integration.
+ *   - `format: "spatial"`: Bounding box, polygon, point, and line drawing integrated with `eox-map` / `eox-drawtools`.
+ * - **URL Parameter Filtering (`removeProperties`)**:
+ *   - Use `options.removeProperties: ["vminmax"]` to drop intermediate form/slider properties from consumers and tile URL updates.
+ * - **Configuration Options**:
+ *   - `no_additional_properties: true`: Restrict output strictly to defined schema properties.
+ *   - `disable_collapse`, `disable_edit_json`, `disable_properties`: Standard JSON-Editor UI toggles.
  *
  * Features:
- * - Renders forms from JSON schema, supporting complex nested structures and custom validation.
+ * - Renders forms from JSON schema, supporting complex nested structures, branching (`anyOf`/`oneOf`), and custom validation.
  * - All properties and event handlers are passed via args, enabling dynamic configuration and integration. Properties can also be passed as stringified JSON attributes (e.g. `schema`, `value`, `options`).
  * - Supports custom editor interfaces for advanced input types and external editor integration (e.g., Ace, Markdown, spatial drawtools).
  * - Handles spatial inputs (bounding box, polygons, points, lines) and outputs in various formats (GeoJSON, WKT).
@@ -26,7 +44,7 @@ import _DOMPurify from "isomorphic-dompurify"; // required for allowing HTML in 
  * - Integrates with `eox-map` for spatial feature selection when required.
  * - Supports unstyled rendering for custom design integration.
  *
- * See the stories for usage examples covering validation, custom editors, spatial inputs, opt-in/optional properties, external loading, and more.
+ * See the stories for usage examples covering validation, custom editors, branching variants, spatial inputs, opt-in/optional properties, external loading, and more.
  *
  * @typedef {JSON & {properties: object}} JsonSchema
  * @element eox-jsonform
@@ -53,7 +71,7 @@ export class EOxJSONForm extends LitElement {
     super();
 
     /**
-     * Schema for the form editor
+     * Schema for the form editor. Supports full JSON Schema draft-04/07 specs plus JSON-Editor extensions (e.g., `options`, `watch`, `template`, `format: "minmax"`).
      *
      * @type {JsonSchema}
      */
@@ -74,7 +92,8 @@ export class EOxJSONForm extends LitElement {
     this.defaults = {};
 
     /**
-     * Options for the form editor
+     * Configuration options for the JSONEditor instance (e.g., `keep_oneof_values: false`, `no_additional_properties: true`, `removeProperties: [...]`).
+     * See JSON-Editor options: https://raw.githubusercontent.com/json-editor/json-editor/refs/heads/master/README.md
      *
      * @type {object}
      */

--- a/elements/jsonform/stories/branching.js
+++ b/elements/jsonform/stories/branching.js
@@ -1,0 +1,15 @@
+/**
+ * Story demonstrating `anyOf` / `oneOf` branching with `keep_oneof_values: false`,
+ * minmax sliders, dynamic watchers, and string templates.
+ */
+import { html } from "lit";
+import branchingSchema from "./public/branchingSchema.json";
+
+export default {
+  args: {
+    schema: branchingSchema,
+  },
+  render: (args) => html`
+    <eox-jsonform .schema=${args.schema}></eox-jsonform>
+  `,
+};

--- a/elements/jsonform/stories/index.js
+++ b/elements/jsonform/stories/index.js
@@ -26,3 +26,4 @@ export { default as GridStrictStory } from "./grid-strict"; // Grid strict layou
 
 export { default as FlexLayoutStory } from "./flex-layout"; // Flex layout story
 export { default as StepsEditorStory } from "./steps-editor"; // Steps editor wizard story
+export { default as BranchingStory } from "./branching"; // Branching story with anyOf and keep_oneof_values: false

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -28,6 +28,7 @@ import {
   GridStory,
   GridStrictStory,
   StepsEditorStory,
+  BranchingStory,
 } from "./index.js";
 
 export default {
@@ -241,6 +242,13 @@ export const Defaults = DefaultsStory;
  * ```
  */
 export const StepsEditor = StepsEditorStory;
+
+/**
+ * Branching example with `anyOf` / `oneOf`. Demonstrates multi-variant schemas with `"keep_oneof_values": false`
+ * in options to ensure clean default resets across branch switches (avoiding stale value/slider bleeding),
+ * minmax sliders, dynamic watchers, and string template interpolation.
+ */
+export const Branching = BranchingStory;
 
 /**
  * Unstyled example. Renders the form without default styles.

--- a/elements/jsonform/stories/public/branchingSchema.json
+++ b/elements/jsonform/stories/public/branchingSchema.json
@@ -1,0 +1,113 @@
+{
+  "type": "object",
+  "title": "Asset Variant",
+  "options": {
+    "no_additional_properties": true,
+    "keep_oneof_values": false
+  },
+  "anyOf": [
+    {
+      "title": "Single Asset (HV)",
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "string",
+          "enum": ["HV"],
+          "default": "HV",
+          "options": { "hidden": true }
+        },
+        "vminmax": {
+          "type": "object",
+          "title": "Value Range",
+          "properties": {
+            "vmin": {
+              "type": "number",
+              "default": 0,
+              "format": "range",
+              "minimum": 0,
+              "step": 0.0005
+            },
+            "vmax": {
+              "type": "number",
+              "default": 0.005,
+              "format": "range",
+              "maximum": 0.0075
+            }
+          },
+          "format": "minmax"
+        },
+        "rescale": {
+          "type": "string",
+          "template": "{{vminmax.vmin}},{{vminmax.vmax}}",
+          "watch": {
+            "vminmax": "vminmax"
+          },
+          "options": {
+            "hidden": true
+          }
+        },
+        "colormap_name": {
+          "type": "string",
+          "title": "Colormap",
+          "default": "gray",
+          "enum": ["gray", "viridis", "magma"]
+        }
+      },
+      "required": ["vminmax", "assets"]
+    },
+    {
+      "title": "Dual Asset Ratio (HH/HV)",
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["HH", "HV"],
+          "options": { "hidden": true }
+        },
+        "expression": {
+          "type": "string",
+          "default": "b1/b2",
+          "options": { "hidden": true }
+        },
+        "vminmax": {
+          "type": "object",
+          "title": "Value Range",
+          "properties": {
+            "vmin": {
+              "type": "number",
+              "default": 0,
+              "format": "range",
+              "minimum": 0,
+              "step": 1
+            },
+            "vmax": {
+              "type": "number",
+              "default": 20,
+              "format": "range",
+              "maximum": 50
+            }
+          },
+          "format": "minmax"
+        },
+        "rescale": {
+          "type": "string",
+          "template": "{{vminmax.vmin}},{{vminmax.vmax}}",
+          "watch": {
+            "vminmax": "vminmax"
+          },
+          "options": {
+            "hidden": true
+          }
+        },
+        "colormap_name": {
+          "type": "string",
+          "title": "Colormap",
+          "default": "magma",
+          "enum": ["bone", "magma"]
+        }
+      },
+      "required": ["vminmax", "assets", "expression"]
+    }
+  ]
+}


### PR DESCRIPTION
## Rationale

When I was trying to let AI develop jsonform schemas in context of eodash debugging, I often struggled with having the special json-editor/json-editor options in the available context. I'd hope that this PR improves the situation.

## Implemented changes
- Added JSON-Editor documentation reference and core options guide to `EOxJSONForm` class JSDoc in `elements/jsonform/src/main.js`.
   - Documented `keep_oneof_values: false`, `removeProperties`, `format: "minmax"`, `watch`, and `template` usage for branching schemas (`anyOf` / `oneOf`).
   - Added a dedicated Storybook `Branching` story (`elements/jsonform/stories/branching.js` and `elements/jsonform/stories/public/branchingSchema.json`).
   - Minor updates to the AGENTS.md from unrelated :) previous work

New story /?path=/story/elements-eox-jsonform--branching currently shows a validation error `Value must validate against at least one of the provided schemas` which should get fixed once https://github.com/EOX-A/EOxElements/pull/2492 is merged (fixes the too early  slider values rounding issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
