### PR TITLE
feat: add file attachment and custom button to markdown toolbar

### DIFF
--- a/elements/jsonform/src/custom-inputs/ace-custom/createMarkdownToolbar.js
+++ b/elements/jsonform/src/custom-inputs/ace-custom/createMarkdownToolbar.js
@@ -1,4 +1,141 @@
 /**
+ * Resolves upload configuration from editor instance options.
+ * @param {any} editorInstance - The ace editor instance wrapper
+ * @returns {object | null}
+ */
+const getUploadConfig = (editorInstance) => {
+  const mdToolbar = editorInstance.options?.markdownToolbar;
+  const rawConfig =
+    (typeof mdToolbar === "object" && mdToolbar !== null
+      ? mdToolbar.upload
+      : null) ??
+    editorInstance.options?.markdownToolbarUpload ??
+    editorInstance.options?.uploadEndpoint ??
+    (typeof editorInstance.options?.upload === "string" ||
+    (typeof editorInstance.options?.upload === "object" &&
+      editorInstance.options?.upload !== null)
+      ? editorInstance.options.upload
+      : null);
+
+  if (!rawConfig) {
+    return null;
+  }
+
+  if (typeof rawConfig === "string") {
+    if (
+      rawConfig.startsWith("http://") ||
+      rawConfig.startsWith("https://") ||
+      rawConfig.startsWith("/")
+    ) {
+      return { endpoint: rawConfig };
+    }
+    return { upload_handler: rawConfig };
+  }
+
+  if (typeof rawConfig === "function") {
+    return { uploadHandler: rawConfig };
+  }
+
+  if (typeof rawConfig === "object") {
+    return rawConfig;
+  }
+
+  return null;
+};
+
+/**
+ * Checks if a file or URL represents an image.
+ * @param {File | null | undefined} file
+ * @param {string} url
+ * @returns {boolean}
+ */
+const isImage = (file, url) => {
+  if (file?.type?.startsWith("image/")) {
+    return true;
+  }
+  const imageExtensions = [
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".svg",
+    ".bmp",
+    ".avif",
+    ".ico",
+    ".tiff",
+    ".tif",
+  ];
+  const cleanTarget = (url || file?.name || "")
+    .split("?")[0]
+    .split("#")[0]
+    .toLowerCase();
+  return imageExtensions.some((ext) => cleanTarget.endsWith(ext));
+};
+
+/**
+ * Checks if a file or URL represents a video.
+ * @param {File | null | undefined} file
+ * @param {string} url
+ * @returns {boolean}
+ */
+const isVideo = (file, url) => {
+  if (file?.type?.startsWith("video/")) {
+    return true;
+  }
+  const videoExtensions = [
+    ".mp4",
+    ".webm",
+    ".ogg",
+    ".mov",
+    ".mkv",
+    ".avi",
+    ".m4v",
+    ".wmv",
+    ".flv",
+  ];
+  const cleanTarget = (url || file?.name || "")
+    .split("?")[0]
+    .split("#")[0]
+    .toLowerCase();
+  return videoExtensions.some((ext) => cleanTarget.endsWith(ext));
+};
+
+/**
+ * Generates the inserted markdown / HTML for an uploaded file.
+ * @param {File} file
+ * @param {string} fileUrl
+ * @param {string} selectedText
+ * @param {object | null} uploadConfig
+ * @returns {string}
+ */
+const getInsertedText = (file, fileUrl, selectedText, uploadConfig) => {
+  const altOrLabel = selectedText || file?.name || "file";
+
+  // If a custom template function is provided in upload config
+  if (
+    uploadConfig &&
+    typeof (/** @type {any} */ (uploadConfig).template) === "function"
+  ) {
+    return /** @type {any} */ (uploadConfig).template(
+      fileUrl,
+      file,
+      altOrLabel,
+    );
+  }
+
+  if (isImage(file, fileUrl)) {
+    return `![${altOrLabel}](${fileUrl})`;
+  }
+
+  if (isVideo(file, fileUrl)) {
+    return `<video src="${fileUrl}" controls></video>`;
+  }
+
+  return `[${altOrLabel}](${fileUrl})`;
+};
+
+/**
  * Creates a markdown toolbar for the ace editor instance.
  * @param {any} editorInstance - The ace editor instance wrapper
  */
