### PR TITLE
fix(style): fill selected date with primary color across all selection modes

### DIFF
--- a/elements/timecontrol/src/helpers/inject-calendar-styles.js
+++ b/elements/timecontrol/src/helpers/inject-calendar-styles.js
@@ -94,25 +94,29 @@ export const calendarStyle = `
   .vc-week__day {
     color: var(--primary) !important;
   }
-  button {
+  .vc button {
     background-color: transparent !important;
     color: var(--on-surface) !important;
   }
-  button:hover {
+  .vc button:hover {
     background-color: color-mix(in srgb, var(--primary) 10%, transparent) !important;
   }
-  .vc-date[data-vc-date-selected="first"] .vc-date__btn,
-  .vc-date[data-vc-date-selected="last"] .vc-date__btn,
-  .vc-date[data-vc-date-hover="first"] .vc-date__btn {
+  .vc-date[data-vc-date-hover] .vc-date__btn {
+    background-color: color-mix(in srgb, var(--primary) 10%, transparent) !important;
+  }
+  .vc-date[data-vc-date-hover="first"] .vc-date__btn,
+  .vc-date[data-vc-date-hover="last"] .vc-date__btn,
+  .vc-date[data-vc-date-hover="first-and-last"] .vc-date__btn {
+    background-color: var(--primary) !important;
+    color: var(--on-primary) !important;
+  }
+  .vc-date[data-vc-date-selected] .vc-date__btn {
     background-color: var(--primary) !important;
     color: var(--on-primary) !important;
   }
   .vc-date[data-vc-date-selected="middle"] .vc-date__btn {
     background-color: color-mix(in srgb, var(--primary) 60%, transparent) !important;
     color: var(--on-primary) !important;
-  }
-  .vc-date[data-vc-date-hover]:not([data-vc-date-hover="first"]) .vc-date__btn {
-    background-color: color-mix(in srgb, var(--primary) 10%, transparent) !important;
   }
   .vc-date[data-vc-date-month="prev"] button,
   .vc-date[data-vc-date-month="next"] button,

--- a/elements/timecontrol/test/cases/index.js
+++ b/elements/timecontrol/test/cases/index.js
@@ -19,3 +19,4 @@ export { default as loadExpertModeExport } from "./load-expert-mode-export.js";
 export { default as loadDateInUTC } from "./load-date-in-utc.js";
 export { default as loadTimelineWithRangeConfiguration } from "./load-timeline-with-range-configuration.js";
 export { default as loadTimelineWithClustering } from "./load-timeline-with-clustering.js";
+export { default as loadDatePickerSelectionModes } from "./load-date-picker-selection-modes.js";

--- a/elements/timecontrol/test/cases/load-date-picker-selection-modes.js
+++ b/elements/timecontrol/test/cases/load-date-picker-selection-modes.js
@@ -1,0 +1,93 @@
+import { html } from "lit";
+import { STORY_ARGS } from "../../src/enums.js";
+
+/**
+ * Test to verify that timecontrol-picker calendar correctly applies --primary background fill
+ * to selected dates in all selection modes (single, first-and-last, and ranges) along with
+ * appropriate availability dot colors.
+ */
+const loadDatePickerSelectionModes = () => {
+  // setup - intercept network requests
+  cy.intercept(/^.*openstreetmap.*$/, {
+    fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
+  });
+
+  // mount standalone picker in range mode
+  cy.mount(html`
+    <eox-map
+      id="picker-selection-modes-test"
+      style="width: 400px; height: 300px;"
+      .zoom=${STORY_ARGS.zoom}
+      .center=${STORY_ARGS.center}
+      .layers=${STORY_ARGS.layers}
+    ></eox-map>
+    <eox-timecontrol for="eox-map#picker-selection-modes-test">
+      <eox-timecontrol-date
+        format="${STORY_ARGS.format}"
+      ></eox-timecontrol-date>
+      <eox-timecontrol-picker
+        format="${STORY_ARGS.format}"
+        .range=${true}
+        .showDots=${true}
+      ></eox-timecontrol-picker>
+    </eox-timecontrol>
+  `);
+
+  // Wait for calendar to be rendered
+  cy.get("eox-timecontrol-picker")
+    .shadow()
+    .within(() => {
+      cy.get("#cal .vc-date").should("have.length.gt", 0);
+
+      // 1. First-and-last / single date in range mode
+      cy.get(`[data-vc-date="2023-04-10"] .vc-date__btn`).click();
+      cy.get(`[data-vc-date="2023-04-10"] .vc-date__btn`).click();
+
+      cy.get(`[data-vc-date="2023-04-10"] .vc-date__btn`)
+        .should("have.css", "background-color", "rgb(0, 65, 112)")
+        .and("have.css", "color", "rgb(255, 255, 255)");
+
+      cy.get(`[data-vc-date="2023-04-10"] .vc-day__dot`).should(
+        "have.css",
+        "background-color",
+        "rgb(255, 255, 255)",
+      );
+
+      // 2. Range mode (start: 2023-04-10, end: 2023-04-12)
+      cy.get(`[data-vc-date="2023-04-10"] .vc-date__btn`).click();
+      cy.get(`[data-vc-date="2023-04-12"] .vc-date__btn`).click();
+
+      // First day of range
+      cy.get(`[data-vc-date="2023-04-10"] .vc-date__btn`)
+        .should("have.css", "background-color", "rgb(0, 65, 112)")
+        .and("have.css", "color", "rgb(255, 255, 255)");
+
+      // Middle day of range
+      cy.get(`[data-vc-date="2023-04-11"] .vc-date__btn`)
+        .should("satisfy", ($el) => {
+          const bg =
+            $el[0].style.backgroundColor ||
+            window.getComputedStyle($el[0]).backgroundColor;
+          return (
+            bg.includes("0.6") ||
+            bg === "rgba(0, 65, 112, 0.6)" ||
+            bg.startsWith("color(srgb 0 0.254902 0.439216 / 0.6")
+          );
+        })
+        .and("have.css", "color", "rgb(255, 255, 255)");
+
+      // Last day of range
+      cy.get(`[data-vc-date="2023-04-12"] .vc-date__btn`)
+        .should("have.css", "background-color", "rgb(0, 65, 112)")
+        .and("have.css", "color", "rgb(255, 255, 255)");
+
+      // Availability dots on selected range dates are white
+      cy.get(`[data-vc-date="2023-04-10"] .vc-day__dot`).should(
+        "have.css",
+        "background-color",
+        "rgb(255, 255, 255)",
+      );
+    });
+};
+
+export default loadDatePickerSelectionModes;

--- a/elements/timecontrol/test/cases/load-date-picker-standalone.js
+++ b/elements/timecontrol/test/cases/load-date-picker-standalone.js
@@ -119,6 +119,17 @@ const loadDatePickerStandalone = () => {
         .should("not.equal", getDate(initialDate));
     });
 
+  // verify the clicked date has primary background fill
+  cy.get("eox-timecontrol-picker")
+    .shadow()
+    .within(() => {
+      cy.get(`[data-vc-date="${testDate}"] .vc-date__btn`).should(
+        "have.css",
+        "background-color",
+        "rgb(0, 65, 112)",
+      );
+    });
+
   // verify calendar is still visible after date selection (doesn't close)
   cy.get("body").then(($body) => {
     const vcInBody = $body.find(".vc").length > 0;

--- a/elements/timecontrol/test/general.cy.js
+++ b/elements/timecontrol/test/general.cy.js
@@ -26,6 +26,7 @@ import {
   loadExpertModeExport,
   loadDateInUTC,
   loadTimelineWithRangeConfiguration,
+  loadDatePickerSelectionModes,
 } from "./cases";
 
 // Test suite for TimeControl
@@ -95,4 +96,8 @@ describe("TimeControl", () => {
 
   // Test to verify that expert mode with timelapse export functionality works correctly
   it("loads expert mode export", () => loadExpertModeExport());
+
+  // Test to verify that date picker selection styles are applied in all modes (single, first-and-last, ranges)
+  it("loads date picker selection styles across modes", () =>
+    loadDatePickerSelectionModes());
 });


### PR DESCRIPTION
## Implemented changes

This PR addresses an issue (fixes #2484) where selected dates in `eox-timecontrol-picker` lacked background fill in single and `first-and-last` selection modes, causing availability dots to appear invisible against the light background.

### Changes
- Updated calendar CSS selectors to apply `var(--primary)` background fill to `.vc-date[data-vc-date-selected] .vc-date__btn` (supporting single date, first-and-last, and range edge dates).
- Preserved range middle date styling (`color-mix(in srgb, var(--primary) 60%, transparent)`).
- Scoped generic calendar button styles to `.vc button` to avoid leaking global styles.
- Added Cypress component test case `loadDatePickerSelectionModes` covering single, first-and-last, and range selection modes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [ ] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
