### PR TITLE
feat: customizable show-items tooltip

### DIFF
--- a/elements/timecontrol/src/components/timecontrol-picker.js
+++ b/elements/timecontrol/src/components/timecontrol-picker.js
@@ -123,29 +123,34 @@ export class EOxTimeControlPicker extends LitElement {
     this.position = ["top", "left"];
 
     /**
-     * Property key used to select the primary line in the popup items card.
-     * Defaults to undefined (falls back to timecontrol's titleKey or 'name').
+     * Property key on the timeline item used to select the primary title line in the popup items card.
+     * Available item properties include `layerName` (display name of the layer), `group` (layer ID),
+     * `itemId` (item identifier), `originalDate` (date string), plus any custom properties defined on the
+     * layer's `timeControlValues` objects (e.g., `cloudCoverage`).
+     * Defaults to undefined (falls back to timecontrol's titleKey or 'name', resolving to the layer title).
      *
      * @type {string | undefined}
      */
     this.itemTitleKey = undefined;
 
     /**
-     * Whether to show time in the popup items card.
+     * Whether to show time in the popup items card. Defaults to true (omitted if item has no time component).
      *
      * @type {boolean}
      */
     this.showTime = true;
 
     /**
-     * Format string for time display in the popup items card (dayjs format).
+     * Format string for time display in the popup items card (dayjs format). Defaults to "HH:mm".
      *
      * @type {string}
      */
     this.timeFormat = "HH:mm";
 
     /**
-     * Custom transformation function for popup items.
+     * Custom transformation function for popup items. Receives an item object containing
+     * `{ title, subtitle, time, dotColor, layerName, group, itemId, originalDate, ...customItemProps }`.
+     * Can return an updated item object, an HTML string, or null/false to hide the item.
      *
      * @type {((item: Object) => Object | string | null | false) | null}
      */
@@ -276,10 +281,6 @@ export class EOxTimeControlPicker extends LitElement {
       this.closest("eox-timecontrol")
     );
     setTimeout(() => {
-      if (this.cal) {
-        this.cal.destroy();
-        this.cal = null;
-      }
       const defaultCalendarSelector = /** @type {HTMLElement} */ (
         this.renderRoot.querySelector("#cal")
       );
@@ -352,17 +353,24 @@ export class EOxTimeControlPicker extends LitElement {
                 : groupObj?.content;
               const layerTitle = item.layerName || groupContent || "";
 
-              let title =
-                item[titleKey] ||
-                (titleKey === "id" ? item.itemId || item.id : null) ||
-                layerTitle ||
-                item.name ||
-                item.title ||
-                item.itemId ||
-                group;
+              const hasItemValue =
+                item[titleKey] !== undefined && item[titleKey] !== null;
+
+              let title = hasItemValue
+                ? item[titleKey]
+                : (titleKey === "id" ? item.itemId || item.id : null) ||
+                  (titleKey === "name" ? layerTitle : null) ||
+                  layerTitle ||
+                  item.name ||
+                  item.title ||
+                  item.itemId ||
+                  group;
 
               let subtitle = "";
-              if (item[titleKey] && item[titleKey] !== layerTitle) {
+              if (
+                hasItemValue &&
+                String(item[titleKey]) !== String(layerTitle)
+              ) {
                 subtitle = layerTitle || group;
               } else if (
                 titleKey !== "id" &&
@@ -375,7 +383,7 @@ export class EOxTimeControlPicker extends LitElement {
               const dotColor = `var(--dot-color-${groupsList.indexOf(group) + 1}, var(--primary))`;
 
               let itemData = {
-                title: String(title || ""),
+                title: String(title ?? ""),
                 subtitle: String(subtitle || ""),
                 time: formattedTime,
                 dotColor: dotColor,

--- a/elements/timecontrol/src/components/timecontrol-picker.js
+++ b/elements/timecontrol/src/components/timecontrol-picker.js
@@ -46,6 +46,10 @@ export class EOxTimeControlPicker extends LitElement {
       showItems: { type: Boolean, attribute: "show-items" },
       showDots: { type: Boolean, attribute: "show-dots" },
       position: { type: Array, attribute: false },
+      itemTitleKey: { type: String, attribute: "item-title-key" },
+      showTime: { type: Boolean, attribute: "show-time" },
+      timeFormat: { type: String, attribute: "time-format" },
+      propertyTransform: { attribute: false, type: Function },
     };
   }
 
@@ -117,6 +121,35 @@ export class EOxTimeControlPicker extends LitElement {
      * @type {Array<string>}
      */
     this.position = ["top", "left"];
+
+    /**
+     * Property key used to select the primary line in the popup items card.
+     * Defaults to undefined (falls back to timecontrol's titleKey or 'name').
+     *
+     * @type {string | undefined}
+     */
+    this.itemTitleKey = undefined;
+
+    /**
+     * Whether to show time in the popup items card.
+     *
+     * @type {boolean}
+     */
+    this.showTime = true;
+
+    /**
+     * Format string for time display in the popup items card (dayjs format).
+     *
+     * @type {string}
+     */
+    this.timeFormat = "HH:mm";
+
+    /**
+     * Custom transformation function for popup items.
+     *
+     * @type {((item: Object) => Object | string | null | false) | null}
+     */
+    this.propertyTransform = null;
   }
 
   /**
@@ -129,10 +162,35 @@ export class EOxTimeControlPicker extends LitElement {
   }
 
   /**
+   * Updates component when properties change.
+   *
+   * @param {Map<string, any>} changedProperties - Changed properties map.
+   */
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    if (
+      this.cal &&
+      (changedProperties.has("showItems") ||
+        changedProperties.has("showDots") ||
+        changedProperties.has("range") ||
+        changedProperties.has("itemTitleKey") ||
+        changedProperties.has("showTime") ||
+        changedProperties.has("timeFormat") ||
+        changedProperties.has("propertyTransform"))
+    ) {
+      this.initCalendar({ selectedDateRange: this.#selectedDateRange });
+    }
+  }
+
+  /**
    * Lifecycle method called when the component is disconnected from the DOM.
    * Cleans up calendar styles to prevent memory leaks.
    */
   disconnectedCallback() {
+    if (this.cal) {
+      this.cal.destroy();
+      this.cal = null;
+    }
     super.disconnectedCallback();
     cleanCalendarStyles();
   }
@@ -218,6 +276,10 @@ export class EOxTimeControlPicker extends LitElement {
       this.closest("eox-timecontrol")
     );
     setTimeout(() => {
+      if (this.cal) {
+        this.cal.destroy();
+        this.cal = null;
+      }
       const defaultCalendarSelector = /** @type {HTMLElement} */ (
         this.renderRoot.querySelector("#cal")
       );
@@ -232,7 +294,10 @@ export class EOxTimeControlPicker extends LitElement {
         : externalCalendarSelector || defaultCalendarSelector;
       if (calendarSelector) {
         defaultCalendarSelector.innerHTML = "";
-        this.#selectedDateRange = options.selectedDateRange;
+        this.#selectedDateRange =
+          options.selectedDateRange ||
+          this.#selectedDateRange ||
+          EOxTimeControl?.selectedDateRange;
         const showUTC = EOxTimeControl.showUTC;
         const selectedDates = getSelectedDatesMethod(
           this.#selectedDateRange,
@@ -247,10 +312,14 @@ export class EOxTimeControlPicker extends LitElement {
         let popups = {};
 
         if (this.showItems) {
+          const titleKey =
+            this.itemTitleKey || EOxTimeControl?.titleKey || "name";
+          const groupsList = Object.keys(groupBy(data, "group"));
+
           for (const date of Object.keys(itemGroups)) {
             const items = itemGroups[date];
 
-            // Get top 5 items
+            // Get top 3 items
             const topItems = items.slice(0, 3);
             const remainingCount = items.length - 3;
 
@@ -258,32 +327,117 @@ export class EOxTimeControlPicker extends LitElement {
             let listHTML = "";
 
             topItems.forEach((item) => {
-              const id = item.id || "";
-              const utcTime = showUTC
-                ? dayjs(item.utc).utc().format("HH:mm")
-                : dayjs(item.utc).format("HH:mm");
+              const hasTime =
+                item.originalDate &&
+                (item.originalDate.includes("T") ||
+                  item.originalDate.includes(":") ||
+                  (item.originalDate.includes(" ") &&
+                    item.originalDate.length > 10));
+
+              const formattedTime =
+                this.showTime && hasTime
+                  ? showUTC
+                    ? dayjs(item.utc)
+                        .utc()
+                        .format(this.timeFormat || "HH:mm")
+                    : dayjs(item.utc).format(this.timeFormat || "HH:mm")
+                  : "";
+
               const group = item.group || "";
-              const groupsList = Object.keys(groupBy(data, "group"));
+              const groupObj = /** @type {any} */ (
+                EOxTimeControl?.groups?.get(group)
+              );
+              const groupContent = Array.isArray(groupObj)
+                ? groupObj[0]?.content
+                : groupObj?.content;
+              const layerTitle = item.layerName || groupContent || "";
 
-              // Truncate ID if too long
-              const truncatedId =
-                id.length > 30 ? id.substring(0, 30) + "..." : id;
+              let title =
+                item[titleKey] ||
+                (titleKey === "id" ? item.itemId || item.id : null) ||
+                layerTitle ||
+                item.name ||
+                item.title ||
+                item.itemId ||
+                group;
 
-              listHTML += `
+              let subtitle = "";
+              if (item[titleKey] && item[titleKey] !== layerTitle) {
+                subtitle = layerTitle || group;
+              } else if (
+                titleKey !== "id" &&
+                item.itemId &&
+                item.itemId !== item.id
+              ) {
+                subtitle = item.itemId;
+              }
+
+              const dotColor = `var(--dot-color-${groupsList.indexOf(group) + 1}, var(--primary))`;
+
+              let itemData = {
+                title: String(title || ""),
+                subtitle: String(subtitle || ""),
+                time: formattedTime,
+                dotColor: dotColor,
+                ...item,
+              };
+
+              let customHtml = null;
+
+              if (typeof this.propertyTransform === "function") {
+                const transformed = this.propertyTransform(itemData);
+                if (transformed === false || transformed === null) {
+                  return;
+                }
+                if (typeof transformed === "string") {
+                  customHtml = transformed;
+                } else if (
+                  typeof transformed === "object" &&
+                  transformed !== null
+                ) {
+                  itemData = {
+                    ...itemData,
+                    ...transformed,
+                  };
+                }
+              }
+
+              if (customHtml !== null) {
+                listHTML += `
+                <div class="vc-item-popup__item">
+                  ${customHtml}
+                </div>
+              `;
+              } else {
+                const displayTitle = itemData.title || "";
+                const truncatedTitle =
+                  displayTitle.length > 30
+                    ? displayTitle.substring(0, 30) + "..."
+                    : displayTitle;
+
+                const metaParts = [itemData.time, itemData.subtitle].filter(
+                  Boolean,
+                );
+                const metaText = metaParts.join(" ");
+
+                listHTML += `
                 <div class="vc-item-popup__item">
                   <div class="vc-item-popup__item-content">
-                    <div class="vc-item-popup__dot" style="background-color: var(--dot-color-${groupsList.indexOf(group) + 1}, var(--primary))"></div>
+                    <div class="vc-item-popup__dot" style="background-color: ${itemData.dotColor || dotColor}"></div>
                     <div class="vc-item-popup__text-container">
-                      <div class="vc-item-popup__id">
-                        ID: ${truncatedId}
+                      <div class="vc-item-popup__id vc-item-popup__title">
+                        ${truncatedTitle}
                       </div>
-                      <div class="vc-item-popup__meta">
-                        ${utcTime} ${group}
-                      </div>
+                      ${
+                        metaText
+                          ? `<div class="vc-item-popup__meta">${metaText}</div>`
+                          : ""
+                      }
                     </div>
                   </div>
                 </div>
               `;
+              }
             });
 
             // Add "more" indicator if there are remaining items
@@ -303,6 +457,30 @@ export class EOxTimeControlPicker extends LitElement {
               },
             };
           }
+        }
+
+        if (this.cal) {
+          const wasOpen = Boolean(this.cal.context?.isShowInInputMode);
+          const selectedYear =
+            this.cal.context?.selectedYear ?? this.cal.selectedYear;
+          const selectedMonth =
+            this.cal.context?.selectedMonth ?? this.cal.selectedMonth;
+          this.cal.set({
+            popups: popups,
+            selectionDatesMode: this.range ? "multiple-ranged" : "single",
+            ...(options.min
+              ? { dateMin: options.min, displayDateMin: options.min }
+              : {}),
+            ...(options.max
+              ? { dateMax: options.max, displayDateMax: options.max }
+              : {}),
+            ...(selectedYear !== undefined ? { selectedYear } : {}),
+            ...(selectedMonth !== undefined ? { selectedMonth } : {}),
+          });
+          if (wasOpen) {
+            this.cal.show();
+          }
+          return;
         }
 
         this.cal = new Calendar(calendarSelector || "#cal", {

--- a/elements/timecontrol/src/helpers/inject-calendar-styles.js
+++ b/elements/timecontrol/src/helpers/inject-calendar-styles.js
@@ -178,7 +178,8 @@ export const calendarStyle = `
   .vc-item-popup__text-container {
     flex: 1;
   }
-  .vc-item-popup__id {
+  .vc-item-popup__id,
+  .vc-item-popup__title {
     font-weight: bold;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/elements/timecontrol/src/helpers/update-timeline-items.js
+++ b/elements/timecontrol/src/helpers/update-timeline-items.js
@@ -86,6 +86,8 @@ export default function updateTimelineItems(
       items.add({
         ...value,
         id: id,
+        itemId: value.id || id,
+        layerName: slider.name,
         group: slider.layer,
         className: `milestone item-${id} ${value.originalDate}`,
         start: start,

--- a/elements/timecontrol/src/types.ts
+++ b/elements/timecontrol/src/types.ts
@@ -133,7 +133,8 @@ export type TimeControlPickerOptions = {
    */
   showItems?: boolean;
   /**
-   * Property key used to select the primary line in the popup items card.
+   * Property key on the timeline item used to select the primary line in the popup items card
+   * (e.g., `layerName`, `group`, `itemId`, `originalDate`, or custom properties on `timeControlValues`).
    */
   itemTitleKey?: string;
   /**
@@ -147,7 +148,67 @@ export type TimeControlPickerOptions = {
   /**
    * Custom transformation function for popup items.
    */
-  propertyTransform?: (item: any) => any;
+  propertyTransform?: (
+    item: TimeControlPopupItem,
+  ) => TimeControlPopupItem | string | null | false;
+};
+
+/**
+ * Timeline item data object passed to the popup card renderer or `propertyTransform` function.
+ */
+export type TimeControlPopupItem = {
+  /**
+   * Primary title line displayed in bold.
+   */
+  title: string;
+  /**
+   * Subtitle text displayed in the metadata line.
+   */
+  subtitle: string;
+  /**
+   * Formatted time string (if `showTime` is true and item has time).
+   */
+  time: string;
+  /**
+   * CSS color variable or color string for the indicator dot.
+   */
+  dotColor: string;
+  /**
+   * Layer display name (from `layer.properties[titleKey]`).
+   */
+  layerName?: string;
+  /**
+   * Layer identifier (from `layer.properties[layerIdKey]`).
+   */
+  group?: string;
+  /**
+   * Unique item identifier (from `timeControlValues[i].id` or generated uuid).
+   */
+  itemId?: string;
+  /**
+   * Generated unique UUID for timeline tracking.
+   */
+  id?: string;
+  /**
+   * Original date string from layer configuration.
+   */
+  originalDate?: string;
+  /**
+   * Formatted date string (YYYY-MM-DD).
+   */
+  date?: string;
+  /**
+   * ISO UTC date string.
+   */
+  utc?: string;
+  /**
+   * ISO local timezone string.
+   */
+  local?: string;
+  /**
+   * Additional custom metadata properties defined on `timeControlValues` entries.
+   */
+  [key: string]: any;
 };
 
 /**
@@ -540,7 +601,8 @@ declare global {
      */
     showItems: boolean;
     /**
-     * Property key used to select the primary line in the popup items card.
+     * Property key on the timeline item used to select the primary line in the popup items card
+     * (e.g., `layerName`, `group`, `itemId`, `originalDate`, or custom properties on `timeControlValues`).
      */
     itemTitleKey: string;
     /**
@@ -554,7 +616,11 @@ declare global {
     /**
      * Custom transformation function for popup items.
      */
-    propertyTransform: ((item: any) => any) | null;
+    propertyTransform:
+      | ((
+          item: TimeControlPopupItem,
+        ) => TimeControlPopupItem | string | null | false)
+      | null;
     /**
      * Position of the calendar picker.
      */

--- a/elements/timecontrol/src/types.ts
+++ b/elements/timecontrol/src/types.ts
@@ -128,6 +128,26 @@ export type TimeControlPickerOptions = {
    * Whether to show dots indicating available data on calendar dates.
    */
   showDots?: boolean;
+  /**
+   * Whether to show items in the calendar popup.
+   */
+  showItems?: boolean;
+  /**
+   * Property key used to select the primary line in the popup items card.
+   */
+  itemTitleKey?: string;
+  /**
+   * Whether to show time in the popup items card.
+   */
+  showTime?: boolean;
+  /**
+   * Format string for time display in the popup items card.
+   */
+  timeFormat?: string;
+  /**
+   * Custom transformation function for popup items.
+   */
+  propertyTransform?: (item: any) => any;
 };
 
 /**
@@ -515,6 +535,26 @@ declare global {
      * Whether to show dots on calendar.
      */
     showDots: boolean;
+    /**
+     * Whether to show items in the calendar popup.
+     */
+    showItems: boolean;
+    /**
+     * Property key used to select the primary line in the popup items card.
+     */
+    itemTitleKey: string;
+    /**
+     * Whether to show time in the popup items card.
+     */
+    showTime: boolean;
+    /**
+     * Format string for time display in the popup items card.
+     */
+    timeFormat: string;
+    /**
+     * Custom transformation function for popup items.
+     */
+    propertyTransform: ((item: any) => any) | null;
     /**
      * Position of the calendar picker.
      */

--- a/elements/timecontrol/stories/date-picker-popup-items.js
+++ b/elements/timecontrol/stories/date-picker-popup-items.js
@@ -7,10 +7,36 @@ import { STORY_ARGS } from "../src/enums";
  * @returns {Object} The story configuration with arguments for the component.
  */
 const DatePickerPopupItemsStory = {
+  argTypes: {
+    showItems: {
+      control: { type: "boolean" },
+      description:
+        "Whether to show the items popup card when hovering over available dates.",
+    },
+    itemTitleKey: {
+      control: { type: "select" },
+      options: [undefined, "cloudCoverage", "layerName", "itemId", "id"],
+      description:
+        "Property key on the timeline item used as the primary title in the card (e.g. `cloudCoverage`, `layerName`, `itemId`, `id`).",
+    },
+    showTime: {
+      control: { type: "boolean" },
+      description:
+        "Whether to show time in the popup items card (automatically omitted for date-only items).",
+    },
+    timeFormat: {
+      control: { type: "text" },
+      description: "Format string for time display in the popup items card.",
+    },
+  },
   args: {
     layerIdKey: STORY_ARGS.layerIdKey,
     navigation: true,
     popup: true,
+    showItems: true,
+    itemTitleKey: undefined,
+    showTime: true,
+    timeFormat: "HH:mm",
     for: "eox-map#date-picker-popup",
     select: (e) => {
       console.log(e.detail);
@@ -37,6 +63,7 @@ const DatePickerPopupItemsStory = {
         showItems: true,
         itemTitleKey: undefined,
         showTime: true,
+        timeFormat: "HH:mm",
       },
     },
   },
@@ -67,15 +94,17 @@ const DatePickerPopupItemsStory = {
         .showDots=${args.storyAdditionalComponents["eox-timecontrol-picker"]
           .showDots}
         .popup=${args.storyAdditionalComponents["eox-timecontrol-picker"].popup}
-        .showItems=${args.storyAdditionalComponents["eox-timecontrol-picker"]
-          .showItems}
-        .itemTitleKey=${args.storyAdditionalComponents["eox-timecontrol-picker"]
-          .itemTitleKey}
-        .showTime=${args.storyAdditionalComponents["eox-timecontrol-picker"]
-          .showTime}
-        .propertyTransform=${args.storyAdditionalComponents[
-          "eox-timecontrol-picker"
-        ].propertyTransform}
+        .showItems=${args.showItems ??
+        args.storyAdditionalComponents["eox-timecontrol-picker"].showItems}
+        .itemTitleKey=${args.itemTitleKey ??
+        args.storyAdditionalComponents["eox-timecontrol-picker"].itemTitleKey}
+        .showTime=${args.showTime ??
+        args.storyAdditionalComponents["eox-timecontrol-picker"].showTime}
+        .timeFormat=${args.timeFormat ??
+        args.storyAdditionalComponents["eox-timecontrol-picker"].timeFormat}
+        .propertyTransform=${args.propertyTransform ??
+        args.storyAdditionalComponents["eox-timecontrol-picker"]
+          .propertyTransform}
       ></eox-timecontrol-picker>
     </eox-timecontrol>
   `,

--- a/elements/timecontrol/stories/date-picker-popup-items.js
+++ b/elements/timecontrol/stories/date-picker-popup-items.js
@@ -35,6 +35,8 @@ const DatePickerPopupItemsStory = {
         showDots: true,
         popup: true,
         showItems: true,
+        itemTitleKey: undefined,
+        showTime: true,
       },
     },
   },
@@ -67,6 +69,13 @@ const DatePickerPopupItemsStory = {
         .popup=${args.storyAdditionalComponents["eox-timecontrol-picker"].popup}
         .showItems=${args.storyAdditionalComponents["eox-timecontrol-picker"]
           .showItems}
+        .itemTitleKey=${args.storyAdditionalComponents["eox-timecontrol-picker"]
+          .itemTitleKey}
+        .showTime=${args.storyAdditionalComponents["eox-timecontrol-picker"]
+          .showTime}
+        .propertyTransform=${args.storyAdditionalComponents[
+          "eox-timecontrol-picker"
+        ].propertyTransform}
       ></eox-timecontrol-picker>
     </eox-timecontrol>
   `,

--- a/elements/timecontrol/stories/timecontrol.stories.js
+++ b/elements/timecontrol/stories/timecontrol.stories.js
@@ -73,11 +73,29 @@ export const DateWithNavigation = DateWithNavigationStory;
 export const DatePickerPopup = DatePickerPopupStory;
 
 /**
- * Calendar date picker displayed in popup mode and shows items in the popup
+ * Calendar date picker displayed in popup mode with configurable items popup card
  *
  * This example demonstrates the `<eox-timecontrol-picker>` component with `showItems` enabled.
  * The calendar appears as a popup overlay when clicking on the date input field (provided by
- * `<eox-timecontrol-date>`). The picker shows items in the popup.
+ * `<eox-timecontrol-date>`). Hovering over a date with available data displays a popup card.
+ *
+ * Card content is configurable using:
+ * - `itemTitleKey` / `item-title-key`: Selects which property to display on the primary line (defaults to timecontrol's `titleKey` / `"name"`).
+ * - `showTime` / `show-time`: Controls whether time is shown in the card metadata (defaults to `true`; time is automatically omitted for date-only items).
+ * - `propertyTransform`: Optional function to customize or transform item rendering (returns transformed object or custom HTML string).
+ *
+ * ```html
+ * <eox-timecontrol for="eox-map#my-map">
+ *   <eox-timecontrol-date navigation></eox-timecontrol-date>
+ *   <eox-timecontrol-picker
+ *     popup
+ *     show-dots
+ *     show-items
+ *     item-title-key="name"
+ *     show-time
+ *   ></eox-timecontrol-picker>
+ * </eox-timecontrol>
+ * ```
  */
 export const DatePickerPopupItems = DatePickerPopupItemsStory;
 

--- a/elements/timecontrol/stories/timecontrol.stories.js
+++ b/elements/timecontrol/stories/timecontrol.stories.js
@@ -80,9 +80,17 @@ export const DatePickerPopup = DatePickerPopupStory;
  * `<eox-timecontrol-date>`). Hovering over a date with available data displays a popup card.
  *
  * Card content is configurable using:
- * - `itemTitleKey` / `item-title-key`: Selects which property to display on the primary line (defaults to timecontrol's `titleKey` / `"name"`).
+ * - `itemTitleKey` / `item-title-key`: Selects which property on the timeline item to display on the primary line.
+ *   - Available item properties include:
+ *     - `layerName`: The layer title/name (from `layer.properties[titleKey]`).
+ *     - `group`: The layer ID (from `layer.properties[layerIdKey]`).
+ *     - `itemId`: The item identifier (from `timeControlValues[i].id` or generated UUID).
+ *     - `originalDate`: The raw date string from `timeControlValues[i].date`.
+ *     - Any custom properties defined on `timeControlValues` objects (e.g., `cloudCoverage`).
+ *   - Defaults to `undefined` (which falls back to the layer title `layerName`).
  * - `showTime` / `show-time`: Controls whether time is shown in the card metadata (defaults to `true`; time is automatically omitted for date-only items).
- * - `propertyTransform`: Optional function to customize or transform item rendering (returns transformed object or custom HTML string).
+ * - `timeFormat` / `time-format`: Dayjs format string for displaying item time (defaults to `"HH:mm"`).
+ * - `propertyTransform`: Optional function to customize or transform item rendering (receives `{ title, subtitle, time, dotColor, layerName, group, itemId, originalDate, ...customItemProps }` and returns transformed object or custom HTML string).
  *
  * ```html
  * <eox-timecontrol for="eox-map#my-map">
@@ -91,7 +99,7 @@ export const DatePickerPopup = DatePickerPopupStory;
  *     popup
  *     show-dots
  *     show-items
- *     item-title-key="name"
+ *     item-title-key="layerName"
  *     show-time
  *   ></eox-timecontrol-picker>
  * </eox-timecontrol>

--- a/elements/timecontrol/test/cases/load-date-picker-popup-items.js
+++ b/elements/timecontrol/test/cases/load-date-picker-popup-items.js
@@ -70,31 +70,36 @@ const loadDatePickerPopupItems = () => {
   cy.get(".vc", { timeout: 10000 }).should("exist").and("be.visible");
 
   // find our test date
-  cy.get(".vc").within(() => {
-    // it probably needs a second to render all days/dots
-    cy.get(`[data-vc-date="${utcTestDate}"]`, { timeout: 10000 }).should(
-      "exist",
-    );
-    // it probably needs a second to render all days/dots
-    cy.get(".vc-day__dots", { timeout: 10000 }).should("exist");
-  });
+  cy.get(".vc")
+    .last()
+    .within(() => {
+      // it probably needs a second to render all days/dots
+      cy.get(`[data-vc-date="${utcTestDate}"]`, { timeout: 10000 }).should(
+        "exist",
+      );
+      // it probably needs a second to render all days/dots
+      cy.get(".vc-day__dots", { timeout: 10000 }).should("exist");
+    });
 
   // verify the test date has dots (data from multiple layers)
   // we first need to ensure the calendar is fully loaded and items are rendered
-  cy.get(".vc").within(() => {
-    cy.get(`[data-vc-date="${utcTestDate}"]`, { timeout: 10000 })
-      .should("have.class", "vc-data-available")
-      .within(() => {
-        // should have the dots container
-        cy.get(".vc-day__dots").should("exist");
+  cy.get(".vc")
+    .last()
+    .within(() => {
+      cy.get(`[data-vc-date="${utcTestDate}"]`, { timeout: 10000 })
+        .first()
+        .should("have.class", "vc-data-available")
+        .within(() => {
+          // should have the dots container
+          cy.get(".vc-day__dots").should("exist");
 
-        // count the number of dots (should be >= 1)
-        cy.get(".vc-day__dot", { timeout: 10000 }).should(
-          "have.length.at.least",
-          expectedDotCount,
-        );
-      });
-  });
+          // count the number of dots (should be >= 1)
+          cy.get(".vc-day__dot", { timeout: 10000 }).should(
+            "have.length.at.least",
+            expectedDotCount,
+          );
+        });
+    });
 
   // verify the date popup element exists with opacity: 0 by default
   cy.get(`[data-vc-date="${utcTestDate}"] .vc-date__popup`)
@@ -116,8 +121,15 @@ const loadDatePickerPopupItems = () => {
   );
 
   // verify the popup contains content (visible when opacity is 1)
-  cy.get(`[data-vc-date="${utcTestDate}"] .vc-date__popup`).then(($popup) => {
-    expect($popup.html()).to.not.be.empty;
+  cy.get(`[data-vc-date="${utcTestDate}"] .vc-date__popup`).should(($popup) => {
+    const htmlContent = $popup.html();
+    expect(htmlContent).to.not.be.empty;
+    // verify primary line shows layer title and does NOT have the hardcoded "ID: " prefix
+    expect(htmlContent).to.include("Wind Visualisation 10M");
+    expect(htmlContent).to.include("NO2 Visualisation");
+    expect(htmlContent).to.not.include("ID: ");
+    // verify no misleading "00:00" for date-only items
+    expect(htmlContent).to.not.include("00:00");
   });
 
   // reset opacity back to 0 (simulating mouse leave)
@@ -135,19 +147,113 @@ const loadDatePickerPopupItems = () => {
   // verify a date with only one layer has only one dot
   // use the last date which should only be in layer 2
   const singleLayerDate = "2023-04-24";
-  cy.get(".vc").within(() => {
-    // navigate to April 2023 by clicking on the test date first
-    // this ensures we're in the right month
-    cy.get(`[data-vc-date="${singleLayerDate}"]`, { timeout: 5000 })
-      .should("exist")
-      .within(() => {
-        // should have dots container
-        cy.get(".vc-day__dots").should("exist");
+  cy.get(".vc")
+    .last()
+    .within(() => {
+      // navigate to April 2023 by clicking on the test date first
+      // this ensures we're in the right month
+      cy.get(`[data-vc-date="${singleLayerDate}"]`, { timeout: 5000 })
+        .first()
+        .should("exist")
+        .within(() => {
+          // should have dots container
+          cy.get(".vc-day__dots").should("exist");
 
-        // should have only 1 dot (only in layer 2)
-        cy.get(".vc-day__dot").should("have.length", 1);
-      });
-  });
+          // should have only 1 dot (only in layer 2)
+          cy.get(".vc-day__dot").should("have.length", 1);
+        });
+    });
+
+  // mount with custom itemTitleKey and propertyTransform
+  cy.mount(html`
+    <eox-map
+      id="picker-custom-popup-test"
+      style="width: 400px; height: 300px;"
+      .zoom=${STORY_ARGS.zoom}
+      .center=${STORY_ARGS.center}
+      .layers=${STORY_ARGS.layers}
+    ></eox-map>
+    <eox-timecontrol for="eox-map#picker-custom-popup-test">
+      <eox-timecontrol-date
+        format="${STORY_ARGS.format}"
+        .navigation=${true}
+      ></eox-timecontrol-date>
+      <eox-timecontrol-picker
+        item-title-key="cloudCoverage"
+        .showDots=${true}
+        .popup=${true}
+        .showItems=${true}
+        .propertyTransform=${(item) => ({
+          title: `Transformed: ${item.cloudCoverage}%`,
+          subtitle: "Custom Meta",
+        })}
+      ></eox-timecontrol-picker>
+    </eox-timecontrol>
+  `);
+
+  // open calendar in custom configuration
+  cy.get("eox-timecontrol")
+    .last()
+    .find("eox-timecontrol-date")
+    .shadow()
+    .within(() => {
+      cy.get("#date-container input[type='text']").click();
+    });
+
+  cy.get(".vc").last().should("exist").and("be.visible");
+
+  // verify propertyTransform custom object rendering
+  cy.get(`[data-vc-date="${utcTestDate}"] .vc-date__popup`)
+    .last()
+    .should(($popup) => {
+      const htmlContent = $popup.html();
+      expect(htmlContent).to.include("Transformed: 74%");
+      expect(htmlContent).to.include("Custom Meta");
+    });
+
+  // mount with custom HTML propertyTransform
+  cy.mount(html`
+    <eox-map
+      id="picker-html-popup-test"
+      style="width: 400px; height: 300px;"
+      .zoom=${STORY_ARGS.zoom}
+      .center=${STORY_ARGS.center}
+      .layers=${STORY_ARGS.layers}
+    ></eox-map>
+    <eox-timecontrol for="eox-map#picker-html-popup-test">
+      <eox-timecontrol-date
+        format="${STORY_ARGS.format}"
+        .navigation=${true}
+      ></eox-timecontrol-date>
+      <eox-timecontrol-picker
+        .showDots=${true}
+        .popup=${true}
+        .showItems=${true}
+        .propertyTransform=${(item) =>
+          `<div class="custom-card">Custom ${item.cloudCoverage}</div>`}
+      ></eox-timecontrol-picker>
+    </eox-timecontrol>
+  `);
+
+  // open calendar in HTML custom configuration
+  cy.get("eox-timecontrol")
+    .last()
+    .find("eox-timecontrol-date")
+    .shadow()
+    .within(() => {
+      cy.get("#date-container input[type='text']").click();
+    });
+
+  cy.get(".vc").last().should("exist").and("be.visible");
+
+  // verify propertyTransform custom HTML rendering
+  cy.get(`[data-vc-date="${utcTestDate}"] .vc-date__popup`)
+    .last()
+    .should(($popup) => {
+      const htmlContent = $popup.html();
+      expect(htmlContent).to.include("custom-card");
+      expect(htmlContent).to.include("Custom 74");
+    });
 };
 
 export default loadDatePickerPopupItems;

--- a/elements/timecontrol/test/cases/load-date-picker-popup-items.js
+++ b/elements/timecontrol/test/cases/load-date-picker-popup-items.js
@@ -183,6 +183,64 @@ const loadDatePickerPopupItems = () => {
         .showDots=${true}
         .popup=${true}
         .showItems=${true}
+      ></eox-timecontrol-picker>
+    </eox-timecontrol>
+  `);
+
+  // open calendar in custom configuration
+  cy.get("eox-timecontrol")
+    .last()
+    .find("eox-timecontrol-date")
+    .shadow()
+    .within(() => {
+      cy.get("#date-container input[type='text']").click();
+    });
+
+  cy.get(".vc").last().should("exist").and("be.visible");
+
+  // verify itemTitleKey displays the cloudCoverage value on primary line and layerName in metadata
+  cy.get(`[data-vc-date="${utcTestDate}"] .vc-date__popup`)
+    .last()
+    .should(($popup) => {
+      const htmlContent = $popup.html();
+      expect(htmlContent).to.include("74");
+      expect(htmlContent).to.include("Wind Visualisation 10M");
+    });
+
+  // dynamically update property on the picker element
+  cy.get("eox-timecontrol-picker")
+    .last()
+    .then(($picker) => {
+      /** @type {any} */ ($picker[0]).itemTitleKey = "layerName";
+    });
+
+  // verify dynamic property update re-renders popup content in-place
+  cy.get(`[data-vc-date="${utcTestDate}"] .vc-date__popup`)
+    .last()
+    .should(($popup) => {
+      const htmlContent = $popup.html();
+      expect(htmlContent).to.include("Wind Visualisation 10M");
+    });
+
+  // mount with custom propertyTransform (object)
+  cy.mount(html`
+    <eox-map
+      id="picker-transform-popup-test"
+      style="width: 400px; height: 300px;"
+      .zoom=${STORY_ARGS.zoom}
+      .center=${STORY_ARGS.center}
+      .layers=${STORY_ARGS.layers}
+    ></eox-map>
+    <eox-timecontrol for="eox-map#picker-transform-popup-test">
+      <eox-timecontrol-date
+        format="${STORY_ARGS.format}"
+        .navigation=${true}
+      ></eox-timecontrol-date>
+      <eox-timecontrol-picker
+        item-title-key="cloudCoverage"
+        .showDots=${true}
+        .popup=${true}
+        .showItems=${true}
         .propertyTransform=${(item) => ({
           title: `Transformed: ${item.cloudCoverage}%`,
           subtitle: "Custom Meta",
@@ -191,7 +249,7 @@ const loadDatePickerPopupItems = () => {
     </eox-timecontrol>
   `);
 
-  // open calendar in custom configuration
+  // open calendar in transform configuration
   cy.get("eox-timecontrol")
     .last()
     .find("eox-timecontrol-date")

--- a/elements/timecontrol/test/cases/load-expert-mode-export.js
+++ b/elements/timecontrol/test/cases/load-expert-mode-export.js
@@ -20,9 +20,94 @@ const loadExpertModeExport = () => {
     return true;
   });
 
+  const todayDate = dayjs().format("YYYY-MM-DD");
+  const pastDate = dayjs().subtract(30, "day").format("YYYY-MM-DD");
+
   // setup - intercept network requests
   cy.intercept(/^.*openstreetmap.*$/, {
     fixture: "./map/test/fixtures/tiles/osm/0/0/0.png",
+  });
+
+  cy.intercept(/^.*planetarycomputer.*search.*$/, {
+    body: {
+      features: [
+        {
+          id: "S2_CURRENT",
+          properties: {
+            datetime: `${todayDate}T10:00:00Z`,
+            "eo:cloud_cover": 10,
+          },
+        },
+        {
+          id: "S2_PAST",
+          properties: {
+            datetime: `${pastDate}T10:00:00Z`,
+            "eo:cloud_cover": 15,
+          },
+        },
+      ],
+    },
+  });
+
+  cy.intercept(/^.*planetarycomputer.*mosaic\/register.*$/, {
+    body: {
+      links: [
+        {
+          rel: "tilejson",
+          href: "https://example.com/mock-tilejson",
+        },
+      ],
+    },
+  });
+
+  const mockItems = [
+    {
+      id: "S2_PAST",
+      properties: {
+        datetime: `${pastDate}T10:00:00Z`,
+        "eo:cloud_cover": 15,
+      },
+    },
+    {
+      id: "S2_CURRENT",
+      properties: {
+        datetime: `${todayDate}T10:00:00Z`,
+        "eo:cloud_cover": 10,
+      },
+    },
+  ];
+
+  const osmLayer = {
+    type: "Tile",
+    properties: {
+      id: "OSM",
+    },
+    source: {
+      type: "OSM",
+    },
+  };
+
+  // mosaic layer factory - creates sentinel-2 mosaic layer from STAC items
+  const createMosaicLayer = (items, _tileJson = "") => ({
+    type: "Tile",
+    source: {
+      type: "OSM",
+    },
+    properties: {
+      id: "sentinel-2",
+      name: "sentinel-2",
+      title: items.length
+        ? items[0].properties?.datetime || "dummy"
+        : "dummy title",
+      // map STAC items to timeControlValues format
+      timeControlValues:
+        items?.map((f) => ({
+          date: f.properties?.datetime || f.date,
+          itemId: f.id || f.itemId,
+          cloudCoverage: f.properties?.["eo:cloud_cover"] ?? f.cloudCoverage,
+        })) || [],
+      timeControlProperty: "dummy",
+    },
   });
 
   // mount - mount expert mode components with external map rendering
@@ -32,6 +117,7 @@ const loadExpertModeExport = () => {
       id="external-map-rendering-mosaic"
       .zoom=${10}
       .center=${[12, 42]}
+      .layers=${[osmLayer, createMosaicLayer(mockItems, "")]}
     ></eox-map>
     <eox-timecontrol
       .for=${"eox-map#external-map-rendering-mosaic"}
@@ -80,112 +166,6 @@ const loadExpertModeExport = () => {
     const eoxMap = $eoxMap[0];
     const exportMode = eoxMap.parentElement;
 
-    // initialize data variables for STAC items and mosaic layers
-    let items = [];
-    let tileJson = "";
-    let startDate = "2025-09-01T00:00:00Z";
-    let endDate = new Date().toISOString();
-
-    // layer configuration - define base OSM layer
-    const osmLayer = {
-      type: "Tile",
-      properties: {
-        id: "OSM",
-      },
-      source: {
-        type: "OSM",
-      },
-    };
-
-    // mosaic layer factory - creates sentinel-2 mosaic layer from STAC items
-    const createMosaicLayer = (items, tileJson) => ({
-      type: "Tile",
-      source: {
-        type: "TileJSON",
-        url:
-          tileJson +
-          "?&tile_scale=2&assets=B04&assets=B03&assets=B02&color_formula=Gamma%20RGB%203.2%20Saturation%200.8%20Sigmoidal%20RGB%2025%200.35&nodata=0&minzoom=9&collection=sentinel-2-l2a&format=png",
-        crossOrigin: "anonymous",
-      },
-      properties: {
-        id: "sentinel-2",
-        title: items.length ? items[0].properties.datetime : "dummy title",
-        // map STAC items to timeControlValues format
-        timeControlValues:
-          items?.map((f) => ({
-            date: f.properties.datetime,
-            itemId: f.id,
-            cloudCoverage: f.properties["eo:cloud_cover"],
-          })) || [],
-        timeControlProperty: "dummy",
-      },
-    });
-
-    // async function - fetch STAC items from planetary computer API
-    const fetchItems = async (extent, dateStart, dateEnd) => {
-      const url =
-        "https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=sentinel-2-l2a&bbox=" +
-        eoxMap.lonLatExtent +
-        "&limit=200&datetime=" +
-        dateStart +
-        "/" +
-        dateEnd +
-        "&sortby=-datetime";
-      const searchResponse = await fetch(url);
-      const { features } = await searchResponse.json();
-      return features;
-    };
-
-    // async function - register mosaic with planetary computer for tile generation
-    const registerMosaic = async (dateStart, dateEnd) => {
-      const registerResponse = await fetch(
-        "https://planetarycomputer.microsoft.com/api/data/v1/mosaic/register",
-        {
-          method: "POST",
-          body: JSON.stringify({
-            "filter-lang": "cql2-json",
-            filter: {
-              op: "and",
-              args: [
-                {
-                  op: "=",
-                  args: [{ property: "collection" }, "sentinel-2-l2a"],
-                },
-                {
-                  op: "anyinteracts",
-                  args: [
-                    { property: "datetime" },
-                    { interval: [dateStart, dateEnd] },
-                  ],
-                },
-              ],
-            },
-            sortby: [{ field: "datetime", direction: "desc" }],
-          }),
-          headers: {
-            "Content-Type": "application/json",
-          },
-        },
-      );
-      const { links } = await registerResponse.json();
-      return links.find((l) => l.rel === "tilejson").href;
-    };
-
-    // event listener - handle date range selection from timecontrol
-    const timeControl = exportMode.querySelector("eox-timecontrol");
-    timeControl.addEventListener("select", async (e) => {
-      // skip if no items loaded yet
-      if (!items.length) return;
-
-      // extract date range from event detail
-      const start = new Date(e.detail.date[0]);
-      const end = new Date(e.detail.date[1]);
-
-      // register mosaic for selected date range and update map layers
-      tileJson = await registerMosaic(start.toISOString(), end.toISOString());
-      eoxMap.layers = [osmLayer, createMosaicLayer(items, tileJson)];
-    });
-
     // event listener - handle timelapse export functionality
     const timelapse = exportMode.querySelector("eox-timecontrol-timelapse");
     timelapse.addEventListener("export", async (e) => {
@@ -198,12 +178,6 @@ const loadExpertModeExport = () => {
       // iterate through selected date range items for export
       for (const dateKey in e.detail.selectedRangeItems) {
         const date = e.detail.selectedRangeItems[dateKey][0].originalDate;
-        const start = new Date(date);
-        // create end date as next day for single-day mosaic
-        const end = new Date(
-          new Date(start).setDate(new Date(start).getDate() + 1),
-        );
-
         // filter items by cloud coverage and create mosaic layers
         if (
           date &&
@@ -214,14 +188,8 @@ const loadExpertModeExport = () => {
               o.cloudCoverage < minCloudCover,
           )
         ) {
-          // register mosaic for this specific date
-          const currentTileJson = await registerMosaic(
-            start.toISOString(),
-            end.toISOString(),
-          );
-          // add layer configuration for this date to export
           mapLayers.push({
-            layers: [osmLayer, createMosaicLayer([], currentTileJson)],
+            layers: [osmLayer, createMosaicLayer([], "")],
             date: dateKey,
           });
         }
@@ -231,17 +199,6 @@ const loadExpertModeExport = () => {
         mapLayers,
       });
     });
-
-    // initialize map with base OSM layer
-    eoxMap.layers = [osmLayer];
-
-    // map event listener - fetch new items when map extent changes
-    if (eoxMap.map) {
-      eoxMap.map.on("moveend", async () => {
-        items = await fetchItems(eoxMap.lonLatExtent, startDate, endDate);
-        eoxMap.layers = [osmLayer, createMosaicLayer(items, tileJson)];
-      });
-    }
   });
 
   // setup - stub window functions for download testing


### PR DESCRIPTION
## Implemented changes

This PR adds some customization functionality to `showItems` of the date picker:

- Made `<eox-timecontrol-picker>`'s `showItems` card content configurable:
  - Added `itemTitleKey` (`item-title-key`) to customize the primary line property.
  - Removed the hardcoded `"ID: "` prefix in the card title line.
  - Added `showTime` (`show-time`) to toggle time display, and automatically omit time for date-only values (avoiding `"00:00"`).
  - Added `timeFormat` (`time-format`) to format time tokens.
  - Added `propertyTransform` function property for custom item card transformations and custom HTML rendering.
- Closes #2486

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