@@ -20,6 +157,13 @@ export const createMarkdownToolbar = (editorInstance) => {
   const parent = aceContainer.parentNode;
 
   if (!parent) return;
+
+  const uploadConfig = getUploadConfig(editorInstance);
+  const hasUpload =
+    uploadConfig &&
+    (Boolean(uploadConfig.endpoint) ||
+      Boolean(uploadConfig.upload_handler) ||
+      typeof uploadConfig.uploadHandler === "function");
 
   const toolbar = document.createElement("nav");
   toolbar.className =
@@ -66,6 +210,8 @@ export const createMarkdownToolbar = (editorInstance) => {
     "M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z";
   const imageIcon =
     "M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z";
+  const paperclipIcon =
+    "M16.5,6V17.5A4,4 0 0,1 12.5,21.5A4,4 0 0,1 8.5,17.5V5A2.5,2.5 0 0,1 11,2.5A2.5,2.5 0 0,1 13.5,5V15.5A1,1 0 0,1 12.5,16.5A1,1 0 0,1 11.5,15.5V6H10V15.5A2.5,2.5 0 0,0 12.5,18A2.5,2.5 0 0,0 15,15.5V5A4,4 0 0,0 11,1A4,4 0 0,0 7,5V17.5A5.5,5.5 0 0,0 12.5,23A5.5,5.5 0 0,0 18,17.5V6H16.5Z";
   const listIcon =
     "M7 5h14v2H7V5m0 6h14v2H7v-2m0 6h14v2H7v-2M4 5a1 1 0 1 1 0 2 1 1 0 0 1 0-2m0 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2m0 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z";
   const numberedListIcon =
@@ -107,6 +253,15 @@ export const createMarkdownToolbar = (editorInstance) => {
         <i class="small">${icon(imageIcon)}</i>
         <span class="tooltip">Image</span>
       </button>
+      ${
+        hasUpload
+          ? `
+      <button type="button" class="transparent no-round small" id="md-upload" title="Attach file">
+        <i class="small">${icon(paperclipIcon)}</i>
+        <span class="tooltip">Attach file</span>
+      </button>`
+          : ""
+      }
       <button type="button" class="transparent no-round small" id="md-list" title="Bulleted List">
         <i class="small">${icon(listIcon)}</i>
         <span class="tooltip">Bulleted List</span>
@@ -143,6 +298,226 @@ export const createMarkdownToolbar = (editorInstance) => {
   /** @type {HTMLButtonElement} */ (
     toolbar.querySelector("#md-numbered-list")
   ).onclick = () => insertList("1. ", true);
+
+  if (hasUpload && uploadConfig) {
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.style.display = "none";
+    if (uploadConfig.accept) {
+      fileInput.accept = uploadConfig.accept;
+    }
+    toolbar.appendChild(fileInput);
+
+    fileInput.addEventListener("input", (e) => e.stopPropagation());
+
+    const uploadButton = /** @type {HTMLButtonElement | null} */ (
+      toolbar.querySelector("#md-upload")
+    );
+
+    if (uploadButton) {
+      uploadButton.onclick = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        fileInput.click();
+      };
+
+      let isUploading = false;
+      fileInput.onchange = async (e) => {
+        e.stopPropagation();
+        if (isUploading) return;
+
+        const file = fileInput.files?.[0];
+        if (!file) return;
+
+        isUploading = true;
+        try {
+          uploadButton.disabled = true;
+
+          let fileUrl = "";
+
+          if (typeof uploadConfig.uploadHandler === "function") {
+            const res = await uploadConfig.uploadHandler(file, editorInstance);
+            if (typeof res === "string") {
+              fileUrl = res;
+            } else if (res && typeof res === "object") {
+              fileUrl =
+                res.fileUrl ||
+                res.url ||
+                res.link ||
+                res.file ||
+                res.fallbackUrl ||
+                res.location ||
+                "";
+            }
+          } else if (uploadConfig.upload_handler) {
+            const handlerName = uploadConfig.upload_handler;
+            const callbackFn =
+              // @ts-expect-error JSONEditor global defaults lookup
+              window.JSONEditor?.defaults?.callbacks?.upload?.[handlerName] ||
+              editorInstance.defaults?.callbacks?.upload?.[handlerName] ||
+              editorInstance.jsoneditor?.defaults?.callbacks?.upload?.[
+                handlerName
+              ] ||
+              /** @type {any} */ (window)[handlerName];
+
+            if (typeof callbackFn === "function") {
+              const res = await new Promise((resolve, reject) => {
+                const cbs = {
+                  /** @param {string | { url?: string, fileUrl?: string }} url */
+                  success: (url) => resolve(url),
+                  /** @param {any} err */
+                  failure: (err) =>
+                    reject(
+                      new Error(
+                        typeof err === "string" ? err : "Upload failed",
+                      ),
+                    ),
+                  updateProgress: () => {},
+                };
+                try {
+                  const result = callbackFn.call(
+                    editorInstance,
+                    editorInstance.jsoneditor || editorInstance,
+                    editorInstance.path,
+                    file,
+                    cbs,
+                  );
+                  if (result instanceof Promise) {
+                    result.then(resolve).catch(reject);
+                  } else if (typeof result === "string") {
+                    resolve(result);
+                  } else if (
+                    result &&
+                    typeof result === "object" &&
+                    (result.url || result.fileUrl)
+                  ) {
+                    resolve(result.fileUrl || result.url);
+                  }
+                } catch (err) {
+                  reject(err);
+                }
+              });
+
+              if (typeof res === "string") {
+                fileUrl = res;
+              } else if (res && typeof res === "object") {
+                fileUrl =
+                  res.fileUrl ||
+                  res.url ||
+                  res.link ||
+                  res.file ||
+                  res.fallbackUrl ||
+                  res.location ||
+                  "";
+              }
+            } else {
+              console.error(
+                `Upload handler "${handlerName}" not found in defaults.callbacks.upload`,
+              );
+            }
+          } else if (uploadConfig.endpoint) {
+            const formData = new FormData();
+            formData.append(uploadConfig.fieldName || "file", file);
+
+            if (uploadConfig.data && typeof uploadConfig.data === "object") {
+              Object.entries(uploadConfig.data).forEach(([key, value]) => {
+                formData.append(key, value);
+              });
+            }
+
+            const response = await fetch(uploadConfig.endpoint, {
+              method: uploadConfig.method || "POST",
+              headers: uploadConfig.headers || {},
+              body: formData,
+            });
+
+            if (!response.ok) {
+              throw new Error(`Upload failed with status ${response.status}`);
+            }
+
+            const contentType = response.headers.get("content-type") || "";
+            if (contentType.includes("application/json")) {
+              const data = await response.json();
+              if (typeof data === "string") {
+                fileUrl = data;
+              } else if (data && typeof data === "object") {
+                const propName = uploadConfig.propertyName;
+                if (propName && data[propName]) {
+                  fileUrl = data[propName];
+                } else {
+                  fileUrl =
+                    data.fileUrl ||
+                    data.url ||
+                    data.link ||
+                    data.file ||
+                    data.fallbackUrl ||
+                    data.location ||
+                    data.path ||
+                    data.data?.url ||
+                    (Array.isArray(data) && data[0]?.url) ||
+                    "";
+                }
+              }
+            } else {
+              fileUrl = (await response.text()).trim();
+            }
+          }
+
+          if (fileUrl) {
+            const selected = aceInstance.getSelectedText();
+            const textToInsert = getInsertedText(
+              file,
+              fileUrl,
+              selected,
+              uploadConfig,
+            );
+            aceInstance.insert(textToInsert);
+            aceInstance.focus();
+          }
+        } catch (err) {
+          console.error("Markdown toolbar file upload failed:", err);
+        } finally {
+          uploadButton.disabled = false;
+          fileInput.value = "";
+          isUploading = false;
+        }
+      };
+    }
+  }
+
+  // Support additional custom buttons if specified
+  const customButtons =
+    editorInstance.options?.markdownToolbar?.customButtons ||
+    editorInstance.options?.customButtons;
+
+  if (Array.isArray(customButtons)) {
+    customButtons.forEach((btn, index) => {
+      if (!btn || !btn.title) return;
+      const btnId = btn.id || `md-custom-${index}`;
+      const btnElement = document.createElement("button");
+      btnElement.type = "button";
+      btnElement.className = "transparent no-round small";
+      btnElement.id = btnId;
+      btnElement.title = btn.title;
+      const btnIcon = btn.icon
+        ? btn.icon.startsWith("<")
+          ? btn.icon
+          : icon(btn.icon)
+        : `<span style="font-weight:bold;font-size:12px;">${btn.title.charAt(0)}</span>`;
+      btnElement.innerHTML = `
+        <i class="small">${btnIcon}</i>
+        <span class="tooltip">${btn.title}</span>
+      `;
+      btnElement.onclick = () => {
+        if (typeof btn.action === "function") {
+          btn.action(aceInstance, editorInstance);
+        } else if (typeof btn.insert === "string") {
+          insertText(btn.insert, btn.placeholder || "");
+        }
+      };
+      toolbar.appendChild(btnElement);
+    });
+  }
 
   // Insert the toolbar before the ace editor container
   if (parent && parent.contains(aceContainer)) {

--- a/elements/jsonform/src/helpers/editor.js
+++ b/elements/jsonform/src/helpers/editor.js
@@ -55,7 +55,8 @@ export const createEditor = (element) => {
       target.tagName === "TEXTAREA" ||
       (target.tagName === "INPUT" &&
         target.getAttribute("type") !== "checkbox" &&
-        target.getAttribute("type") !== "radio")
+        target.getAttribute("type") !== "radio" &&
+        target.getAttribute("type") !== "file")
     ) {
       e.target.dispatchEvent(new Event("change", { bubbles: true }));
     }
@@ -216,7 +217,7 @@ export const createEditor = (element) => {
     // TEMP - see https://github.com/json-editor/json-editor/issues/1445
     /** @type {NodeListOf<HTMLInputElement>} */
     const inputElements = element.renderRoot.querySelectorAll(
-      "[data-schematype=string] input",
+      "[data-schematype=string] input:not([type=file]):not([type=checkbox]):not([type=radio])",
     );
     inputElements.forEach((element) => {
       element.addEventListener("input", () => {

--- a/elements/jsonform/src/main.js
+++ b/elements/jsonform/src/main.js
@@ -26,7 +26,7 @@ import _DOMPurify from "isomorphic-dompurify"; // required for allowing HTML in 
  * - **Custom & Advanced Inputs**:
  *   - `format: "minmax"`: Dual-handle range slider (via `tc-range-slider`) for selecting min/max bounds with automatic precision detection based on `step`.
  *   - `format: "range"`: Single range slider with `minimum`, `maximum`, and `step`.
- *   - `format: "markdown"` / `format: "ace"`: Markdown and Ace code editor integration.
+ *   - `format: "markdown"` / `format: "ace"`: Markdown and Ace code editor integration. Supports `options.markdownToolbar` with optional file upload (`options.markdownToolbar.upload` / `options.uploadEndpoint`) and custom buttons.
  *   - `format: "spatial"`: Bounding box, polygon, point, and line drawing integrated with `eox-map` / `eox-drawtools`.
  * - **URL Parameter Filtering (`removeProperties`)**:
  *   - Use `options.removeProperties: ["vminmax"]` to drop intermediate form/slider properties from consumers and tile URL updates.

--- a/elements/jsonform/stories/code-markdown-toolbar-upload.js
+++ b/elements/jsonform/stories/code-markdown-toolbar-upload.js
@@ -1,0 +1,37 @@
+import { html } from "lit";
+
+export const CodeMarkdownToolbarUpload = {
+  args: {
+    schema: {
+      type: "object",
+      properties: {
+        markdown: {
+          type: "string",
+          format: "markdown",
+          options: {
+            resolver: "ace",
+            markdownToolbar: {
+              upload: {
+                endpoint: "https://httpbin.org/post",
+                fieldName: "file",
+              },
+            },
+          },
+          description:
+            "This is a markdown field rendered with an Ace editor and markdown toolbar with file upload support.",
+        },
+      },
+    },
+    value: {
+      markdown:
+        '# Markdown with Attachment Support\n\nClick the paperclip button in the toolbar to attach images (inserted as `![alt](url)`), videos (inserted as `<video src="url" controls></video>`), or other files (inserted as `[name](url)`).',
+    },
+  },
+  render: (args) => {
+    return html`
+      <eox-jsonform .schema=${args.schema} .value=${args.value}></eox-jsonform>
+    `;
+  },
+};
+
+export default CodeMarkdownToolbarUpload;

--- a/elements/jsonform/stories/index.js
+++ b/elements/jsonform/stories/index.js
@@ -7,6 +7,7 @@ export { default as CollectionStory } from "./collection"; // Input form based o
 export { default as ExternalStory } from "./external"; // Input form based on External URL
 export { default as MarkdownStory } from "./markdown"; // Input form based on Markdown Editor config
 export { default as CodeMarkdownToolbarStory } from "./code-markdown-toolbar"; // Input form based on Code Markdown Toolbar config
+export { default as CodeMarkdownToolbarUploadStory } from "./code-markdown-toolbar-upload"; // Input form based on Code Markdown Toolbar with upload config
 export { default as UnStyledStory } from "./unstyled"; // Unstyled input form
 export { default as BoundingBoxStory } from "./bounding-box"; // Input form based on drawtools - Box
 export { default as PolygonStory } from "./polygons"; // Input form based on drawtools - Polygon

--- a/elements/jsonform/stories/jsonform.stories.js
+++ b/elements/jsonform/stories/jsonform.stories.js
@@ -6,6 +6,7 @@ import {
   ExternalStory,
   MarkdownStory,
   CodeMarkdownToolbarStory,
+  CodeMarkdownToolbarUploadStory,
   PrimaryStory,
   ButtonsEditorStory,
   BinaryCheckboxEditorStory,
@@ -139,6 +140,85 @@ export const Markdown = MarkdownStory;
  * `format: "markdown"`, `options.resolver: "ace"` and `options.markdownToolbar: true` in the schema.
  */
 export const CodeMarkdownToolbar = CodeMarkdownToolbarStory;
+
+/**
+ * Code Markdown editor with file attachment support.
+ * Shows how to enable the paperclip ("Attach file") button in the markdown toolbar.
+ * When uploading an image, it smartly inserts an image tag `![alt](url)`, for videos it inserts
+ * `<video src="url" controls></video>`, and for other files it inserts a link `[name](url)`.
+ * If upload is not configured, the attach file button is not displayed.
+ *
+ * ### Configuration Options
+ *
+ * **1. HTTP Endpoint**:
+ * ```json
+ * {
+ *   "type": "string",
+ *   "format": "markdown",
+ *   "options": {
+ *     "resolver": "ace",
+ *     "markdownToolbar": {
+ *       "upload": {
+ *         "endpoint": "https://api.example.com/upload",
+ *         "fieldName": "file"
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * **2. Custom Async Upload Function** (e.g. GitHub API, S3 presigned URL):
+ * ```javascript
+ * const schema = {
+ *   type: "object",
+ *   properties: {
+ *     markdown: {
+ *       type: "string",
+ *       format: "markdown",
+ *       options: {
+ *         resolver: "ace",
+ *         markdownToolbar: {
+ *           upload: async (file, editorInstance) => {
+ *             // Custom upload logic (e.g. GitHub contents API or cloud storage)
+ *             const uploadedUrl = await myCustomUploader(file);
+ *             return uploadedUrl; // or { fileUrl: uploadedUrl }
+ *           }
+ *         }
+ *       }
+ *     }
+ *   }
+ * };
+ * ```
+ *
+ * **3. Using `defaults.callbacks.upload`** (for pure JSON schemas referencing handlers by name):
+ * ```json
+ * // In schema:
+ * "options": {
+ *   "resolver": "ace",
+ *   "markdownToolbar": {
+ *     "upload": { "upload_handler": "myUploadHandler" }
+ *   }
+ * }
+ * ```
+ * ```javascript
+ * // In element .defaults:
+ * const defaults = {
+ *   callbacks: {
+ *     upload: {
+ *       myUploadHandler: async (jseditor, path, file, cbs) => {
+ *         try {
+ *           const url = await uploadToStorage(file);
+ *           cbs.success(url);
+ *         } catch (err) {
+ *           cbs.failure(err.message);
+ *         }
+ *       }
+ *     }
+ *   }
+ * };
+ * ```
+ */
+export const CodeMarkdownToolbarUpload = CodeMarkdownToolbarUploadStory;
 
 /**
  * Buttons Editor example. Renders a custom button group input based on enum values.

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -7,6 +7,12 @@ export { default as loadExternalValueTest } from "./load-external-value";
 export { default as loadReRenderFormOnChangeTest } from "./re-render-form-on-change";
 export { default as loadMarkdownTest } from "./load-markdown";
 export { default as loadCodeMarkdownToolbarTest } from "./load-code-markdown-toolbar";
+export {
+  default as loadCodeMarkdownToolbarUploadTest,
+  loadCodeMarkdownToolbarPdfUploadTest,
+  loadCodeMarkdownToolbarVideoUploadTest,
+  loadCodeMarkdownToolbarCustomHandlerTest,
+} from "./load-code-markdown-toolbar-upload";
 export { default as loadAceMarkdownDisableUndoRedoTest } from "./load-code-markdown-disable-undo-redo";
 export { default as loadCodeTest } from "./load-code";
 export { default as loadCodeHTMLTest } from "./load-code-html";

--- a/elements/jsonform/test/cases/load-code-markdown-toolbar-upload.js
+++ b/elements/jsonform/test/cases/load-code-markdown-toolbar-upload.js
@@ -1,0 +1,286 @@
+import { html } from "lit";
+import { TEST_SELECTORS } from "../../src/enums";
+
+// Destructure TEST_SELECTORS object
+const { jsonForm } = TEST_SELECTORS;
+
+const testVals = {
+  key: "markdown",
+  value: "Initial content",
+};
+
+/**
+ * Test to verify if the jsonform markdown toolbar upload button works for images and non-image files.
+ */
+const loadCodeMarkdownToolbarUploadTest = () => {
+  cy.intercept("POST", "/api/upload", {
+    statusCode: 200,
+    body: {
+      url: "https://example.com/uploads/sample.png",
+    },
+  }).as("imageUpload");
+
+  cy.intercept("POST", "/api/upload-pdf", {
+    statusCode: 200,
+    body: {
+      url: "https://example.com/uploads/document.pdf",
+    },
+  }).as("pdfUpload");
+
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "markdown",
+            options: {
+              resolver: "ace",
+              markdownToolbar: {
+                upload: {
+                  endpoint: "/api/upload",
+                },
+              },
+            },
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: testVals.value,
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should("exist");
+      cy.get("button[title='Attach file']").should("exist");
+
+      // Select an image file and verify it inserts an image tag
+      cy.get("input[type='file']").selectFile(
+        {
+          contents: Cypress.Buffer.from("sample image data"),
+          fileName: "sample.png",
+          mimeType: "image/png",
+        },
+        { force: true },
+      );
+    });
+
+  cy.wait("@imageUpload");
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should(
+        "contain.text",
+        "![sample.png](https://example.com/uploads/sample.png)",
+      );
+    });
+};
+
+/**
+ * Test to verify that non-image files are inserted as markdown link tags.
+ */
+export const loadCodeMarkdownToolbarPdfUploadTest = () => {
+  cy.intercept("POST", "/api/upload-pdf", {
+    statusCode: 200,
+    body: {
+      url: "https://example.com/uploads/document.pdf",
+    },
+  }).as("pdfUpload");
+
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "markdown",
+            options: {
+              resolver: "ace",
+              markdownToolbar: {
+                upload: {
+                  endpoint: "/api/upload-pdf",
+                },
+              },
+            },
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: "",
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should("exist");
+      cy.get("button[title='Attach file']").should("exist");
+
+      // Select a non-image file (PDF)
+      cy.get("input[type='file']").selectFile(
+        {
+          contents: Cypress.Buffer.from("pdf document data"),
+          fileName: "document.pdf",
+          mimeType: "application/pdf",
+        },
+        { force: true },
+      );
+    });
+
+  cy.wait("@pdfUpload");
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should(
+        "contain.text",
+        "[document.pdf](https://example.com/uploads/document.pdf)",
+      );
+    });
+};
+
+/**
+ * Test to verify that custom upload handler functions (e.g. via defaults.callbacks) work as expected.
+ */
+export const loadCodeMarkdownToolbarCustomHandlerTest = () => {
+  const customUploadHandler = cy
+    .spy((jseditor, path, file, cbs) => {
+      cbs.success({
+        fileUrl: `https://raw.githubusercontent.com/org/repo/sha/assets/${file.name}`,
+      });
+    })
+    .as("customUploadHandler");
+
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "markdown",
+            options: {
+              resolver: "ace",
+              markdownToolbar: {
+                upload: {
+                  upload_handler: "customGithubUploader",
+                },
+              },
+            },
+          },
+        },
+      }}
+      .defaults=${{
+        callbacks: {
+          upload: {
+            customGithubUploader: customUploadHandler,
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: "",
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should("exist");
+      cy.get("button[title='Attach file']").should("exist");
+
+      cy.get("input[type='file']").selectFile(
+        {
+          contents: Cypress.Buffer.from("sample image data"),
+          fileName: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+        { force: true },
+      );
+    });
+
+  cy.get("@customUploadHandler").should("have.been.called");
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should(
+        "contain.text",
+        "![photo.jpg](https://raw.githubusercontent.com/org/repo/sha/assets/photo.jpg)",
+      );
+    });
+};
+
+/**
+ * Test to verify that video files are inserted as <video> tags.
+ */
+export const loadCodeMarkdownToolbarVideoUploadTest = () => {
+  cy.intercept("POST", "/api/upload-video", {
+    statusCode: 200,
+    body: {
+      url: "https://example.com/uploads/clip.mp4",
+    },
+  }).as("videoUpload");
+
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "markdown",
+            options: {
+              resolver: "ace",
+              markdownToolbar: {
+                upload: {
+                  endpoint: "/api/upload-video",
+                },
+              },
+            },
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: "",
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should("exist");
+      cy.get("button[title='Attach file']").should("exist");
+
+      // Select a video file (MP4)
+      cy.get("input[type='file']").selectFile(
+        {
+          contents: Cypress.Buffer.from("mp4 video data"),
+          fileName: "clip.mp4",
+          mimeType: "video/mp4",
+        },
+        { force: true },
+      );
+    });
+
+  cy.wait("@videoUpload");
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get(".ace_editor").should(
+        "contain.text",
+        '<video src="https://example.com/uploads/clip.mp4" controls></video>',
+      );
+    });
+};
+
+export default loadCodeMarkdownToolbarUploadTest;

