### PR TITLE
Timecontrol/feat/timecontrol geozarr and init date

### DIFF
--- a/elements/timecontrol/src/components/timecontrol-slider.js
+++ b/elements/timecontrol/src/components/timecontrol-slider.js
@@ -271,12 +271,14 @@ export class EOxTimeControlSlider extends LitElement {
 
   handleChange(evt) {
     const EOxTimeControl = this.getEOxTimeControl();
+    if (!EOxTimeControl) return;
     const start = dayjs(evt.detail.value1).utc().format();
     const end = EOxTimeControl.showUTC
       ? dayjs(evt.detail.value1).utc().endOf("day").format()
       : dayjs(evt.detail.value1).endOf("day").utc().format();
 
     if (
+      EOxTimeControl.selectedDateRange &&
       start === EOxTimeControl.selectedDateRange[0] &&
       end === EOxTimeControl.selectedDateRange[1]
     )

--- a/elements/timecontrol/src/helpers/get-init-date.js
+++ b/elements/timecontrol/src/helpers/get-init-date.js
@@ -10,20 +10,38 @@ dayjs.extend(timezone);
 
 /**
  * Gets the initial date range from the initDate property.
- * @param {DateRange} initDate - The initial date range as [startDate, endDate] in ISO format.
+ * @param {DateRange | string | Array<string>} initDate - The initial date range, date string, or keyword ("first" | "last").
+ * @param {Array<any>} [items] - The available timeline items array.
  * @returns {DateRange | null} The initial date range as [startDate, endDate] in ISO format.
  */
-export default function getInitDate(initDate) {
-  if (!Array.isArray(initDate) || !initDate.length) {
+export default function getInitDate(initDate, items) {
+  if (!initDate) {
+    return null;
+  }
+
+  let rawVal = Array.isArray(initDate) ? initDate[0] : initDate;
+  if (!rawVal) {
     return null;
   }
 
   let start, end;
 
-  if (initDate.length < 2) {
-    start = end = initDate[0];
-  } else {
+  if (rawVal === "first") {
+    if (items && items.length) {
+      start = end = items[0].utc || items[0].date;
+    } else {
+      return null;
+    }
+  } else if (rawVal === "last") {
+    if (items && items.length) {
+      start = end = items[items.length - 1].utc || items[items.length - 1].date;
+    } else {
+      return null;
+    }
+  } else if (Array.isArray(initDate) && initDate.length >= 2) {
     [start, end] = initDate;
+  } else {
+    start = end = rawVal;
   }
 
   start = dayjs(start).utc().format();

--- a/elements/timecontrol/src/helpers/get-init-date.js
+++ b/elements/timecontrol/src/helpers/get-init-date.js
@@ -12,9 +12,10 @@ dayjs.extend(timezone);
  * Gets the initial date range from the initDate property.
  * @param {DateRange | string | Array<string>} initDate - The initial date range, date string, or keyword ("first" | "last").
  * @param {Array<any>} [items] - The available timeline items array.
+ * @param {boolean} [showUTC=false] - Whether to return the date range in UTC format.
  * @returns {DateRange | null} The initial date range as [startDate, endDate] in ISO format.
  */
-export default function getInitDate(initDate, items) {
+export default function getInitDate(initDate, items, showUTC = false) {
   if (!initDate) {
     return null;
   }
@@ -26,15 +27,15 @@ export default function getInitDate(initDate, items) {
 
   let start, end;
 
-  if (rawVal === "first") {
+  if (rawVal === "first" || rawVal === "last") {
     if (items && items.length) {
-      start = end = items[0].utc || items[0].date;
-    } else {
-      return null;
-    }
-  } else if (rawVal === "last") {
-    if (items && items.length) {
-      start = end = items[items.length - 1].utc || items[items.length - 1].date;
+      const utc = dayjs(
+        rawVal === "first" ? items[0].utc : items[items.length - 1].utc,
+      );
+      start = showUTC ? utc.utc().format() : utc.format();
+      end = showUTC
+        ? utc.utc().endOf("day").format()
+        : utc.endOf("day").format();
     } else {
       return null;
     }

--- a/elements/timecontrol/src/helpers/set-selected-date.js
+++ b/elements/timecontrol/src/helpers/set-selected-date.js
@@ -68,7 +68,7 @@ export default function setSelectedDate(dateRange, eoxMap, EOxTimeControl) {
   });
 
   let instances = {};
-  selectedRangeItems.forEach((item) => {
+  selectedRangeItems.forEach((item, index) => {
     if (item.group && eoxMap) {
       const layer = flatLayers.find((l) => l.get("id") === item.group);
       // @ts-expect-error Property 'getSource' does not exist on type 'BaseLayer'.
@@ -79,9 +79,28 @@ export default function setSelectedDate(dateRange, eoxMap, EOxTimeControl) {
       };
 
       if (!EOxTimeControl.externalMapRendering) {
-        source.updateParams({
-          [item.property]: item.originalDate,
-        });
+        if (typeof source.updateParams === "function") {
+          source.updateParams({
+            [item.property]: item.date,
+          });
+        } else if (typeof source?.updateDimensions === "function") {
+          const sliceMap = layer?.get ? layer.get("_geozarrSliceMap") : null;
+          const targetDate = item.originalDate || item.utc || item.date;
+          let sliceIndex = index;
+          if (sliceMap) {
+            if (targetDate in sliceMap) {
+              sliceIndex = sliceMap[targetDate];
+            } else {
+              const matchedKey = Object.keys(sliceMap).find(
+                (k) => k.startsWith(targetDate) || targetDate.startsWith(k),
+              );
+              if (matchedKey !== undefined) sliceIndex = sliceMap[matchedKey];
+            }
+          }
+          source.updateDimensions({
+            time: sliceIndex,
+          });
+        }
       }
     }
   });

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -97,7 +97,7 @@ export class EOxTimeControl extends LitElement {
       },
       selectedDateRange: { type: Array },
       controlValues: { type: Array },
-      initDate: { type: Array },
+      initDate: { attribute: "init-date" },
     };
   }
 
@@ -389,6 +389,22 @@ export class EOxTimeControl extends LitElement {
       this.#emitUpdateEvent,
     );
     this.requestUpdate();
+  }
+
+  /**
+   * Lifecycle method called after property updates.
+   *
+   * @param {import("lit").PropertyValues} changedProperties
+   */
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    if (
+      changedProperties.has("controlValues") ||
+      changedProperties.has("for") ||
+      changedProperties.has("initDate")
+    ) {
+      firstUpdatedMethod(this, this.#emitUpdateEvent);
+    }
   }
 
   /**

--- a/elements/timecontrol/src/main.js
+++ b/elements/timecontrol/src/main.js
@@ -404,6 +404,13 @@ export class EOxTimeControl extends LitElement {
       changedProperties.has("initDate")
     ) {
       firstUpdatedMethod(this, this.#emitUpdateEvent);
+      this.#cleanupLayersListener?.();
+      this.#cleanupLayersListener = null;
+      this.#cleanupLayersListener = firstUpdatedMethod(
+        this,
+        this.#emitUpdateEvent,
+      );
+      this.requestUpdate();
     }
   }
 

--- a/elements/timecontrol/src/methods/timecontrol/first-updated.js
+++ b/elements/timecontrol/src/methods/timecontrol/first-updated.js
@@ -89,6 +89,12 @@ export default function firstUpdatedMethod(EOxTimeControl, emitUpdateEvent) {
           ? EOxTimeControl.controlValues
           : flatLayers;
         for (const layer of layers) {
+          if (EOxTimeControl.eoxMap && typeof layer?.on === "function") {
+            if (!layer.get("_timeControlListenerAttached")) {
+              layer.set("_timeControlListenerAttached", true);
+              layer.on("change:timeControlValues", () => init());
+            }
+          }
           const properties = EOxTimeControl.controlValues.length
             ? layer
             : layer.getProperties();
@@ -121,8 +127,6 @@ export default function firstUpdatedMethod(EOxTimeControl, emitUpdateEvent) {
               values: values,
               layerInstance: EOxTimeControl.eoxMap ? layer : null,
             });
-            if (EOxTimeControl.eoxMap)
-              layer.on("change:timeControlValues", () => init());
           }
         }
       }
@@ -158,9 +162,11 @@ export default function firstUpdatedMethod(EOxTimeControl, emitUpdateEvent) {
             loading: false,
           });
 
-          const initDateRange = getInitDate(EOxTimeControl.initDate);
-
           const itemValues = EOxTimeControl.items.get();
+          const initDateRange = getInitDate(
+            EOxTimeControl.initDate,
+            itemValues,
+          );
           if (itemValues && itemValues.length) {
             const { dateRange } = getDateRange(
               EOxTimeControl,

--- a/elements/timecontrol/src/methods/timecontrol/first-updated.js
+++ b/elements/timecontrol/src/methods/timecontrol/first-updated.js
@@ -166,6 +166,7 @@ export default function firstUpdatedMethod(EOxTimeControl, emitUpdateEvent) {
           const initDateRange = getInitDate(
             EOxTimeControl.initDate,
             itemValues,
+            EOxTimeControl.showUTC,
           );
           if (itemValues && itemValues.length) {
             const { dateRange } = getDateRange(

--- a/elements/timecontrol/src/methods/timeline/init-timeline.js
+++ b/elements/timecontrol/src/methods/timeline/init-timeline.js
@@ -257,7 +257,7 @@ export default function initTimelineMethod(EOxTimeControlTimeline) {
     const container = EOxTimeControlTimeline.getContainer();
     container.innerHTML = "";
 
-    const initDateRange = getInitDate(EOxTimeControl.initDate, items);
+    const initDateRange = getInitDate(EOxTimeControl.initDate, items, EOxTimeControl.showUTC);
     const { start, end } = getDateRange(EOxTimeControl, items, initDateRange);
 
     const options = {

--- a/elements/timecontrol/src/methods/timeline/init-timeline.js
+++ b/elements/timecontrol/src/methods/timeline/init-timeline.js
@@ -257,7 +257,11 @@ export default function initTimelineMethod(EOxTimeControlTimeline) {
     const container = EOxTimeControlTimeline.getContainer();
     container.innerHTML = "";
 
-    const initDateRange = getInitDate(EOxTimeControl.initDate, items, EOxTimeControl.showUTC);
+    const initDateRange = getInitDate(
+      EOxTimeControl.initDate,
+      items,
+      EOxTimeControl.showUTC,
+    );
     const { start, end } = getDateRange(EOxTimeControl, items, initDateRange);
 
     const options = {

--- a/elements/timecontrol/src/methods/timeline/init-timeline.js
+++ b/elements/timecontrol/src/methods/timeline/init-timeline.js
@@ -257,7 +257,7 @@ export default function initTimelineMethod(EOxTimeControlTimeline) {
     const container = EOxTimeControlTimeline.getContainer();
     container.innerHTML = "";
 
-    const initDateRange = getInitDate(EOxTimeControl.initDate);
+    const initDateRange = getInitDate(EOxTimeControl.initDate, items);
     const { start, end } = getDateRange(EOxTimeControl, items, initDateRange);
 
     const options = {


### PR DESCRIPTION
## Implemented changes

- **`initDate` Keyword Support**: Added support for `"first"` and `"last"` keywords as well as ISO string values in
  `initDate` to dynamically resolve initial date ranges based on loaded timeline items.
- **Reactivity on Property Changes**: Added `updated` lifecycle handler in `EOxTimeControl` to re-initialize controls when
  `controlValues`, `for`, or `initDate` change.
- **GeoZarr Time Slicing**: Integrated `source.updateDimensions({ time: sliceIndex })` in `setSelectedDate` for layers
  implementing dimensional slicing (with `_geozarrSliceMap` mapping).
- **Slider Guard**: Added null-safety check in `EOxTimeControlSlider.handleChange` to prevent runtime errors when
  interacting before the parent timecontrol is attached.

## Screenshots/Videos

<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix (in the layercontrol PR)
- [x] For new features: I have created a story showcasing this new feature(in the layercontrol PR)
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch,
  breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
 - [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)