### PR TITLE
feat: disable undo and redo in ace editor

### DIFF
--- a/elements/jsonform/src/custom-inputs/ace-custom.js
+++ b/elements/jsonform/src/custom-inputs/ace-custom.js
@@ -17,5 +17,24 @@ export class AceCustomEditor extends aceEditor {
     if (this.options.markdownToolbar && this.ace_editor_instance) {
       createMarkdownToolbar(this);
     }
+
+    // @ts-expect-error - options is not defined in the ace-builds type
+    if (this.options.disableUndoRedo && this.ace_editor_instance) {
+      // @ts-expect-error - ace_editor_instance is not defined in the ace-builds type
+      this.ace_editor_instance.commands.addCommand({
+        name: "undo",
+        bindKey: { win: "Ctrl-Z", mac: "Command-Z" },
+        exec: () => {},
+      });
+      // @ts-expect-error - ace_editor_instance is not defined in the ace-builds type
+      this.ace_editor_instance.commands.addCommand({
+        name: "redo",
+        bindKey: {
+          win: "Ctrl-Y|Ctrl-Shift-Z",
+          mac: "Command-Y|Command-Shift-Z",
+        },
+        exec: () => {},
+      });
+    }
   }
 }

--- a/elements/jsonform/src/custom-inputs/ace-custom.js
+++ b/elements/jsonform/src/custom-inputs/ace-custom.js
@@ -25,6 +25,7 @@ export class AceCustomEditor extends aceEditor {
         name: "undo",
         bindKey: { win: "Ctrl-Z", mac: "Command-Z", linux: "Ctrl-Z" },
         exec: () => {},
+        passEvent: true,
       });
       // @ts-expect-error - ace_editor_instance is not defined in the ace-builds type
       this.ace_editor_instance.commands.addCommand({
@@ -35,6 +36,7 @@ export class AceCustomEditor extends aceEditor {
           linux: "Ctrl-Y|Ctrl-Shift-Z",
         },
         exec: () => {},
+        passEvent: true,
       });
     }
   }

--- a/elements/jsonform/src/custom-inputs/ace-custom.js
+++ b/elements/jsonform/src/custom-inputs/ace-custom.js
@@ -23,7 +23,7 @@ export class AceCustomEditor extends aceEditor {
       // @ts-expect-error - ace_editor_instance is not defined in the ace-builds type
       this.ace_editor_instance.commands.addCommand({
         name: "undo",
-        bindKey: { win: "Ctrl-Z", mac: "Command-Z" },
+        bindKey: { win: "Ctrl-Z", mac: "Command-Z", linux: "Ctrl-Z" },
         exec: () => {},
       });
       // @ts-expect-error - ace_editor_instance is not defined in the ace-builds type
@@ -32,6 +32,7 @@ export class AceCustomEditor extends aceEditor {
         bindKey: {
           win: "Ctrl-Y|Ctrl-Shift-Z",
           mac: "Command-Y|Command-Shift-Z",
+          linux: "Ctrl-Y|Ctrl-Shift-Z",
         },
         exec: () => {},
       });

--- a/elements/jsonform/stories/code-markdown-disable-undo-redo.js
+++ b/elements/jsonform/stories/code-markdown-disable-undo-redo.js
@@ -1,0 +1,25 @@
+/**
+ * Code Markdown Disable Undo Redo example. Shows how to disable undo/redo in the markdown code editor.
+ */
+
+import { html } from "lit";
+import codeMarkdownDisableUndoRedoSchema from "./public/codeMarkdownDisableUndoRedoSchema.json";
+
+export const CodeMarkdownDisableUndoRedo = {
+  args: {
+    schema: codeMarkdownDisableUndoRedoSchema,
+    value: {
+      markdown: `# Try to edit this and then use Ctrl-Z / Cmd-Z or Ctrl-Y / Cmd-Y
+You will see that undo/redo keybindings are disabled.
+* This is a markdown list
+* Undo and Redo disabled here.`,
+    },
+  },
+  render: (args) => {
+    return html`
+      <eox-jsonform .schema=${args.schema} .value=${args.value}></eox-jsonform>
+    `;
+  },
+};
+
+export default CodeMarkdownDisableUndoRedo;

--- a/elements/jsonform/stories/index.js
+++ b/elements/jsonform/stories/index.js
@@ -18,6 +18,7 @@ export { default as GeoJSONStory } from "./geojson"; // Input form based on Draw
 export { default as CustomEditorInterfacesStory } from "./custom-editor-interfaces"; // Custom editor interfaces
 export { default as ValidationStory } from "./validation"; // Validate input
 export { default as CodeStory } from "./code"; // Show code editor as input