--- a/elements/jsonform/test/cases/load-code-markdown-toolbar.js
+++ b/elements/jsonform/test/cases/load-code-markdown-toolbar.js
@@ -51,6 +51,7 @@ const loadAceMarkdownTest = () => {
       cy.get("button[title='Image']").should("exist");
       cy.get("button[title='Bulleted List']").should("exist");
       cy.get("button[title='Numbered List']").should("exist");
+      cy.get("button[title='Attach file']").should("not.exist");
     });
 };
 

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -9,6 +9,10 @@ import {
   loadReRenderFormOnChangeTest,
   loadMarkdownTest,
   loadCodeMarkdownToolbarTest,
+  loadCodeMarkdownToolbarUploadTest,
+  loadCodeMarkdownToolbarPdfUploadTest,
+  loadCodeMarkdownToolbarVideoUploadTest,
+  loadCodeMarkdownToolbarCustomHandlerTest,
   loadAceMarkdownDisableUndoRedoTest,
   triggerChangeEventTest,
   loadValuesTest,
@@ -45,6 +49,14 @@ describe("Jsonform", () => {
   it("re-renders form on change", () => loadReRenderFormOnChangeTest());
   it("loads the binary checkbox", () => loadBinaryCheckboxTest());
   it("loads the code markdown toolbar", () => loadCodeMarkdownToolbarTest());
+  it("handles image upload in markdown toolbar", () =>
+    loadCodeMarkdownToolbarUploadTest());
+  it("handles non-image file upload in markdown toolbar", () =>
+    loadCodeMarkdownToolbarPdfUploadTest());
+  it("handles video file upload in markdown toolbar", () =>
+    loadCodeMarkdownToolbarVideoUploadTest());
+  it("handles custom upload handler in markdown toolbar", () =>
+    loadCodeMarkdownToolbarCustomHandlerTest());
   it("disables undo and redo in the markdown editor", () =>
     loadAceMarkdownDisableUndoRedoTest());
   it("loads the markdown editor", () => loadMarkdownTest());


### PR DESCRIPTION
## Implemented changes

This PR adds conditional file attachment support to the Ace markdown toolbar in `eox-jsonform`:
  - Renders a paperclip ("Attach file") button when upload is configured (via `options.markdownToolbar.upload`, `options.uploadEndpoint`, or `defaults.callbacks.upload`).
  - Button is omitted when upload is not configured.
  - Supports HTTP POST endpoints, custom async upload functions (`uploadHandler`), and JSONEditor `upload_handler` callbacks.
  - Smart insertion: inserts `![alt](url)` for images, `<video src="url" controls></video>` for videos, and `[name](url)` for other files.
  - Supports custom insertion templates via `upload.template` and additional toolbar buttons via `customButtons`.
  - Excluded file inputs from generic string-input validation event handlers to prevent duplicate event dispatching.

## Screenshots/Videos

<img width="1025" height="325" alt="image" src="https://github.com/user-attachments/assets/59bcbcdd-c9f3-45a7-bac5-370f3b96614c" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a test related to this feature/fix
- [x] For new features: I have created a story showcasing this new feature
- [x] All checks have passed
- [x] The PR title [follows conventional commit style and reflects the type of change (major/minor/patch, breaking)](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)
- [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)
