### PR TITLE
Fix/jsonform/configurable upload tooltip

### DIFF
--- a/elements/jsonform/src/custom-inputs/ace-custom/createMarkdownToolbar.js
+++ b/elements/jsonform/src/custom-inputs/ace-custom/createMarkdownToolbar.js
@@ -256,7 +256,7 @@ export const createMarkdownToolbar = (editorInstance) => {
       ${
         hasUpload
           ? `
-      <button type="button" class="transparent no-round small" id="md-upload" title="Attach file">
+      <button type="button" class="transparent no-round small" id="md-upload" title="${uploadConfig.tooltip}">
         <i class="small">${icon(paperclipIcon)}</i>
         <span class="tooltip">${uploadConfig.tooltip}</span>
       </button>`

--- a/elements/jsonform/src/custom-inputs/ace-custom/createMarkdownToolbar.js
+++ b/elements/jsonform/src/custom-inputs/ace-custom/createMarkdownToolbar.js
@@ -20,6 +20,7 @@ const getUploadConfig = (editorInstance) => {
   if (!rawConfig) {
     return null;
   }
+  const tooltip = "Attach file";
 
   if (typeof rawConfig === "string") {
     if (
@@ -27,17 +28,17 @@ const getUploadConfig = (editorInstance) => {
       rawConfig.startsWith("https://") ||
       rawConfig.startsWith("/")
     ) {
-      return { endpoint: rawConfig };
+      return { endpoint: rawConfig, tooltip };
     }
-    return { upload_handler: rawConfig };
+    return { upload_handler: rawConfig, tooltip };
   }
 
   if (typeof rawConfig === "function") {
-    return { uploadHandler: rawConfig };
+    return { uploadHandler: rawConfig, tooltip };
   }
 
   if (typeof rawConfig === "object") {
-    return rawConfig;
+    return { tooltip, ...rawConfig };
   }
 
   return null;
@@ -164,7 +165,6 @@ export const createMarkdownToolbar = (editorInstance) => {
     (Boolean(uploadConfig.endpoint) ||
       Boolean(uploadConfig.upload_handler) ||
       typeof uploadConfig.uploadHandler === "function");
-
   const toolbar = document.createElement("nav");
   toolbar.className =
     "surface-container no-round no-margin tiny-padding no-space markdown-toolbar";
@@ -258,7 +258,7 @@ export const createMarkdownToolbar = (editorInstance) => {
           ? `
       <button type="button" class="transparent no-round small" id="md-upload" title="Attach file">
         <i class="small">${icon(paperclipIcon)}</i>
-        <span class="tooltip">Attach file</span>
+        <span class="tooltip">${uploadConfig.tooltip}</span>
       </button>`
           : ""
       }

--- a/elements/jsonform/stories/code-markdown-toolbar-upload.js
+++ b/elements/jsonform/stories/code-markdown-toolbar-upload.js
@@ -14,6 +14,7 @@ export const CodeMarkdownToolbarUpload = {
               upload: {
                 endpoint: "https://httpbin.org/post",
                 fieldName: "file",
+                tooltip: "Upload media",
               },
             },
           },

--- a/elements/jsonform/test/cases/index.js
+++ b/elements/jsonform/test/cases/index.js
@@ -12,6 +12,7 @@ export {
   loadCodeMarkdownToolbarPdfUploadTest,
   loadCodeMarkdownToolbarVideoUploadTest,
   loadCodeMarkdownToolbarCustomHandlerTest,
+  loadCodeMarkdownToolbarCustomTooltipTest,
 } from "./load-code-markdown-toolbar-upload";
 export { default as loadAceMarkdownDisableUndoRedoTest } from "./load-code-markdown-disable-undo-redo";
 export { default as loadCodeTest } from "./load-code";

--- a/elements/jsonform/test/cases/load-code-markdown-toolbar-upload.js
+++ b/elements/jsonform/test/cases/load-code-markdown-toolbar-upload.js
@@ -283,4 +283,43 @@ export const loadCodeMarkdownToolbarVideoUploadTest = () => {
     });
 };
 
+/**
+ * Test to verify that the tooltip of the upload button can be configured.
+ */
+export const loadCodeMarkdownToolbarCustomTooltipTest = () => {
+  const customTooltip = "Custom Upload Tooltip";
+  cy.mount(
+    html`<eox-jsonform
+      .schema=${{
+        type: "object",
+        properties: {
+          [testVals.key]: {
+            type: "string",
+            format: "markdown",
+            options: {
+              resolver: "ace",
+              markdownToolbar: {
+                upload: {
+                  endpoint: "/api/upload",
+                  tooltip: customTooltip,
+                },
+              },
+            },
+          },
+        },
+      }}
+      .value=${{
+        [testVals.key]: "",
+      }}
+    ></eox-jsonform>`,
+  ).as(jsonForm);
+
+  cy.get(jsonForm)
+    .shadow()
+    .within(() => {
+      cy.get("button#md-upload").should("have.attr", "title", customTooltip);
+      cy.get("button#md-upload .tooltip").should("contain.text", customTooltip);
+    });
+};
+
 export default loadCodeMarkdownToolbarUploadTest;

--- a/elements/jsonform/test/general.cy.js
+++ b/elements/jsonform/test/general.cy.js
@@ -13,6 +13,7 @@ import {
   loadCodeMarkdownToolbarPdfUploadTest,
   loadCodeMarkdownToolbarVideoUploadTest,
   loadCodeMarkdownToolbarCustomHandlerTest,
+  loadCodeMarkdownToolbarCustomTooltipTest,
   loadAceMarkdownDisableUndoRedoTest,
   triggerChangeEventTest,
   loadValuesTest,
@@ -55,6 +56,8 @@ describe("Jsonform", () => {
     loadCodeMarkdownToolbarPdfUploadTest());
   it("handles video file upload in markdown toolbar", () =>
     loadCodeMarkdownToolbarVideoUploadTest());
+  it("handles custom upload icon tooltip in markdown toolbar", () =>
+    loadCodeMarkdownToolbarCustomTooltipTest());
   it("handles custom upload handler in markdown toolbar", () =>
     loadCodeMarkdownToolbarCustomHandlerTest());
   it("disables undo and redo in the markdown editor", () =>


### PR DESCRIPTION
##  Implemented changes                                                                                                                                            

Adds option to configure eox-jsonform ace editor toolbar upload custom tooltip text.

### Motivation

We need to give users extra text warning that their upload done via git-clerk GH integration will be visible only after a few seconds with current default text `![](source-gh-repo-link)`.                   
                                                                                                                                                                
## Checklist before requesting a review                                                                                                                           
                                                                                                                                                                
 - [x] I have performed a self-review of my code                                                                                                                
 - [x] I have added a test related to this feature/fix                                                                                                          
 - [ ] For new features: I have created a story showcasing this new feature                                                                                     
 - [x] All checks have passed                                                                                                                                   
 - [x] The PR title follows conventional commit style and reflects the type of change (major/minor/patch, breaking)                                             
       (https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits)                                                          
 - [x] The PR title describes the change within this element (each merged PR equals one entry in the element's changelog!)                                      