+export { default as CodeMarkdownDisableUndoRedoStory } from "./code-markdown-disable-undo-redo"; // Markdown editor with disabled undo/redo
 export { default as OptionalPropertiesStory } from "./optional-properties"; // Hide optional properties
 export { default as ShowOptInPropertiesStory } from "./show-opt-in-properties"; // Show opt-in properties
 export { default as DefaultsStory } from "./defaults"; // Configure defaults

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -22,6 +22,7 @@ import {
   ShowOptInPropertiesStory,
   ValidationStory,
   CodeStory,
+  CodeMarkdownDisableUndoRedoStory,
   OptionalPropertiesStory,
   FlexLayoutStory,
   DefaultsStory,
@@ -69,6 +70,12 @@ export const Validation = ValidationStory;
  * Demonstrates integration of external editors via schema configuration.
  */
 export const Code = CodeStory;
+
+/**
+ * Ace editor with disabled undo/redo example.
+ * Demonstrates how to disable keyboard shortcuts for undo/redo in the markdown Ace editor.
+ */
+export const CodeMarkdownDisableUndoRedo = CodeMarkdownDisableUndoRedoStory;
 
 /**
  * Opt-in properties example. Shows how to display and interact with opt-in properties in the form.

--- a/elements/jsonform/stories/public/codeMarkdownDisableUndoRedoSchema.json
+++ b/elements/jsonform/stories/public/codeMarkdownDisableUndoRedoSchema.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "markdown": {
+      "type": "string",
+      "format": "markdown",
+      "options": {
+        "resolver": "ace",
+        "markdownToolbar": true,
+        "disableUndoRedo": true
+      },
+      "description": "This is a markdown field rendered with a custom ace editor with a toolbar. The undo and redo keyboard shortcuts have been disabled for this editor."
+    }
+  }
+}

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -7,6 +7,7 @@ export { default as loadExternalValueTest } from "./load-external-value";
 export { default as loadReRenderFormOnChangeTest } from "./re-render-form-on-change";
 export { default as loadMarkdownTest } from "./load-markdown";
 export { default as loadCodeMarkdownToolbarTest } from "./load-code-markdown-toolbar";
+export { default as loadAceMarkdownDisableUndoRedoTest } from "./load-code-markdown-disable-undo-redo";
 export { default as loadCodeTest } from "./load-code";
 export { default as loadCodeHTMLTest } from "./load-code-html";
 export { default as triggerChangeEventTest } from "./trigger-change-event";

--- a/elements/jsonform/test/cases/load-code-markdown-disable-undo-redo.js
+++ b/elements/jsonform/test/cases/load-code-markdown-disable-undo-redo.js
@@ -1,0 +1,50 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+/**
+ * Test to verify if the jsonform component with ace markdown editor successfully disables undo/redo.
+ */
+const loadAceMarkdownDisableUndoRedoTest = () => {
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          markdown: {
+            type: "string",
+            format: "markdown",
+            options: {
+              resolver: "ace",
+              disableUndoRedo: true,
+            },
+          },
+        },
+      }}
+      .value=${{
+        markdown: "initial text",
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should("exist");
+
+      // Type something new in the editor
+      cy.get(".ace_text-input").type(" edited", { force: true });
+      cy.get(".ace_content").should("contain.text", "initial text edited");
+
+      // Try to undo (mac/windows)
+      cy.get(".ace_text-input").type("{meta}z", { force: true });
+      cy.get(".ace_text-input").type("{ctrl}z", { force: true });
+
+      // Assert it did not undo because the shortcut is disabled
+      cy.get(".ace_content").should("contain.text", "initial text edited");
+    });
+};
+
+export default loadAceMarkdownDisableUndoRedoTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -9,6 +9,7 @@ import {
   loadReRenderFormOnChangeTest,
   loadMarkdownTest,
   loadCodeMarkdownToolbarTest,
+  loadAceMarkdownDisableUndoRedoTest,
   triggerChangeEventTest,
   loadValuesTest,
   loadMisMatchingValuesTest,
@@ -44,6 +45,8 @@ describe("Jsonform", () => {
   it("re-renders form on change", () => loadReRenderFormOnChangeTest());
   it("loads the binary checkbox", () => loadBinaryCheckboxTest());
   it("loads the code markdown toolbar", () => loadCodeMarkdownToolbarTest());
+  it("disables undo and redo in the markdown editor", () =>
+    loadAceMarkdownDisableUndoRedoTest());
   it("loads the markdown editor", () => loadMarkdownTest());
   it("loads the code editor", () => loadCodeTest());
   it("preserves HTML markup inside code editor", () => loadCodeHTMLTest());

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,7 @@
     },
     "elements/jsonform": {
       "name": "@eox/jsonform",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
@@ -214,7 +214,7 @@
     },
     "elements/layercontrol": {
       "name": "@eox/layercontrol",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
@@ -320,7 +320,7 @@
     },
     "elements/timecontrol": {
       "name": "@eox/timecontrol",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",


### PR DESCRIPTION
## Implemented changes
In `git-clerk`, we are implementing universal `undo-redo` for the file editor. - https://github.com/EOX-A/git-clerk/issues/266
But the `jsonform`'s `ace-editor`'s `undo and redo` functionality conflicts when we undo and redo through key binding. So added a feature to disable undo and redo using a config option in the ACE editor. 

- Added a config option `disableUndoRedo` to enable and disable the undo and redo option. (By default, it is enabled for undo/redo.)
- Disabled by bypassing the key bindings for undo and redo keys

<!-- description of implemented changes -->
<!-- to automatically close an issue via this PR, please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Screenshots/Videos

https://github.com/user-attachments/assets/803b9bb2-07a6-4c1e-8afb-54fcf9b1b593



<!-- upload and add here, or delete section if not applicable -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
